### PR TITLE
[ja] Update sidebar translation

### DIFF
--- a/docs/introduction/_category_.json
+++ b/docs/introduction/_category_.json
@@ -4,7 +4,7 @@
     "collapsible": true,
     "collapsed": true,
     "link": {
-        "description": "Introducing Momento Serverless Cache service.",
+        "description": "Introducing Momento Serverless Cache service."
     },
     "className": "sidebar-item-walkthrough"
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -3,40 +3,32 @@
     "message": "次へ",
     "description": "The label for version current"
   },
-  "sidebar.tutorialSidebar.category.How it works": {
-    "message": "どのように動作するか",
-    "description": "The label for category How it works in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Introduction": {
+    "message": "導入",
+    "description": "The label for category Introduction in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.How it works.link.generated-index.description": {
-    "message": "Learn the concepts, architecture, and other basics of working with Momento.",
-    "description": "The generated-index page description for category How it works in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Develop": {
+    "message": "開発",
+    "description": "The label for category Develop in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Caching Concepts": {
-    "message": "キャッシュの概念",
-    "description": "The label for category Caching Concepts in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Tutorials": {
+    "message": "チュートリアル",
+    "description": "The label for category Tutorials in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.category.Caching Concepts.link.generated-index.description": {
-    "message": "Key concepts in the world of caching.",
-    "description": "The generated-index page description for category Caching Concepts in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Adding a cache to a serverless application": {
+    "message": "サーバーレスアプリケーションにキャッシュを追加",
+    "description": "The label for category Adding a cache to a serverless application in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Guides": {
     "message": "ガイド",
-    "description": "The label for category Guides in sidebar tutorialSidebar"
+    "description": "The label for category Guides"
   },
-  "sidebar.tutorialSidebar.category.Guides.link.generated-index.description": {
-    "message": "Guides to help you out.",
-    "description": "The generated-index page description for category Guides in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Learn": {
+    "message": "学ぶ",
+    "description": "The label for category Learn"
   },
-  "sidebar.tutorialSidebar.category.Tutorial - Adding a cache to a serverless application": {
-    "message": "チュートリアル - サーバーレスアプリケーションにキャッシュを追加",
-    "description": "The label for category Tutorial - Adding a cache to a serverless application in sidebar tutorialSidebar"
-  },
-  "sidebar.tutorialSidebar.category.Tutorial - Adding a cache to a serverless application.link.generated-index.title": {
-    "message": "チュートリアル - サーバーレスアプリケーションにキャッシュを追加",
-    "description": "The generated-index page title for category Tutorial - Adding a cache to a serverless application in sidebar tutorialSidebar"
-  },
-  "sidebar.tutorialSidebar.category.Tutorial - Adding a cache to a serverless application.link.generated-index.description": {
-    "message": "AWS Lambda を使ったサーバーレスアプリケーションにキャッシュを追加したいですか？それでは以下にある5ステップのチュートリアルを試してみてください。",
-    "description": "The generated-index page description for category Tutorial - Adding a cache to a serverless application in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Manage": {
+    "message": "管理",
+    "description": "The label for category Manage"
   }
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/api-reference.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/api-reference.mdx
@@ -1,8 +1,7 @@
 ---
-sidebar_position: 6
-sidebar_class_name: sidebar-item-api-reference
+sidebar_position: 5
 sidebar_label: API リファレンス
-title: API リファレンス
+Title: API reference information
 ---
 
 import { SdkExamples } from "@site/src/components/SdkExamples";
@@ -79,6 +78,16 @@ match cache_client.create_cache(&cache_name).await {
     }
 }
 `}
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.create_cache('test-cache')
+raise repsonse.error if response.error?
+  `}
   cli={`momento cache create --name test-cache`}
 />
 
@@ -150,6 +159,16 @@ match cache_client.delete_cache(&cache_name).await {
     }
 }
 `}
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.delete_cache('test-cache')
+raise repsonse.error if response.error?
+  `}
   cli={`momento cache delete-cache --name test-cache`}
 />
 
@@ -160,6 +179,19 @@ Lists all caches for the provided auth token.
 | Name      | Type   | Description                     |
 | --------- | ------ | ------------------------------- |
 | nextToken | String | Token for pagination of caches. |
+
+<SdkExamples
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+puts client.caches.to_a.join(", ")
+  `}
+  cli={`momento cache list`}
+/>
 
 ## Data APIs
 
@@ -234,6 +266,16 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.set('test-cache', 'test-key', 'test-value')
+raise response.error if response.error?
+  `}
   cli={`momento cache set --key test-key --value test-value`}
 />
 
@@ -305,6 +347,22 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.get('test-cache', 'test-key')
+if response.hit?
+  puts response.value_string
+elsif response.miss?
+  puts "The item was not in the cache."
+elsif response.error?
+  raise response.error
+end
+  `}
   cli={`momento cache get --key test-key --value test-value`}
 />
 
@@ -376,5 +434,15 @@ cache_client
     .await
     .unwrap();
     `}
+  ruby={`
+require 'momento'
+MOMENTO_AUTH_TOKEN = "eyJhbGc.MyTestToken"
+DEFAULT_TTL_SECONDS = 15
+client = Momento::SimpleCacheClient.new(
+  auth_token: MOMENTO_AUTH_TOKEN, default_ttl: DEFAULT_TTL_SECONDS
+)
+response = client.delete('test-cache', 'test-key')
+raise response.error if response.error?
+  `}
   cli={`momento cache delete --key test-key --value test-value`}
 />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/guides/1-caching-with-aws-lambda.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/guides/1-caching-with-aws-lambda.md
@@ -1,8 +1,9 @@
 ---
 sidebar_position: 1
+sidebar_label: AWS Lambda でキャッシュ
 ---
 
-# Caching with AWS Lambda
+# AWS Lambda でキャッシュ
 
 The release of AWS Lambda in November 2014 kicked off the serverless revolution in software architecture. Lambda's event-driven, function-based compute solution changed the nature of how we build applications in the cloud.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/introduction/_category_.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/introduction/_category_.json
@@ -4,7 +4,7 @@
     "collapsible": true,
     "collapsed": true,
     "link": {
-        "description": "Introducing Momento Serverless Cache service.",
+        "description": "Introducing Momento Serverless Cache service."
     },
     "className": "sidebar-item-walkthrough"
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/introduction/common-caching-patterns.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/introduction/common-caching-patterns.md
@@ -1,8 +1,10 @@
 ---
 sidebar_position: 2
+sidebar_label: 一般的なキャッシュパターン
+title: 一般的なキャッシュパターン
 ---
 
-# Common Caching Patterns
+# 一般的なキャッシュパターン
 
 **_Caching is fast_**.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/introduction/common-caching-strategies.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/introduction/common-caching-strategies.md
@@ -1,4 +1,10 @@
-# Common Caching Strategies
+---
+sidebar_position: 3
+sidebar_label: 一般的なキャッシュ戦略
+title: 一般的なキャッシュ戦略
+---
+
+# 一般的なキャッシュ戦略
 
 Now that we know the key choices you need to make when implementing a caching strategy, let's review some popular caching patterns. For each pattern, we will describe the pattern, the choices the pattern makes on the three questions above, and when you may want to use that pattern.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/introduction/what-is-serverless-caching.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/introduction/what-is-serverless-caching.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-sidebar_label: What is Serverless Caching?
-title: What is Serverless Caching?
+sidebar_label: サーバーレスキャッシュとは何か？
+title: サーバーレスキャッシュとは何か？
 description: Learn what serverless is in terms of caching and what Momento Serverless Cache can be your simple, fast cache for your apps.
 ---
 
-# What is Serverless Caching?
+# サーバーレスキャッシュとは何か？
 
 Serverless is one of the hottest trends in software development, and we're seeing an explosion in "serverless-friendly" services.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/learn/how-it-works/cache-eviction-vs-expiration.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/learn/how-it-works/cache-eviction-vs-expiration.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-sidebar_label: Cache eviction vs expiration
+sidebar_label: キャッシュの立ち退き vs 期限切れ
 title: Cache eviction vs expiration
 slug: /learn/how-it-works/cache-eviction-vs-expiration
 description: Learn about differences between expiring and evicting data from a cache and how these terms relate to Momento Serverless cache

--- a/i18n/ja/docusaurus-plugin-content-docs/current/learn/how-it-works/expire-data-with-ttl.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/learn/how-it-works/expire-data-with-ttl.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_class_name: sidebar-item-develop-ttl
-sidebar_label: Expiring data with TTL
+sidebar_label: TTL でデータを期限切れにする
 title: Expiring data with Time to Live (TTL) in Momento Serverless Cache
 description: Learn about expiring data from a cache using Time to Live (TTL) in Momento Serverless Cache
 slug: /learn/how-it-works/expire-data-with-ttl


### PR DESCRIPTION
Apply the latest update and fix missing Japanese translation for the sidebar only.

Some notes:
- `API-reference.mdx` was stale and wrong file name. Copied from `docs`,
- `introduction/_category_.json` had JSON syntax error (trailing comma). Fixed.

Close #75 

cc @poppoerika 