### PR TITLE
fix: add missing paren

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -163,6 +163,6 @@ We currently have the following SDK's languages availabile.
 - [JavaScript](https://github.com/momentohq/client-sdk-examples/tree/main/javascript)
 - [Python](https://github.com/momentohq/client-sdk-examples/tree/main/python)
 - [Rust](https://github.com/momentohq/client-sdk-examples/tree/main/rust)
-- [CLI（MacOS/Linux](https://github.com/momentohq/momento-cli)
+- [CLI（MacOS/Linux)](https://github.com/momentohq/momento-cli)
 
 Check out our [examples repo](https://github.com/momentohq/client-sdk-examples/) for hands-on examples with the various SDKs.


### PR DESCRIPTION
The CLI line is missing a right paren. This change gives it back.