### PR TITLE
docs: update sorted set documentation to reflect latest api

### DIFF
--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -7,11 +7,12 @@ slug: /develop/api-reference/collections/sortedsets
 ---
 
 # Sorted set collections
+
 A sorted set in Momento Serverless Cache is a collection of unique elements with a value (string, byte[], etc.) and score (signed double 64-bit float) pair. The elements in the item are ordered by the score.
 
 ## Sorted set methods
 
-### SortedSetPut
+### SortedSetPutElements
 
 Adds new or updates existing [sorted set elements](#sortedsetelement) in a sorted set item.
 
@@ -36,16 +37,17 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-### SortedSetFetch
+### SortedSetFetchByRank
 
-Fetch all elements in a sorted set and return them in ascending or descending order.
+Fetch elements of sorted set, optionally filtered by rank, and return them in ascending or descending order.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | setName         | String          | Name of the sorted set item. |
-| numberOfResults | Optional[integer]   | How many results to return, default is all results. |
-| order           | Ascending \| Descending | The order you want the sorted set returned |
+| startRank | Optional[integer]   | The inclusive start rank of the results. Default is zero. |
+| endRank | Optional[integer]   | The exclusive end rank of the results. Default is `null`, ie up to and including the element ranked last. |
+| order           | Ascending \| Descending | The order you want the sorted set returned. |
 
 <details>
   <summary>Method response object</summary>
@@ -59,7 +61,33 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-### SortedSetGetScore
+### SortedSetFetchByScore
+
+Fetch elements of sorted set, optionally filtered by score, and return them in ascending or descending order.
+
+| Name            | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| cacheName       | String          | Name of the cache.                            |
+| setName         | String          | Name of the sorted set item. |
+| minScore | Optional[double]   | The inclusive low score of the results. Default is `-inf`, ie include through the lowest score. |
+| maxScore | Optional[double]   | The inclusive high score of the results. Default is `+inf`, ie include through the highest score. |
+| order           | Ascending \| Descending | The order you want the sorted set returned. |
+| offset           | Optional[int] | The offset, inclusive, into the filtered list from which to start returning results. Default is 0, ie do not filter. If specified, must be non-negative. |
+| count           | Optional[int] | The maximum number of results from the filtered list to return. Default is `null`, ie no limit. If specified, must be strictly positive. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Hit
+    * elements(): SortedSetElement[]
+* Miss
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+### SortedSetGetScores
 
 Gets an existing element and its associated score from the sorted set.
 
@@ -84,7 +112,7 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-### SortedSetRemove
+### SortedSetRemoveElements
 
 Removes an element from a sorted set.
 

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -12,6 +12,32 @@ A sorted set in Momento Serverless Cache is a collection of unique elements with
 
 ## Sorted set methods
 
+### SortedSetPutElement
+
+Adds a new or updates an existing [sorted set element](#sortedsetelement) in a sorted set item.
+
+- If the set does not exist, this method creates a new sorted set item with the element passed in.
+
+- If the set exists, the element is added to the sorted set if that **value** doesn't exist. If the value of that element does exist, that element is overwritten.
+
+| Name            | Type               | Description                                   |
+| --------------- | ------------------ | --------------------------------------------- |
+| cacheName       | String             | Name of the cache.                            |
+| setName         | String             | Name of the sorted set item to be altered. |
+| value        | String \| byte[] | The value of the element to be added to the sorted set by this operation. |
+| score        | number | The score of the element to be added to the sorted set by this operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Success
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+
 ### SortedSetPutElements
 
 Adds new or updates existing [sorted set elements](#sortedsetelement) in a sorted set item.
@@ -87,9 +113,31 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+### SortedSetGetScore
+
+Gets an element's score from the sorted set, indexed by value.
+
+| Name             | Type                | Description                                   |
+| ---------------- | ------------------- | --------------------------------------------- |
+| cacheName        | String              | Name of the cache.                            |
+| setName          | String              | Name of the sorted set item. |
+| value           | String \| bytes | The value to get the score of. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Cache hit
+  * Score: number
+* Cache miss (if the sorted set does not exist)
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+
 ### SortedSetGetScores
 
-Gets an existing element and its associated score from the sorted set.
+Gets the scores associated with a list of elements from the sorted set, indexed by value.
 
 | Name             | Type                | Description                                   |
 | ---------------- | ------------------- | --------------------------------------------- |
@@ -112,17 +160,37 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-### SortedSetRemoveElements
+### SortedSetRemoveElement
 
-Removes an element from a sorted set.
+Removes an element from a sorted set, indexed by value.
 
 | Name            | Type             | Description                                   |
 | --------------- | ---------------- | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
 | setName         | String           | Name of the set item to be altered. |
-| values          | All \| string[] \| bytes[] | Values of the elements to be removed by this operation. |
+| value          | String \| bytes | Value of the element to be removed by this operation. |
 
-You can remove either one, all, or specific group of elements.
+<details>
+  <summary>Method response object</summary>
+
+* Success
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+### SortedSetRemoveElements
+
+Removes elements from a sorted set, indexed by values.
+
+| Name            | Type             | Description                                   |
+| --------------- | ---------------- | --------------------------------------------- |
+| cacheName       | String           | Name of the cache.                            |
+| setName         | String           | Name of the set item to be altered. |
+| values          | String[] \| bytes[] | Values of the elements to be removed by this operation. |
+
+You can remove either one or a specific group of elements.
 
 <details>
   <summary>Method response object</summary>


### PR DESCRIPTION
Tweak the method names and split `SortedSetFetch` into
`SortedSetFetchByScore` and `SortedSetFetchByRank`.

Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/202