### PR TITLE
feat: disables ligatures on inline codeblocks

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -77,6 +77,13 @@
   }
 }
 
+code span {
+  // Need this to force no ligatures in code examples. It was throwing some users off.
+  // Find better font for source code. Im fan of FiraCode but would want to use w/
+  // out ligatures enabled somehow https://github.com/tonsky/FiraCode
+  font-family: "monospace" !important;
+}
+
 @media (max-width: 997px) {
   .footer .container {
     flex-direction: column !important;


### PR DESCRIPTION
We had a user report that the docs were wrong because CLI uses `--` vs `-` we have `--` in docs but due to ligatures in custom font we added can see how users would be confused. For now, default back to the default browser `monospace` font  family for inline code blocks which is probably the safest bet. Will make a ticket to find a better font to include in docs for source code vs default browser `monospace`.

**Before:**
<img width="1041" alt="Screen Shot 2022-10-03 at 12 49 53 PM" src="https://user-images.githubusercontent.com/5491827/193667092-98129b86-0beb-4cc6-8efd-3fe9bf6615de.png">

**After:**
<img width="954" alt="Screen Shot 2022-10-03 at 12 56 52 PM" src="https://user-images.githubusercontent.com/5491827/193667418-c357d909-f04d-4f5b-ab2d-f9f688a0d3eb.png">
