### PR TITLE
Remove TODO and add free-tier info

### DIFF
--- a/docs/how-it-works/caching-with-serverless.md
+++ b/docs/how-it-works/caching-with-serverless.md
@@ -90,7 +90,7 @@ If you're an indie hacker or an early-stage startup that's looking to save money
 
 First, Momento has a painless self-service sign up. You can get a Momento authentication token and [start writing to your cache in less than five minutes](./../getting-started). You don't need to talk to a salesperson or sign an upfront contract. In fact, you don't even need to enter a credit card to enjoy the free tier.
 
-Second, Momento has a generous free tier. You get (TODO: Enter free tier details). Our goal is to allow a wide variety of applications to run on Momento without ever paying us a cent. We want to provide a top-tier, robust service for applications that need it while also supporting a broad community of applications to use Momento as they grow.
+Second, Momento has a generous free tier. You get 50 GB free each month (see [pricing](https://docs.momentohq.com/docs/pricing) for details). Our goal is to allow a wide variety of applications to run on Momento without ever paying us a cent. We want to provide a top-tier, robust service for applications that need it while also supporting a broad community of applications to use Momento as they grow.
 
 ## Conclusion
 


### PR DESCRIPTION
Proposal to remove draft `TODO` text and replace with actual free-tier pricing info / link.