### PR TITLE
feat: add winget installation instructions for windows cli users

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,13 @@ which you may add anywhere you like in your execution path.
 
 **Windows**
 
-Visit the web page for the latest [github release](https://github.com/momentohq/momento-cli/releases).
+Our CLI is available in the Windows Package Manager (`winget`). To install, run the following from PowerShell or the Command Prompt:
+
+```powershell
+winget install momento.cli
+```
+
+Alternatively visit the web page for the latest [github release](https://github.com/momentohq/momento-cli/releases).
 There you will find an `.msi` installer for Windows platforms, as well as a windows `.zip` file if
 you prefer to manually copy the `momento` executable to your preferred location.
 


### PR DESCRIPTION
We add winget as the primary installation path for Windows users. Previously the only
installation path was by downloading the installer/zip from the GitHub
release page. We demote this to an alternative path.
