### PR TITLE
fix: correct typo for fallback monospace font in our css

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -81,7 +81,7 @@ code span {
   // Need this to force no ligatures in code examples. It was throwing some users off.
   // Find better font for source code. Im fan of FiraCode but would want to use w/
   // out ligatures enabled somehow https://github.com/tonsky/FiraCode
-  font-family: "monospace" !important;
+  font-family: monospace !important;
 }
 
 @media (max-width: 997px) {


### PR DESCRIPTION
Just needed to remove the `"` surrounding the specified font, brings docs pages back to intended state for https://github.com/momentohq/public-dev-docs/issues/25

Firefox:
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/10414594/213830353-52f82ad8-fd45-4cbc-afd1-83d4b2dc102a.png">

Chrome:
<img width="969" alt="image" src="https://user-images.githubusercontent.com/10414594/213830363-20049a7a-4ba4-4aff-bccd-49812401b480.png">

Safari:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/10414594/213830385-07a3ebd2-791d-430f-967e-9b64d506dad5.png">

