### PR TITLE
feature: add ruby examples

### DIFF
--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -79,10 +79,8 @@ match cache_client.create_cache(&cache_name).await {
 `}
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )
@@ -162,10 +160,8 @@ match cache_client.delete_cache(&cache_name).await {
 `}
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )
@@ -186,10 +182,8 @@ Lists all caches for the provided auth token.
 <SdkExamples
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )
@@ -273,10 +267,8 @@ cache_client
     `}
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )
@@ -356,10 +348,8 @@ cache_client
     `}
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )
@@ -445,10 +435,8 @@ cache_client
     `}
   ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )

--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -77,6 +77,18 @@ match cache_client.create_cache(&cache_name).await {
     }
 }
 `}
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.create_cache('test-cache')
+raise repsonse.error if response.error?
+  `}
   cli={`momento cache create --name test-cache`}
 />
 

--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -271,6 +271,18 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.set('test-cache', 'test-key', 'test-value')
+raise response.error if response.error?
+  `}
   cli={`momento cache set --key test-key --value test-value`}
 />
 
@@ -342,6 +354,24 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.get('test-cache', 'test-key')
+if response.hit?
+  puts response.value_string
+elsif response.miss?
+  puts "The item was not in the cache."
+elsif response.error?
+  raise response.error
+end
+  `}
   cli={`momento cache get --key test-key --value test-value`}
 />
 
@@ -413,5 +443,17 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.delete('test-cache', 'test-key')
+raise response.error if response.error?
+  `}
   cli={`momento cache delete --key test-key --value test-value`}
 />

--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -183,6 +183,21 @@ Lists all caches for the provided auth token.
 | --------- | ------ | ------------------------------- |
 | nextToken | String | Token for pagination of caches. |
 
+<SdkExamples
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+puts client.caches.to_a.join(", ")
+  `}
+  cli={`momento cache list`}
+/>
+
 ## Data APIs
 
 ### Set

--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -274,7 +274,7 @@ cache_client
   ruby={`
 require 'momento'
 
-MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
 
 client = Momento::SimpleCacheClient.new(
@@ -357,7 +357,7 @@ cache_client
   ruby={`
 require 'momento'
 
-MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
 
 client = Momento::SimpleCacheClient.new(
@@ -446,7 +446,7 @@ cache_client
   ruby={`
 require 'momento'
 
-MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
 
 client = Momento::SimpleCacheClient.new(

--- a/docs/API-reference.mdx
+++ b/docs/API-reference.mdx
@@ -160,6 +160,18 @@ match cache_client.delete_cache(&cache_name).await {
     }
 }
 `}
+  ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.delete_cache('test-cache')
+raise repsonse.error if response.error?
+  `}
   cli={`momento cache delete-cache --name test-cache`}
 />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -181,3 +181,4 @@ We currently have the following SDK's languages available. Check out each repo f
 - [.NET](https://github.com/momentohq/client-sdk-dotnet)
 - [Rust](https://github.com/momentohq/client-sdk-rust)
 - [PHP](https://github.com/momentohq/client-sdk-php)
+- [Ruby](https://github.com/momentohq/client-sdk-ruby)

--- a/docs/how-it-works/momento-concepts.mdx
+++ b/docs/how-it-works/momento-concepts.mdx
@@ -68,6 +68,16 @@ let mut cache_client = SimpleCacheClientBuilder::new(
 .unwrap()
 .build();
 `}
+    ruby={`
+require 'momento'
+
+MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+    `}
     cli={`momento configure`}
 />
 

--- a/docs/how-it-works/momento-concepts.mdx
+++ b/docs/how-it-works/momento-concepts.mdx
@@ -71,7 +71,7 @@ let mut cache_client = SimpleCacheClientBuilder::new(
     ruby={`
 require 'momento'
 
-MOMENTO_AUTH_TOKEN = ENV['TEST_AUTH_TOKEN'] || "eyJhbGc.MyTestToken"
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
 
 client = Momento::SimpleCacheClient.new(

--- a/docs/how-it-works/momento-concepts.mdx
+++ b/docs/how-it-works/momento-concepts.mdx
@@ -70,10 +70,8 @@ let mut cache_client = SimpleCacheClientBuilder::new(
 `}
     ruby={`
 require 'momento'
-
 MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
 DEFAULT_TTL_SECONDS = 15
-
 client = Momento::SimpleCacheClient.new(
   auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
 )

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,6 +25,7 @@ In the following pages, you can learn about caching in general and how to use Mo
   - [.NET](https://github.com/momentohq/client-sdk-dotnet)
   - [Rust](https://github.com/momentohq/client-sdk-rust)
   - [Php](https://github.com/momentohq/client-sdk-php)
+  - [Ruby](https://github.com/momentohq/client-sdk-ruby)
 
 - _If you want to know more about Momento Serverless Cache and how it works_, refer to the [How it works](./how-it-works) section, including the reference on [Momento Servless Cache concepts](./how-it-works/momento-concepts).
 

--- a/src/components/SdkExamples/index.jsx
+++ b/src/components/SdkExamples/index.jsx
@@ -22,7 +22,7 @@ export const SdkExamples = ({js, python, java, go, csharp, rust, ruby, cli}) => 
         </TabItem>
         <TabItem value="rust" label="Rust">
             <CodeBlock language={'rust'}>{rust}</CodeBlock>
-        </TabItem
+        </TabItem>
         <TabItem value="ruby" label="Ruby">
             <CodeBlock language={'ruby'}>{ruby}</CodeBlock>
         </TabItem>

--- a/src/components/SdkExamples/index.jsx
+++ b/src/components/SdkExamples/index.jsx
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import React from 'react';
 
-export const SdkExamples = ({js, python, java, go, csharp, rust, cli}) => (
+export const SdkExamples = ({js, python, java, go, csharp, rust, ruby, cli}) => (
     <Tabs>
         <TabItem value="js" label="JavaScript">
             <CodeBlock language={'js'}>{js}</CodeBlock>
@@ -22,6 +22,9 @@ export const SdkExamples = ({js, python, java, go, csharp, rust, cli}) => (
         </TabItem>
         <TabItem value="rust" label="Rust">
             <CodeBlock language={'rust'}>{rust}</CodeBlock>
+        </TabItem
+        <TabItem value="ruby" label="Ruby">
+            <CodeBlock language={'ruby'}>{ruby}</CodeBlock>
         </TabItem>
         <TabItem value="cli" label="CLI">
             <CodeBlock language={'cli'}>{cli}</CodeBlock>


### PR DESCRIPTION
Adds Ruby to all the SDK examples, lists of available SDKs.

I also added Ruby and CLI list cache examples, because it's really easy in both.

Note: The examples will not be 100% valid until v0.2.0 is released at the end of this week.

Closes momentohq/client-sdk-ruby#10