### PR TITLE
fix: add language section footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -233,6 +233,19 @@ const config = {
               },
             ],
           },
+          {
+            title: "Language",
+            items: [
+              {
+                label: "English",
+                to: "https://docs.momentohq.com/",
+              },
+              {
+                label: "日本語",
+                to: "https://docs.momentohq.com/ja/",
+              },
+            ],
+          },
         ],
       },
       prism: {

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -31,6 +31,10 @@
     "message": "GitHub",
     "description": "The label of footer link with label=Github linking to https://github.com/momentohq"
   },
+  "link.title.Language": {
+    "message": "言語",
+    "description": "The title of the footer links column with title=Language in the footer"
+  },
   "copyright": {
     "message": "Copyright © 2022 Momento, Inc.",
     "description": "The footer copyright"


### PR DESCRIPTION
I was browsing our doc on my phone and realized that the language dropdown menu was nowhere to be found.
So I added `Language` section to the footer so that users can see the JP version of our doc.
One thing to note that is when users click one of the languages, the doc will be open in a new tab.

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/22686260/202816868-7ee3efa9-180d-450b-a70c-446ce52ab0b0.png">
