### PR TITLE
chore: update matrix for CDT API support

### DIFF
--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -609,17 +609,19 @@ Collections may contain different types of structures depending on your use case
 * [Dictionaries](./dictionary-collections.md) are used to store unordered field:value pairs.
 * [Lists](./list-collections.md) are a collection of ordered elements, sorted in the sequence each element was inserted.
 * [Sets](./set-collections.md) are an unordered collection of unique elements in string format.
+* [Sorted Sets](./sorted-set-collections.md) are an ordered collection of unique elements.  Each element contains a value:score pair.
 
 For more in-depth information on usage, see [collection data types](./../datatypes.md).
 
 ## Current status of API support in SDKs
 
-| Feature           | .NET               | Java                | Node.js            | Python             | PHP               | Ruby               | Go                 | Rust               |
+| Feature           | .NET               | Java               | Node.js            | Python             | Go                 | PHP                | Ruby                 | Rust               |
 |-------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
 | Control APIs      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Get/Set           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Increment         | :x:                | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
-| Dictionary CDTs   | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
-| Set CDTs          | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
-| List CDTs         | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
-| Flush Cache       | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
+| Increment         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| Dictionary CDTs   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Set CDTs          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| List CDTs         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| Sorted Set CDTs   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
+| Flush Cache       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |


### PR DESCRIPTION
Updates matrix for CDT API support, and adds missing link for SortedSets.