### PR TITLE
fix: `nom` -> `npm`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ Install the Momento SDK and dotenv in your project directory
 
 ```cli
 npm install @gomomento/sdk
-nom install dotenv
+npm install dotenv
 ```
 
 **Create a .env file**


### PR DESCRIPTION
A user reported a typo in our public doc specifically in the getting started section.