### PR TITLE
Fix name of GCP region

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Authentication tokens are associated with a specific Momento Serverless Cache cl
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 ```
 
-#### GCP [available regions are us-east1, ap-northeast1]
+#### GCP [available regions are us-east1, asia-northeast1]
 
 ```console
 momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -105,7 +105,7 @@ Options:
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 ```
 
-#### GCP [利用可能リージョンは us-east1, ap-northeast1]
+#### GCP [利用可能リージョンは us-east1, asia-northeast1]
 
 ```console
 momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>


### PR DESCRIPTION
Updating name in the docs from `ap-northeast1` to `asia-northeast`