### PR TITLE
Update documentation around CDTs

### DIFF
--- a/docs/develop/api-reference/collection-ttl.md
+++ b/docs/develop/api-reference/collection-ttl.md
@@ -2,40 +2,42 @@
 sidebar_position: 4
 sidebar_label: CollectionTTL object
 title: CollectionTTL API reference
-description: Learn how to interact with the API for dictionary collection data types in Momento Serverless Cache.
+description: Learn how to interact with the CollectionTTL object in Momento Serverless Cache.
 slug: /develop/api-reference/collections/collectionttl
 ---
 
 # CollectionTTL object API reference
 
-This object is passed in to API methods to say whether a TTL should be updated and if so, what the new TTL value should be.
+This object is passed into API methods to say whether a TTL should be updated and if so, what the new TTL value should be.
 
 This tries to make the process more intuitive by providing named constructors and copiers for various situations.
 
-See [Expire Data with TTL](../../../learn/how-it-works/expire-data-with-ttl), For more information on how TTL works with Momento Serverless Cache, 
+See [Expire Data with TTL](../../../learn/how-it-works/expire-data-with-ttl) for more information on how TTL works with Momento Serverless Cache.
 
 ## Common method behaviors
 
-- If a CollectionTTL is not passed, CollectionTtl.fromCacheTtl(), from the cache connection object, is used.
+- If a CollectionTTL is not passed in a function call, a default value of `CollectionTtl.fromCacheTtl()` will be used. This value is the TTL configured on the cache client. 
+- The TTL for the collection will be refreshed any time the collection is modified.
 
 ## Constructor parameters
 
 - ttl: duration - (optional)
     * If no TTL is given, the TTL set in the current client connection object is used.
 - refreshTtl: boolean = true
-    * If set to true, the collection’s TTL will be reset to the ttl.
-    * If set to false, the exisitng TTL set on the item is retained.
+    * If set to true, the collection’s TTL will be reset to the provided value.
+    * If set to false, the existing TTL set on the item is retained.
 
 ## Additional constructors
 
 - fromCacheTtl(): CollectionTtl - uses the client’s TTL, equivalent to `CollectionTtl(null, true)`
 - of(ttl: duration): CollectionTtl - equivalent to `CollectionTtl(ttl, true)`
-- refreshTtlIfProvided(ttl?: duration): CollectionTtl - if a ttl is provided, it will refresh the TTL. If no ttl is provided, it will not refresh the TTL.
+- refreshTtlIfProvided(ttl?: duration): CollectionTtl - if a value is provided, it will refresh the item's TTL. If no value is provided, it will not refresh the TTL.
 
 ## Instance methods
 
-- ttl(): duration?
-- refreshTtl(): boolean
+- ttlSeconds(): duration - Returns the TTL in seconds
+- ttlMilliseconds(): duration - Returns the TTL in milliseconds
+- refreshTtl(): boolean - Sets if the TTL should be refreshed when the item is modified
 - withRefreshTtlOnUpdates(): CollectionTtl - a copy, but refresh is true
 - withNoRefreshTtlOnUpdates(): CollectionTtl - a copy, but refresh is false
-- toString(): displays the ttl and refreshTtl.
+- toString(): displays the TTL in seconds and the refreshTtl configuration

--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -2,23 +2,23 @@
 sidebar_position: 1
 sidebar_label: Dictionary
 title: Dictionary API reference
-description: Learn how to interact with the API for dictionary data types in Momento Serverless Cache.
+description: Learn how to interact with the API for Dictionary Collection Data Types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/dictionary
 ---
 
 # Dictionary API reference for Momento Serverless Cache
-This page details the Momento API methods for the [dictionary data type](./../datatypes.md#dictionary-collections).
+This page details the Momento API methods for the [Dictionary Collection Data Type](./../datatypes.md#dictionary-collections).
 
 ## Dictionary methods
 
 ### DictionaryFetch
 
-Gets a dictionary item from a cache.
+Gets a Dictionary item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| dictionaryName  | String | The name of the dictionary item to be retreived. |
+| dictionaryName  | String | The name of the Dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -39,13 +39,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryGetField
-Get one field from a dictionary item in the cache.
+Get one field from a Dictionary item in the cache.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be retreived. |
-| field           | String/bytes | Name of the field in the dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the Dictionary item to be retreived. |
+| field           | String/bytes | Name of the field in the Dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -56,7 +56,7 @@ Get one field from a dictionary item in the cache.
     - `valueString()`: string
     - `valueBytes()`: bytes
 
-        These return the field and its value from the dictionary.
+        These return the field and its value from the Dictionary.
 
 * Cache miss
     - `fieldString()`: string
@@ -71,13 +71,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryGetFields
-Get one or more fields from a dictionary in the cache.
+Get one or more fields from a Dictionary in the cache.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be retreived.  |
-| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the Dictionary item to be retreived.  |
+| fields          | String[]/bytes[] | Name of the field in the Dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -96,7 +96,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryIncrement
-Adds to the value of a field, if and only if the existing value is a UTF-8 string representing a base 10 integer. If the field is missing from the dictionary, this method sets the field's value to the amount to increment by.
+Adds to the value of a field, if and only if the existing value is a UTF-8 string representing a base 10 integer. If the field is missing from the Dictionary, this method sets the field's value to the amount to increment by.
 
 :::note
 
@@ -113,8 +113,8 @@ Examples:
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be retreived.  |
-| field           | String|bytes | Name of the field in the dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the Dictionary item to be retreived.  |
+| field           | String|bytes | Name of the field in the Dictionary item to be retreived. |
 | amount          | Integer      | The quantity to add to the value. May be positive, negative, or zero. Defaults to 1. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | This will come back as a TTL construct. |
 
@@ -132,13 +132,13 @@ See [response objects](./response-objects.md) for specific information.
 
 ### DictionaryRemoveField
 
-Revmoves a field from a dictionary item.
+Removes a field from a Dictionary item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be retreived. |
-| field           | String|bytes | Name of the field in the dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the Dictionary item to be retreived. |
+| field           | String|bytes | Name of the field in the Dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -151,13 +151,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryRemoveFields
-Removes multiple fields from a dictionary item.
+Removes multiple fields from a Dictionary item.
 
 | Name            | Type             | Description                                   |
 | --------------- | ------------     | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
-| dictionaryName  | String           | Name of the dictionary item to be retreived. |
-| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retreived. |
+| dictionaryName  | String           | Name of the Dictionary item to be retreived. |
+| fields          | String[]/bytes[] | Name of the field in the Dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -170,15 +170,15 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionarySetField
-Sets a field:value pair in an existing dictionary item. If the dictionary item does not exist, it is created with the new field:value pair.
+Sets a field:value pair in an existing Dictionary item. If the Dictionary item does not exist, it is created with the new field:value pair.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be set. |
-| field           | String/bytes | Name of the field in the dictionary item to be set. |
+| dictionaryName  | String       | Name of the Dictionary item to be set. |
+| field           | String/bytes | Name of the field in the Dictionary item to be set. |
 | value           | String/bytes | Value for the field to be set. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>
   <summary>Method response object</summary>
@@ -191,14 +191,14 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionarySetFields
-Sets several field:value pairs in a dictionary item. If the dictionary item does not exist, it is created with the new fields.
+Sets several field:value pairs in a Dictionary item. If the Dictionary item does not exist, it is created with the new fields.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the dictionary item to be set. |
-| fields          | String[]/bytes[] | Field:value pair to be added to the dictionary item by the set operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| dictionaryName  | String       | Name of the Dictionary item to be set. |
+| fields          | String[]/bytes[] | Field:value pair to be added to the Dictionary item by the set operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>
   <summary>Method response object</summary>

--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -2,23 +2,23 @@
 sidebar_position: 1
 sidebar_label: Dictionary
 title: Dictionary API reference
-description: Learn how to interact with the API for Dictionary Collection Data Types in Momento Serverless Cache.
+description: Learn how to interact with the API for dictionary collection data types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/dictionary
 ---
 
 # Dictionary API reference for Momento Serverless Cache
-This page details the Momento API methods for the [Dictionary Collection Data Type](./../datatypes.md#dictionary-collections).
+This page details the Momento API methods for the [dictionary collection data type](./../datatypes.md#dictionary-collections).
 
 ## Dictionary methods
 
 ### DictionaryFetch
 
-Gets a Dictionary item from a cache.
+Gets a dictionary item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| dictionaryName  | String | The name of the Dictionary item to be retreived. |
+| dictionaryName  | String | The name of the dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -39,13 +39,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryGetField
-Get one field from a Dictionary item in the cache.
+Get one field from a dictionary item in the cache.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be retreived. |
-| field           | String/bytes | Name of the field in the Dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the dictionary item to be retreived. |
+| field           | String/bytes | Name of the field in the dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -56,7 +56,7 @@ Get one field from a Dictionary item in the cache.
     - `valueString()`: string
     - `valueBytes()`: bytes
 
-        These return the field and its value from the Dictionary.
+        These return the field and its value from the dictionary.
 
 * Cache miss
     - `fieldString()`: string
@@ -71,13 +71,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryGetFields
-Get one or more fields from a Dictionary in the cache.
+Get one or more fields from a dictionary in the cache.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be retreived.  |
-| fields          | String[]/bytes[] | Name of the field in the Dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the dictionary item to be retreived.  |
+| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -96,7 +96,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryIncrement
-Adds to the value of a field, if and only if the existing value is a UTF-8 string representing a base 10 integer. If the field is missing from the Dictionary, this method sets the field's value to the amount to increment by.
+Adds to the value of a field, if and only if the existing value is a UTF-8 string representing a base 10 integer. If the field is missing from the dictionary, this method sets the field's value to the amount to increment by.
 
 :::note
 
@@ -113,8 +113,8 @@ Examples:
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be retreived.  |
-| field           | String|bytes | Name of the field in the Dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the dictionary item to be retreived.  |
+| field           | String|bytes | Name of the field in the dictionary item to be retreived. |
 | amount          | Integer      | The quantity to add to the value. May be positive, negative, or zero. Defaults to 1. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | This will come back as a TTL construct. |
 
@@ -132,13 +132,13 @@ See [response objects](./response-objects.md) for specific information.
 
 ### DictionaryRemoveField
 
-Removes a field from a Dictionary item.
+Removes a field from a dictionary item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be retreived. |
-| field           | String|bytes | Name of the field in the Dictionary item to be retreived. |
+| dictionaryName  | String       | Name of the dictionary item to be retreived. |
+| field           | String|bytes | Name of the field in the dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -151,13 +151,13 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionaryRemoveFields
-Removes multiple fields from a Dictionary item.
+Removes multiple fields from a dictionary item.
 
 | Name            | Type             | Description                                   |
 | --------------- | ------------     | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
-| dictionaryName  | String           | Name of the Dictionary item to be retreived. |
-| fields          | String[]/bytes[] | Name of the field in the Dictionary item to be retreived. |
+| dictionaryName  | String           | Name of the dictionary item to be retreived. |
+| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retreived. |
 
 <details>
   <summary>Method response object</summary>
@@ -170,15 +170,15 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionarySetField
-Sets a field:value pair in an existing Dictionary item. If the Dictionary item does not exist, it is created with the new field:value pair.
+Sets a field:value pair in an existing dictionary item. If the dictionary item does not exist, it is created with the new field:value pair.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be set. |
-| field           | String/bytes | Name of the field in the Dictionary item to be set. |
+| dictionaryName  | String       | Name of the dictionary item to be set. |
+| field           | String/bytes | Name of the field in the dictionary item to be set. |
 | value           | String/bytes | Value for the field to be set. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>
   <summary>Method response object</summary>
@@ -191,14 +191,14 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### DictionarySetFields
-Sets several field:value pairs in a Dictionary item. If the Dictionary item does not exist, it is created with the new fields.
+Sets several field:value pairs in a dictionary item. If the dictionary item does not exist, it is created with the new fields.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| dictionaryName  | String       | Name of the Dictionary item to be set. |
-| fields          | String[]/bytes[] | Field:value pair to be added to the Dictionary item by the set operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| dictionaryName  | String       | Name of the dictionary item to be set. |
+| fields          | String[]/bytes[] | Field:value pair to be added to the dictionary item by the set operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>
   <summary>Method response object</summary>

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -2,23 +2,23 @@
 sidebar_position: 2
 sidebar_label: Lists
 title: List API reference
-description: Learn how to interact with the API for List Collection Data Types in Momento Serverless Cache.
+description: Learn how to interact with the API for list collection data types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/list
 ---
 
 # List API reference for Momento Serverless Cache
-This page details the Momento API methods for the [List Collection Data Types](./../datatypes.md#list-collections).
+This page details the Momento API methods for the [list collection data types](./../datatypes.md#list-collections).
 
 ## List methods
 
 ### ListFetch
 
-Gets a List item from a cache.
+Gets a list item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| listName        | String | The name of the List item to be retreived.         |
+| listName        | String | The name of the list item to be retreived.         |
 
 <details>
   <summary>Method response object</summary>
@@ -37,7 +37,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListConcatenateBack
-Appends the supplied list to the end of an existing List item.
+Appends the supplied list to the end of an existing list item.
 
 Example:
 
@@ -46,16 +46,16 @@ If you have [1, 2, 3] and listConcatenateBack [4, 5, 6] you will have [1, 2, 3, 
 | Name            | Type                | Description                                   |
 | --------------- | ------------------- | --------------------------------------------- |
 | cacheName       | String              | Name of the cache.                            |
-| listName        | String              | Name of the List item to be set. |
-| values          | String[] \| bytes[] | Values to be added as elements to the List item. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache client connection object. |
+| listName        | String              | Name of the list item to be set. |
+| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client connection object. |
 | truncateFrontToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the List
+    * `listLength()`: number - the new length of the list
     * `toString()`: string - add the listLength
 * Error
 
@@ -64,7 +64,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListConcatenateFront
-Appends the supplied list to the front of an existing List item.
+Appends the supplied list to the front of an existing list item.
 
 Example:
 
@@ -73,16 +73,16 @@ If you have [1, 2, 3] and listConcatenateFront [4, 5, 6] you will have [4, 5, 6,
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the List item to be set.              |
-| values          | String[] \| bytes[] | Values to be added as elements to the List item. |
-| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| listName        | String       | Name of the list item to be set.              |
+| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
+| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the List item
+    * `listLength()`: number - the new length of the list item
     * `toString()`: string - add the listLength
 * Error
 
@@ -91,12 +91,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListLength
-Get the length of an existing List item
+Get the length of an existing list item
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the List item to be checked.          |
+| listName        | String       | Name of the list item to be checked.          |
 
 <details>
   <summary>Method response object</summary>
@@ -112,12 +112,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPopBack
-Remove and return the last element from a List item.
+Remove and return the last element from a list item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the List item to be retreived.        |
+| listName        | String       | Name of the list item to be retreived.        |
 
 <details>
   <summary>Method response object</summary>
@@ -134,12 +134,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPopFront
-Remove and return the first element from a List item.
+Remove and return the first element from a list item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the List item to be retreived.        |
+| listName        | String       | Name of the list item to be retreived.        |
 
 <details>
   <summary>Method response object</summary>
@@ -156,21 +156,21 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPushBack
-Push a value to the end of a List item. This is exactly like passing just one value to [ListConcatenateBack](#listconcatenateback).
+Push a value to the end of a list item. This is exactly like passing just one value to [ListConcatenateBack](#listconcatenateback).
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the List to be set.                   |
+| listName        | String          | Name of the list to be set.                   |
 | value           | String \| bytes | Value to be added.              |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the List item
+    * `listLength()`: number - the new length of the list item
     * `toString()`: string - add the listLength
 * Error
 
@@ -179,21 +179,21 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPushFront
-Push a value to the beginning of a List item. Just like [ListPushBack](#listpushback), but to the front.
+Push a value to the beginning of a list item. Just like [ListPushBack](#listpushback), but to the front.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the List to be set. |
-| value           | String \| bytes | Value to be added to the List item by the operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| listName        | String          | Name of the list to be set. |
+| value           | String \| bytes | Value to be added to the list item by the operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the List
+    * `listLength()`: number - the new length of the list
     * `toString()`: string - add the listLength
 * Error
 
@@ -202,7 +202,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListRemoveValue
-Remove all elements in a List item equal to a particular value.
+Remove all elements in a list item equal to a particular value.
 
 Examples
 
@@ -211,8 +211,8 @@ Examples
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the List item to be set.              |
-| value           | String \| bytes | Value to be added to the List item by the operation. |
+| listName        | String          | Name of the list item to be set.              |
+| value           | String \| bytes | Value to be added to the list item by the operation. |
 
 <details>
   <summary>Method response object</summary>
@@ -228,8 +228,8 @@ See [response objects](./response-objects.md) for specific information.
 
 ## Truncate to size
 
-[ListConcatenate](#listconcatenateback) and [ListPush](#listpushback) type API calls all have truncation options. If after adding their elements the List exceeds this size, this List will be truncated.
+[ListConcatenate](#listconcatenateback) and [ListPush](#listpushback) type API calls all have truncation options. If after adding their elements the list exceeds this size, this list will be truncated.
 
-* Example: If the List is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 5` the List will be truncated to `[2, 3, 4, 5, 6]` and the response ListLength will be 5.
+* Example: If the list is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 5` the list will be truncated to `[2, 3, 4, 5, 6]` and the response ListLength will be 5.
 
-* Example: If the List is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 10` the List will not be truncated. It will be `[1, 2, 3, 4, 5, 6]`
+* Example: If the list is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 10` the list will not be truncated. It will be `[1, 2, 3, 4, 5, 6]`

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -2,23 +2,23 @@
 sidebar_position: 2
 sidebar_label: Lists
 title: List API reference
-description: Learn how to interact with the API for list data types in Momento Serverless Cache.
+description: Learn how to interact with the API for List Collection Data Types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/list
 ---
 
 # List API reference for Momento Serverless Cache
-This page details the Momento API methods for the [list data types](./../datatypes.md#list-collections).
+This page details the Momento API methods for the [List Collection Data Types](./../datatypes.md#list-collections).
 
 ## List methods
 
 ### ListFetch
 
-Gets a list item from a cache.
+Gets a List item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| listName        | String | The name of the list item to be retreived.         |
+| listName        | String | The name of the List item to be retreived.         |
 
 <details>
   <summary>Method response object</summary>
@@ -37,7 +37,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListConcatenateBack
-Appends the supplied list to the end of an existing list item.
+Appends the supplied list to the end of an existing List item.
 
 Example:
 
@@ -46,16 +46,16 @@ If you have [1, 2, 3] and listConcatenateBack [4, 5, 6] you will have [1, 2, 3, 
 | Name            | Type                | Description                                   |
 | --------------- | ------------------- | --------------------------------------------- |
 | cacheName       | String              | Name of the cache.                            |
-| listName        | String              | Name of the list item to be set. |
-| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client connection object. |
+| listName        | String              | Name of the List item to be set. |
+| values          | String[] \| bytes[] | Values to be added as elements to the List item. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache client connection object. |
 | truncateFrontToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list
+    * `listLength()`: number - the new length of the List
     * `toString()`: string - add the listLength
 * Error
 
@@ -64,7 +64,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListConcatenateFront
-Appends the supplied list to the front of an existing list item.
+Appends the supplied list to the front of an existing List item.
 
 Example:
 
@@ -73,16 +73,16 @@ If you have [1, 2, 3] and listConcatenateFront [4, 5, 6] you will have [4, 5, 6,
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the list item to be set.              |
-| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
-| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
+| listName        | String       | Name of the List item to be set.              |
+| values          | String[] \| bytes[] | Values to be added as elements to the List item. |
+| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list item
+    * `listLength()`: number - the new length of the List item
     * `toString()`: string - add the listLength
 * Error
 
@@ -91,12 +91,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListLength
-Get the length of an existing list item
+Get the length of an existing List item
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the list item to be checked.          |
+| listName        | String       | Name of the List item to be checked.          |
 
 <details>
   <summary>Method response object</summary>
@@ -112,12 +112,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPopBack
-Remove and return the last element from a list item.
+Remove and return the last element from a List item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the list item to be retreived.        |
+| listName        | String       | Name of the List item to be retreived.        |
 
 <details>
   <summary>Method response object</summary>
@@ -134,12 +134,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPopFront
-Remove and return the first element from a list item.
+Remove and return the first element from a List item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| listName        | String       | Name of the list item to be retreived.        |
+| listName        | String       | Name of the List item to be retreived.        |
 
 <details>
   <summary>Method response object</summary>
@@ -156,21 +156,21 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPushBack
-Push a value to the end of a list item. This is exactly like passing just one value to [ListConcatenateBack](#listconcatenateback).
+Push a value to the end of a List item. This is exactly like passing just one value to [ListConcatenateBack](#listconcatenateback).
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the list to be set.                   |
+| listName        | String          | Name of the List to be set.                   |
 | value           | String \| bytes | Value to be added.              |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list item
+    * `listLength()`: number - the new length of the List item
     * `toString()`: string - add the listLength
 * Error
 
@@ -179,21 +179,21 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListPushFront
-Push a value to the beginning of a list item. Just like [ListPushBack](#listpushback), but to the front.
+Push a value to the beginning of a List item. Just like [ListPushBack](#listpushback), but to the front.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the list to be set. |
-| value           | String \| bytes | Value to be added to the list item by the operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| listName        | String          | Name of the List to be set. |
+| value           | String \| bytes | Value to be added to the List item by the operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the List item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list
+    * `listLength()`: number - the new length of the List
     * `toString()`: string - add the listLength
 * Error
 
@@ -202,7 +202,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### ListRemoveValue
-Remove all elements in a list item equal to a particular value.
+Remove all elements in a List item equal to a particular value.
 
 Examples
 
@@ -211,8 +211,8 @@ Examples
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| listName        | String          | Name of the list item to be set.              |
-| value           | String \| bytes | Value to be added to the list item by the operation. |
+| listName        | String          | Name of the List item to be set.              |
+| value           | String \| bytes | Value to be added to the List item by the operation. |
 
 <details>
   <summary>Method response object</summary>
@@ -228,8 +228,8 @@ See [response objects](./response-objects.md) for specific information.
 
 ## Truncate to size
 
-[ListConcatenate](#listconcatenateback) and [ListPush](#listpushback) type API calls all have truncation options. If after adding their elements the list exceeds this size, this list will be truncated.
+[ListConcatenate](#listconcatenateback) and [ListPush](#listpushback) type API calls all have truncation options. If after adding their elements the List exceeds this size, this List will be truncated.
 
-* Example: If the list is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 5` the list will be truncated to `[2, 3, 4, 5, 6]` and the response ListLength will be 5.
+* Example: If the List is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 5` the List will be truncated to `[2, 3, 4, 5, 6]` and the response ListLength will be 5.
 
-* Example: If the list is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 10` the list will not be truncated. It will be `[1, 2, 3, 4, 5, 6]`
+* Example: If the List is `[1, 2, 3]` and you ListConcatenateBack `[4, 5, 6]` with `truncateFrontToSize: 10` the List will not be truncated. It will be `[1, 2, 3, 4, 5, 6]`

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -2,29 +2,29 @@
 sidebar_position: 3
 sidebar_label: Sets
 title: Set API reference
-description: Learn how to interact with the API for Set Collection Data Types in Momento Serverless Cache.
+description: Learn how to interact with the API for set collection data types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/sets
 ---
 
 # Set API reference for Momento Serverless Cache
 
-A Set is a collection of elements, but each element can appear only once and order is not guaranteed.
+A set is a collection of elements, but each element can appear only once and order is not guaranteed.
 
-Example: if your Set contains `[1, 2, 3]` and you add 2, the Set remains `[1, 2, 3].`
+Example: if your set contains `[1, 2, 3]` and you add 2, the set remains `[1, 2, 3].`
 
 See [Sets](./../datatypes.md#set-collections) for more information on their usage.
 
 ## Set methods
 
 ### SetAddElement
-Adds an element to a Set. If the Set item does not already exist, this method will create one.
+Adds an element to a set. If the set item does not already exist, this method will create one.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the Set item to be altered. |
+| setName         | String          | Name of the set item to be altered. |
 | element         | String \| bytes | Element to be added by this operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -37,14 +37,14 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetAddElements
-Adds multiple elements to a Set item.
+Adds multiple elements to a set item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| setName         | String       | Name of the Set item to be altered. |
+| setName         | String       | Name of the set item to be altered. |
 | elements        | String[] \| bytes[] | Elements to be added by this operation. |
-| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the Set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -58,12 +58,12 @@ See [response objects](./response-objects.md) for specific information.
 
 ### SetFetch
 
-Gets a Set item from a cache.
+Gets a set item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| setName         | String | The name of the Set item to be retreived.     |
+| setName         | String | The name of the set item to be retreived.     |
 
 <details>
   <summary>Method response object</summary>
@@ -82,12 +82,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetRemoveElement
-Removes a single element from an existing Set item.
+Removes a single element from an existing set item.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the Set item to be altered.           |
+| setName         | String          | Name of the set item to be altered.           |
 | element         | String \| bytes | Element to be removed by this operation.   |
 
 <details>
@@ -101,12 +101,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetRemoveElements
-Removes multiple elements from an existing Set item.
+Removes multiple elements from an existing set item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| setName         | String       | Name of the Set item to be altered. |
+| setName         | String       | Name of the set item to be altered. |
 | element         | String \| bytes | Element to be removed by this operation.   |
 
 <details>

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -2,29 +2,29 @@
 sidebar_position: 3
 sidebar_label: Sets
 title: Set API reference
-description: Learn how to interact with the API for set data types in Momento Serverless Cache.
+description: Learn how to interact with the API for Set Collection Data Types in Momento Serverless Cache.
 slug: /develop/api-reference/collections/sets
 ---
 
 # Set API reference for Momento Serverless Cache
 
-A set is a collection of elements, but each element can appear only once and order is not guaranteed.
+A Set is a collection of elements, but each element can appear only once and order is not guaranteed.
 
-Example: if your set contains `[1, 2, 3]` and you add 2, the set remains `[1, 2, 3].`
+Example: if your Set contains `[1, 2, 3]` and you add 2, the Set remains `[1, 2, 3].`
 
-See [sets](./../datatypes.md#set-collections) for more information on their usage.
+See [Sets](./../datatypes.md#set-collections) for more information on their usage.
 
 ## Set methods
 
 ### SetAddElement
-Adds an element to a set. If the set item does not already exist, this method will create one.
+Adds an element to a Set. If the Set item does not already exist, this method will create one.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the set to be set. |
+| setName         | String          | Name of the Set item to be altered. |
 | element         | String \| bytes | Element to be added by this operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the Set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -37,14 +37,14 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetAddElements
-Adds multiple elements to a set item.
+Adds multiple elements to a Set item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| setName         | String       | Name of the set item to be altered. |
+| setName         | String       | Name of the Set item to be altered. |
 | elements        | String[] \| bytes[] | Elements to be added by this operation. |
-| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the Set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -58,12 +58,12 @@ See [response objects](./response-objects.md) for specific information.
 
 ### SetFetch
 
-Gets a set item from a cache.
+Gets a Set item from a cache.
 
 | Name            | Type   | Description                                   |
 | --------------- | ------ | --------------------------------------------- |
 | cacheName       | String | Name of the cache.                            |
-| setName         | String | The name of the set item to be retreived.     |
+| setName         | String | The name of the Set item to be retreived.     |
 
 <details>
   <summary>Method response object</summary>
@@ -82,12 +82,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetRemoveElement
-Removes a single element from an existing set item.
+Removes a single element from an existing Set item.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the set item to be altered.           |
+| setName         | String          | Name of the Set item to be altered.           |
 | element         | String \| bytes | Element to be removed by this operation.   |
 
 <details>
@@ -101,12 +101,12 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SetRemoveElements
-Removes multiple elements from an existing set item.
+Removes multiple elements from an existing Set item.
 
 | Name            | Type         | Description                                   |
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
-| setName         | String       | Name of the set item to be set. |
+| setName         | String       | Name of the Set item to be altered. |
 | element         | String \| bytes | Element to be removed by this operation.   |
 
 <details>

--- a/docs/develop/datatypes.md
+++ b/docs/develop/datatypes.md
@@ -14,13 +14,13 @@ Momento Serverless Cache provides a group of core data types to match up with co
 ### Byte arrays
 All data stored in Momento Serverless Cache is represented as byte arrays. The Momento SDKs provide easy methods you can use to store your data as raw bytes or as portable UTF-8 strings. Those can be in the form of scalar data, such as strings, characters, numbers, and binary data, such as images and Protocol Buffers serialized arrays.
 
-### Collection Data Types (CDTs)
+### Collection data types (CDTs)
 Collection Data Types are a grouping of related data into a single item. They are stored as byte array values and each has their own set of API calls in Momento SDKs. For example, DictionaryFetch, ListFetch, and SetFetch.
 
-![Collection Data Types diagram](/img/collection_data_types.svg "Collection Data Types")
+![Collection data types diagram](/img/collection_data_types.svg "Collection data types")
 
 #### Lists
-A List is a collection of ordered elements, sorted in the sequence each element was inserted.
+A list is a collection of ordered elements, sorted in the sequence each element was inserted.
 
 ```javascript
 "Hoover’s Sour Cream Cookies" = [
@@ -37,12 +37,12 @@ A List is a collection of ordered elements, sorted in the sequence each element 
 ]
 ```
 
-To learn the API methods, check the [API reference for List Collection Data Types](./api-reference/list-collections.md).
+To learn the API methods, check the [API reference for list collection data types](./api-reference/list-collections.md).
 
 #### Dictionaries
-A Dictionary is a collection of unordered elements where each element is a field:value pair.
+A dictionary is a collection of unordered elements where each element is a field:value pair.
 
-An example of using a Dictionary is when you need to store data together and retrieve field:value pairs by name.
+An example of using a dictionary is when you need to store data together and retrieve field:value pairs by name.
 ```javascript
 "truck546" = {
     "brand" : "Ford", 
@@ -52,10 +52,10 @@ An example of using a Dictionary is when you need to store data together and ret
 }
 ```
 
-To learn the API methods, check the [API reference for Dictionary Collection Data Types](./api-reference/dictionary-collections.md).
+To learn the API methods, check the [API reference for dictionary collection data types](./api-reference/dictionary-collections.md).
 
 #### Sets
-A Set is an unordered collection of unique elements, each in string format. For example, no matter how many times you add 'sugar' to a set, there will only be one entry for 'sugar'.
+A set is an unordered collection of unique elements, each in string format. For example, no matter how many times you add 'sugar' to a set, there will only be one entry for 'sugar'.
 
 ```javascript
 "myIngredients" = {
@@ -68,17 +68,17 @@ A Set is an unordered collection of unique elements, each in string format. For 
 }
 ```
 
-To learn the API methods, check the [API reference for Set Collection Data Types](./api-reference/set-collections.md).
+To learn the API methods, check the [API reference for set collection data types](./api-reference/set-collections.md).
 
 ## FAQs
 <details>
-  <summary>If I perform an API call to get a subset of data from a Dictionary item, will the size of the entire item count toward the per GB transfer costs?</summary>
+  <summary>If I perform an API call to get a subset of data from a dictionary item, will the size of the entire item count toward the per GB transfer costs?</summary>
 No, it will not. For example, if you perform the API call DictionaryGetField to get one 5-kilobyte field:value pair from a dictionary where the entire dictionary item is 50 kilobytes, only 5 kilobytes count towards your per GB transfer costs.
 </details>
 
 <details>
   <summary>How do I store a JSON document in Momento Serverless Cache?</summary>
-Use your favorite JSON library to serialize the JSON document into a byte array and insert that byte array into Momento Serverless Cache.
+Use your favorite JSON library to serialize the JSON document into a byte array and insert that byte array into Momento Serverless Cache. You could also store each field value in your JSON document in a dictionary.
 </details>
 
 <details>

--- a/docs/develop/datatypes.md
+++ b/docs/develop/datatypes.md
@@ -14,13 +14,13 @@ Momento Serverless Cache provides a group of core data types to match up with co
 ### Byte arrays
 All data stored in Momento Serverless Cache is represented as byte arrays. The Momento SDKs provide easy methods you can use to store your data as raw bytes or as portable UTF-8 strings. Those can be in the form of scalar data, such as strings, characters, numbers, and binary data, such as images and Protocol Buffers serialized arrays.
 
-### Collection data types (CDTs)
-Collection data types are a grouping of related data into a single item. They are stored as byte array values and each has their own set of API calls in Momento SDKs. For example, DictionaryFetch, ListFetch, and SetFetch.
+### Collection Data Types (CDTs)
+Collection Data Types are a grouping of related data into a single item. They are stored as byte array values and each has their own set of API calls in Momento SDKs. For example, DictionaryFetch, ListFetch, and SetFetch.
 
-![Collection data types diagram](/img/collection_data_types.svg "Collection data types")
+![Collection Data Types diagram](/img/collection_data_types.svg "Collection Data Types")
 
-#### List collections
-A list is a collection of ordered elements, sorted in the sequence each element was inserted.
+#### Lists
+A List is a collection of ordered elements, sorted in the sequence each element was inserted.
 
 ```javascript
 "Hoover’s Sour Cream Cookies" = [
@@ -37,12 +37,12 @@ A list is a collection of ordered elements, sorted in the sequence each element 
 ]
 ```
 
-To learn the API methods, check the [api reference for list collection data types](./api-reference/list-collections.md).
+To learn the API methods, check the [API reference for List Collection Data Types](./api-reference/list-collections.md).
 
-#### Dictionary collections
-Dictionary data types are a collection of unordered elements where each element is a field:value pair.
+#### Dictionaries
+A Dictionary is a collection of unordered elements where each element is a field:value pair.
 
-An example of using a dictionary is when you need to store data together and retrieve field:value pairs by name.
+An example of using a Dictionary is when you need to store data together and retrieve field:value pairs by name.
 ```javascript
 "truck546" = {
     "brand" : "Ford", 
@@ -52,10 +52,10 @@ An example of using a dictionary is when you need to store data together and ret
 }
 ```
 
-To learn the API methods, check the [api reference for dictionary collection data types](./api-reference/dictionary-collections.md).
+To learn the API methods, check the [API reference for Dictionary Collection Data Types](./api-reference/dictionary-collections.md).
 
-#### Set collections
-The set collection data type is an unordered collection of unique elements, each in string format. For example, no matter how many times you add 'sugar' to a set, there will only be one entry for 'sugar'.
+#### Sets
+A Set is an unordered collection of unique elements, each in string format. For example, no matter how many times you add 'sugar' to a set, there will only be one entry for 'sugar'.
 
 ```javascript
 "myIngredients" = {
@@ -68,7 +68,7 @@ The set collection data type is an unordered collection of unique elements, each
 }
 ```
 
-To learn the API methods, check the [api reference for set collection data types](./api-reference/set-collections.md).
+To learn the API methods, check the [API reference for Set Collection Data Types](./api-reference/set-collections.md).
 
 ## FAQs
 <details>


### PR DESCRIPTION
This is mostly capitalization edits.

* Replacing 'api' with 'API' on data types page
* Change to title case on CDT names
* Finish out definitions for collectionTTL page