### PR TITLE
Adding ap-south-1 to AWS region coverage.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,7 +89,7 @@ _Note: the version number listed in the output will vary._
 
 Authentication tokens are associated with a specific Momento Serverless Cache cloud provider and specific region. You can provision an auth token **for each region** using the `account` command with your desired cloud provider and Region:
 
-#### AWS [available regions are us-west-2, us-east-1, ap-northeast-1]
+#### AWS [available regions are us-west-2, us-east-1, ap-northeast-1, ap-south-1]
 
 ```console
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -71,7 +71,7 @@ SUBCOMMANDS:
 
 認証トークンは Momento サーバーレスキャッシュの特定のリージョンに紐づいています。`account` コマンドをご希望のクラウドプロバイダーとリージョンを指定しながら使うと、各リージョン用の認証トークンを生成することができます:
 
-#### AWS [利用可能リージョンは us-west-2, us-east-1, ap-northeast-1]
+#### AWS [利用可能リージョンは us-west-2, us-east-1, ap-northeast-1, ap-south-1]
 
 ```console
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>


### PR DESCRIPTION
ap-south-1 now available, so adding to getting started info.