### PR TITLE
feat: generate language API support matrix

### DIFF
--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -6,7 +6,6 @@ sidebar_label: API reference
 description: Learn the API calls you need to know and how to use them with Momento Cache.
 ---
 
-import { SdkExamples } from "@site/src/components/SdkExamples";
 import { SdkExampleSnippets } from "@site/src/components/SdkExampleSnippets";
 // This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
 // plugin will transform instances of SdkExampleSnippets to SdkExampleSnippetTabs
@@ -255,14 +254,4 @@ For more in-depth information on usage, see [collection data types](./../datatyp
 
 ## Current status of API support in SDKs
 
-| Feature           | .NET               | Java               | Node.js            | Python             | Go                 | PHP                | Ruby               | Rust               |
-|-------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| Control APIs      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Get/Set           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Increment         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
-| Dictionary CDTs   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| Set CDTs          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| List CDTs         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| Sorted Set CDTs   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
-| Flush Cache       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :white_check_mark: |
-| Topics (pub/sub)  | :x:                | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:                | :x:                |
+For the current status of API support in various SDK languages, see the [language support page](./language-support.md).

--- a/docs/develop/api-reference/language-support.md
+++ b/docs/develop/api-reference/language-support.md
@@ -1,0 +1,11 @@
+---
+sidebar_position: 12
+sidebar_label: Language Support
+title: Language API Support Matrix
+description: A reference as to which Momento SDK languages support each API
+slug: /develop/api-reference/language-support
+---
+
+## Current Status of API support in Momento SDKs
+
+%%%API_SUPPORT_MATRIX%%%

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@ const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
 const exampleSnippetsPlugin = require('./plugins/example-code-snippets/dist/inject-example-code-snippets');
+const languageApiSupportMatrixPlugin = require('./plugins/example-code-snippets/dist/language-api-support-matrix');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -37,7 +38,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: "https://github.com/momentohq/public-dev-docs/tree/main/",
 	        routeBasePath: '/', // Serve the docs at the site's root
-          remarkPlugins: [exampleSnippetsPlugin]
+          remarkPlugins: [exampleSnippetsPlugin, languageApiSupportMatrixPlugin]
         },
 	     blog: false, // Turn off blog functionality
         theme: {

--- a/plugins/example-code-snippets/package-lock.json
+++ b/plugins/example-code-snippets/package-lock.json
@@ -62,18 +62,18 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.5.tgz",
-      "integrity": "sha512-M+XAiQ7GzQ3FDPf0KOLkugzptnIypt0X0ma0wmlTKPR3IchgNFdx2JXxZdvd18JY5s7QkaFD/qyX0dsMpog/Ug==",
+      "version": "7.21.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.7.tgz",
+      "integrity": "sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -82,7 +82,7 @@
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
         "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.5",
+        "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.5.tgz",
-      "integrity": "sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
+      "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1428,15 +1428,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
-      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/type-utils": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1462,14 +1462,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
-      "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1489,13 +1489,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
-      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1506,13 +1506,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
-      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1533,9 +1533,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
-      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1546,13 +1546,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
-      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1573,17 +1573,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
-      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -1599,12 +1599,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
-      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2062,9 +2062,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001481",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
-      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
+      "version": "1.0.30001482",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
+      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
       "dev": true,
       "funding": [
         {
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.377.tgz",
-      "integrity": "sha512-H3BYG6DW5Z+l0xcfXaicJGxrpA4kMlCxnN71+iNX+dBLkRMOdVJqFJiAmbNZZKA1zISpRg17JR03qGifXNsJtw==",
+      "version": "1.4.380",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.380.tgz",
+      "integrity": "sha512-XKGdI4pWM78eLH2cbXJHiBnWUwFSzZM7XujsB6stDiGu9AeSqziedP6amNLpJzE3i0rLTcfAwdCTs5ecP5yeSg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -7339,15 +7339,15 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.5.tgz",
-      "integrity": "sha512-M+XAiQ7GzQ3FDPf0KOLkugzptnIypt0X0ma0wmlTKPR3IchgNFdx2JXxZdvd18JY5s7QkaFD/qyX0dsMpog/Ug==",
+      "version": "7.21.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.7.tgz",
+      "integrity": "sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
@@ -7356,7 +7356,7 @@
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
         "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.5",
+        "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
@@ -7596,9 +7596,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.5.tgz",
-      "integrity": "sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
+      "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -7832,9 +7832,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -8453,15 +8453,15 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
-      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/type-utils": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -8471,53 +8471,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
-      "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
-      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
-      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
-      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
-      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -8526,28 +8526,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
-      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
-      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -8869,9 +8869,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001481",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
-      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
+      "version": "1.0.30001482",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
+      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
       "dev": true
     },
     "chalk": {
@@ -9060,9 +9060,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.377.tgz",
-      "integrity": "sha512-H3BYG6DW5Z+l0xcfXaicJGxrpA4kMlCxnN71+iNX+dBLkRMOdVJqFJiAmbNZZKA1zISpRg17JR03qGifXNsJtw==",
+      "version": "1.4.380",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.380.tgz",
+      "integrity": "sha512-XKGdI4pWM78eLH2cbXJHiBnWUwFSzZM7XujsB6stDiGu9AeSqziedP6amNLpJzE3i0rLTcfAwdCTs5ecP5yeSg==",
       "dev": true
     },
     "emittery": {

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -1,0 +1,318 @@
+import {Sdk, sdkDisplayName} from '../examples/sdk-source/sdks';
+import * as path from 'path';
+import {SdkSourceProvider} from '../examples/sdk-source/sdk-source-provider';
+import {SdkGithubRepoSourceProvider} from '../examples/sdk-source/sdk-github-repo-source-provider';
+import * as fs from 'fs';
+import {heading, Heading, table, Table} from '../utils/markdown-nodes';
+
+interface SdkInfo {
+  sdk: Sdk;
+  cacheClientFile: string | Array<string>;
+  configObjectFile?: string;
+  topicClientFile?: string;
+}
+
+const SDKS: Array<SdkInfo> = [
+  {
+    sdk: Sdk.NODEJS,
+    cacheClientFile: [
+      'packages/client-sdk-nodejs/src/cache-client.ts',
+      'packages/core/src/internal/clients/cache/AbstractCacheClient.ts',
+    ],
+    configObjectFile: 'packages/client-sdk-nodejs/src/config/configuration.ts',
+    topicClientFile: 'packages/client-sdk-nodejs/src/topic-client.ts',
+  },
+  {
+    sdk: Sdk.WEB,
+    cacheClientFile: [
+      'packages/client-sdk-web/src/cache-client.ts',
+      'packages/core/src/internal/clients/cache/AbstractCacheClient.ts',
+    ],
+    configObjectFile: undefined,
+    topicClientFile: undefined,
+  },
+  {
+    sdk: Sdk.DOTNET,
+    cacheClientFile: 'src/Momento.Sdk/ICacheClient.cs',
+    configObjectFile: 'src/Momento.Sdk/Config/Configuration.cs',
+    topicClientFile: undefined,
+  },
+  {
+    sdk: Sdk.PYTHON,
+    cacheClientFile: 'src/momento/cache_client_async.py',
+    configObjectFile: 'src/momento/config/configuration.py',
+    topicClientFile: undefined,
+  },
+  {
+    sdk: Sdk.GO,
+    cacheClientFile: 'momento/cache_client.go',
+    configObjectFile: 'config/config.go',
+    topicClientFile: 'momento/topic_client.go',
+  },
+  {
+    sdk: Sdk.JAVA,
+    cacheClientFile: 'momento-sdk/src/main/java/momento/sdk/CacheClient.java',
+    configObjectFile:
+      'momento-sdk/src/main/java/momento/sdk/config/Configuration.java',
+    topicClientFile: undefined,
+  },
+  {
+    sdk: Sdk.PHP,
+    cacheClientFile: 'src/Cache/CacheClient.php',
+    configObjectFile: 'src/Config/Configuration.php',
+    topicClientFile: undefined,
+  },
+  {
+    sdk: Sdk.RUST,
+    cacheClientFile: 'src/simple_cache_client.rs',
+    configObjectFile: undefined,
+    topicClientFile: 'src/preview/topics.rs',
+  },
+  {
+    sdk: Sdk.RUBY,
+    cacheClientFile: 'lib/momento/simple_cache_client.rb',
+    configObjectFile: undefined,
+    topicClientFile: undefined,
+  },
+];
+
+type Api = string | {displayName: string; functionName: string | RegExp};
+
+interface ApiGroup {
+  groupName: string;
+  apis: Array<Api>;
+}
+
+const CONFIG_API_GROUPS: Array<ApiGroup> = [
+  {
+    groupName: 'Configuration',
+    apis: [
+      {
+        displayName: 'ClientTimeout',
+        functionName: / withclienttimeout(?:millis)?\(/,
+      },
+      {displayName: 'Retries', functionName: 'withRetryStrategy'},
+      {displayName: 'Middleware', functionName: 'withMiddlewares'},
+    ],
+  },
+];
+
+const CACHE_API_GROUPS: Array<ApiGroup> = [
+  {
+    groupName: 'Global',
+    apis: [
+      'ping',
+      'flushCache',
+      'keysExist',
+      'keyExists',
+      'delete',
+      'updateTtl',
+      'increaseTtl',
+      'decreaseTtl',
+    ],
+  },
+  {
+    groupName: 'Scalars',
+    apis: ['get', 'set', 'setIfNotExists', 'increment'],
+  },
+  {
+    groupName: 'Lists',
+    apis: [
+      'listConcatenateBack',
+      'listConcatenateFront',
+      'listFetch',
+      'listLength',
+      'listPopBack',
+      'listPopFront',
+      'listPushBack',
+      'listPushFront',
+      'listRemoveValue',
+      'listRetain',
+    ],
+  },
+  {
+    groupName: 'Dictionaries',
+    apis: [
+      'dictionaryFetch',
+      'dictionaryGetField',
+      'dictionaryGetFields',
+      'dictionaryIncrement',
+      'dictionaryRemoveField',
+      'dictionaryRemoveFields',
+      'dictionarySetField',
+      'dictionarySetFields',
+    ],
+  },
+  {
+    groupName: 'Sets',
+    apis: [
+      'setAddElement',
+      'setAddElements',
+      'setFetch',
+      'setRemoveElement',
+      'setRemoveElements',
+      'setContainsElement',
+      'setContainsElements',
+    ],
+  },
+  {
+    groupName: 'Sorted Sets',
+    apis: [
+      'sortedSetFetchByRank',
+      'sortedSetFetchByScore',
+      'sortedSetGetRank',
+      'sortedSetGetScore',
+      'sortedSetGetScores',
+      'sortedSetIncrementScore',
+      'sortedSetPutElement',
+      'sortedSetPutElements',
+      'sortedSetRemoveElement',
+      'sortedSetRemoveElements',
+    ],
+  },
+  {
+    groupName: 'Signing Keys',
+    apis: ['createSigningKey', 'listSigningKeys', 'revokeSigningKey'],
+  },
+  {groupName: 'SSO', apis: ['generateApiToken']},
+];
+
+const TOPIC_API_GROUPS: Array<ApiGroup> = [
+  {groupName: 'Topics', apis: ['subscribe', 'publish']},
+];
+
+export class ApiSupportMatrixGenerator {
+  generateApiMatrixMarkdownNodes(): Array<Heading | Table> {
+    const sourceProvider: SdkSourceProvider = new SdkGithubRepoSourceProvider();
+
+    const allSdksCacheApiSupport = new Map<string, Map<string, boolean>>();
+    const allSdksConfigApiSupport = new Map<string, Map<string, boolean>>();
+    const allSdksTopicsApiSupport = new Map<string, Map<string, boolean>>();
+
+    for (const sdk of SDKS) {
+      const sdkRepoDir = sourceProvider.sdkSourceDir(sdk.sdk);
+      const sdkName = sdk.sdk.valueOf();
+      console.log(`Checking sdk: ${sdkName}`);
+
+      const cacheApiSupport = determineApiSupport(
+        sdkRepoDir,
+        sdk.cacheClientFile,
+        CACHE_API_GROUPS
+      );
+      allSdksCacheApiSupport.set(sdkName, cacheApiSupport);
+      const configApiSupport = determineApiSupport(
+        sdkRepoDir,
+        sdk.configObjectFile,
+        CONFIG_API_GROUPS
+      );
+      allSdksConfigApiSupport.set(sdkName, configApiSupport);
+      const topicApiSupport = determineApiSupport(
+        sdkRepoDir,
+        sdk.topicClientFile,
+        TOPIC_API_GROUPS
+      );
+      allSdksTopicsApiSupport.set(sdkName, topicApiSupport);
+    }
+
+    const nodes: Array<Heading | Table> = [];
+    nodes.push(...renderApiGroups(CACHE_API_GROUPS, allSdksCacheApiSupport));
+    nodes.push(...renderApiGroups(TOPIC_API_GROUPS, allSdksTopicsApiSupport));
+    nodes.push(...renderApiGroups(CONFIG_API_GROUPS, allSdksConfigApiSupport));
+    return nodes;
+  }
+}
+
+function renderApiGroups(
+  apiGroups: Array<ApiGroup>,
+  allSdksApiSupport: Map<string, Map<string, boolean>>
+): Array<Heading | Table> {
+  const nodes: Array<Heading | Table> = [];
+  for (const apiGroup of apiGroups) {
+    nodes.push(heading(apiGroup.groupName, 3));
+    nodes.push(
+      table([
+        ['Feature', ...SDKS.map(s => sdkDisplayName(s.sdk))],
+        ...apiGroup.apis.map(api => {
+          const displayName = typeof api === 'string' ? api : api.displayName;
+          return [
+            displayName,
+            ...SDKS.map(sdk => {
+              if (
+                allSdksApiSupport.get(sdk.sdk.valueOf())?.get(displayName) ===
+                true
+              ) {
+                return '✅';
+              } else {
+                return '❌';
+              }
+            }),
+          ];
+        }),
+      ])
+    );
+  }
+  return nodes;
+}
+
+function determineApiSupport(
+  sdkRepoDir: string,
+  codeFile: string | Array<string> | undefined,
+  apiGroups: Array<ApiGroup>
+): Map<string, boolean> {
+  const apiSupport = new Map<string, boolean>();
+  for (const apiGroup of apiGroups) {
+    for (const api of apiGroup.apis) {
+      const displayName = typeof api === 'string' ? api : api.displayName;
+      apiSupport.set(displayName, false);
+    }
+  }
+
+  if (codeFile === undefined) {
+    return apiSupport;
+  }
+
+  const codeFiles: Array<string> =
+    typeof codeFile === 'string' ? [codeFile] : codeFile;
+
+  for (const f of codeFiles) {
+    const clientCodeFile = path.join(sdkRepoDir, f);
+    // this is silly and inefficient, reading the whole file into memory at once.  However,
+    // it was feeling pretty tricky to call async functions from the remark plugin, and there
+    // is no sane way that I could find to do synchronous line-by-line iteration over file
+    // contents in node.js.  So we are just slurping the whole thing into memory for now,
+    // can revisit later if we need to.
+    const lines = fs.readFileSync(clientCodeFile).toString().split('\n');
+    for (const line of lines) {
+      if (line.trim().startsWith('//')) continue;
+      if (line.trim().startsWith('#')) continue;
+      const unSnaked = line.replaceAll('_', '');
+      const unAsynced = unSnaked.replaceAll('Async(', '(');
+      for (const apiGroup of apiGroups) {
+        for (const api of apiGroup.apis) {
+          const functionName = typeof api === 'string' ? api : api.functionName;
+          const displayName = typeof api === 'string' ? api : api.displayName;
+          const apiFound =
+            typeof functionName === 'string'
+              ? unAsynced
+                  .toLowerCase()
+                  .includes(` ${functionName.toLowerCase()}(`)
+              : unAsynced.toLowerCase().match(functionName);
+
+          if (apiFound) {
+            apiSupport.set(displayName, true);
+          }
+        }
+      }
+    }
+  }
+  console.log(
+    `Done scanning client files '${JSON.stringify(
+      codeFile
+    )}'.  Supported APIs: ${JSON.stringify(
+      Object.fromEntries(apiSupport),
+      null,
+      2
+    )}`
+  );
+  return apiSupport;
+}

--- a/plugins/example-code-snippets/src/examples/sdk-source/sdk-github-repo-source-provider.ts
+++ b/plugins/example-code-snippets/src/examples/sdk-source/sdk-github-repo-source-provider.ts
@@ -15,6 +15,8 @@ export function githubRepoNameForSdk(sdk: Sdk): string {
   switch (sdk) {
     case Sdk.NODEJS:
       return 'client-sdk-nodejs';
+    case Sdk.WEB:
+      return 'client-sdk-nodejs';
     case Sdk.DOTNET:
       return 'client-sdk-dotnet';
     case Sdk.PYTHON:

--- a/plugins/example-code-snippets/src/examples/sdk-source/sdks.ts
+++ b/plugins/example-code-snippets/src/examples/sdk-source/sdks.ts
@@ -3,6 +3,7 @@
  */
 export enum Sdk {
   NODEJS = 'nodejs',
+  WEB = 'web',
   DOTNET = 'dotnet',
   PYTHON = 'python',
   GO = 'go',
@@ -11,4 +12,32 @@ export enum Sdk {
   RUST = 'rust',
   RUBY = 'ruby',
   CLI = 'cli',
+}
+
+export function sdkDisplayName(sdk: Sdk): string {
+  switch (sdk) {
+    case Sdk.NODEJS:
+      return 'Node.js';
+    case Sdk.WEB:
+      return 'Web';
+    case Sdk.DOTNET:
+      return '.NET';
+    case Sdk.PYTHON:
+      return 'Python';
+    case Sdk.GO:
+      return 'Go';
+    case Sdk.JAVA:
+      return 'Java';
+    case Sdk.PHP:
+      return 'PHP';
+    case Sdk.RUST:
+      return 'Rust';
+    case Sdk.RUBY:
+      return 'Ruby';
+    case Sdk.CLI:
+      return 'Cli';
+    default:
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      throw new Error(`Unrecognized SDK: ${sdk}`);
+  }
 }

--- a/plugins/example-code-snippets/src/inject-example-code-snippets.ts
+++ b/plugins/example-code-snippets/src/inject-example-code-snippets.ts
@@ -24,13 +24,9 @@ function markdownNodeContainsExampleSnippets<T extends unist.Node>(
 }
 
 /**
- * This is a docusaurus MDX/remark plugin.  It finds markers in the markdown
- * source, in 'text' or 'code' blocks, and injects example snippets into the
- * content in their place.
- *
- * The markers are delimited by 3 percent signs; here is an example:
- *
- * %%%example:typescript:code:API_Set%%%
+ * This is a docusaurus MDX/remark plugin.  It finds <SdkExampleSnippets> in the markdown
+ * source, and replaces them with <SdkExampleSnippetTabs> tags that are populated with the
+ * example code snippets pulled in from the SDK repos.
  *
  * @param options
  * @returns {unknown}
@@ -70,9 +66,7 @@ function plugin(options: unknown): unknown {
   cli={\`${snippetForLanguage(ExampleLanguage.CLI)}\`}
 />
 `;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      node.value = sdkExamplesValue;
+      literal.value = sdkExamplesValue;
     });
   }
   return transformer;

--- a/plugins/example-code-snippets/src/language-api-support-matrix.ts
+++ b/plugins/example-code-snippets/src/language-api-support-matrix.ts
@@ -1,0 +1,51 @@
+import visit from 'unist-util-visit';
+// eslint-disable-next-line import/no-unresolved,node/no-missing-import
+import * as unist from 'unist';
+import {ApiSupportMatrixGenerator} from './api-support/api-support-matrix-generator';
+
+function isSupportMatrixNode<T extends unist.Node>(node: unknown): node is T {
+  const unistNode = node as unist.Node;
+  if (unistNode.type === 'paragraph') {
+    const unistParent = unistNode as unist.Parent;
+    if (unistParent.children.length === 1) {
+      const childLiteral: unist.Literal = unistParent
+        .children[0] as unist.Literal;
+      if (childLiteral.type === 'text') {
+        const value = childLiteral.value as string;
+        if (value.match('%%%API_SUPPORT_MATRIX%%%')) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * This is a docusaurus MDX/remark plugin.  It finds the %%%API_SUPPORT_MATRIX%%% marker
+ * in the markdown and injects the API support matrix tables in its place.
+ *
+ * @param options
+ * @returns {unknown}
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function plugin(options: unknown): unknown {
+  function transformer(tree: unist.Parent) {
+    visit(tree, isSupportMatrixNode, node => {
+      const matrixGenerator = new ApiSupportMatrixGenerator();
+      const newNodes = matrixGenerator.generateApiMatrixMarkdownNodes();
+
+      const treeChildren: Array<unist.Node> = tree.children;
+      const thisNodeIndex = treeChildren.findIndex(n => n === node);
+      console.log(`THIS NODE INDEX: ${thisNodeIndex}`);
+      tree.children = [
+        ...treeChildren.slice(0, thisNodeIndex),
+        ...newNodes,
+        ...treeChildren.slice(thisNodeIndex + 1),
+      ];
+    });
+  }
+  return transformer;
+}
+
+module.exports = plugin;

--- a/plugins/example-code-snippets/src/utils/markdown-nodes.ts
+++ b/plugins/example-code-snippets/src/utils/markdown-nodes.ts
@@ -1,0 +1,73 @@
+/**
+ * The typescript definitions for remark/unist are really useless (at least with the current dependency versions of
+ * docusaurus).  So here we just create some overlapping interfaces that make it easier to write the code before
+ * we cast back to unist Nodes at the end.
+ */
+export interface Text {
+  type: 'text';
+  value: string;
+}
+
+export interface TableCell {
+  type: 'tableCell';
+  children: [Text];
+}
+
+export interface TableRow {
+  type: 'tableRow';
+  children: Array<TableCell>;
+}
+export interface Table {
+  type: 'table';
+  children: Array<TableRow>;
+}
+
+export interface Paragraph {
+  type: 'paragraph';
+  children: [Text];
+}
+
+export interface Heading {
+  type: 'heading';
+  depth: number;
+  children: [Text];
+}
+
+export function heading(value: string, depth: number): Heading {
+  return {
+    type: 'heading',
+    depth: depth,
+    children: [
+      {
+        type: 'text',
+        value: value,
+      },
+    ],
+  };
+}
+
+export function table(rows: Array<Array<string>>): Table {
+  return {
+    type: 'table',
+    children: rows.map(r => tableRow(r)),
+  };
+}
+
+export function tableRow(values: Array<string>): TableRow {
+  return {
+    type: 'tableRow',
+    children: values.map(v => tableCell(v)),
+  };
+}
+
+export function tableCell(value: string): TableCell {
+  return {
+    type: 'tableCell',
+    children: [
+      {
+        type: 'text',
+        value: value,
+      },
+    ],
+  };
+}

--- a/plugins/example-code-snippets/tsconfig.json
+++ b/plugins/example-code-snippets/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2018",
     "module": "commonjs",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2021", "dom"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This commit gets rid of the hard-coded language support matrix
and adds a new page to the API reference section which includes
dynamically-generated tables indicating which languages support
each API, broken into tables for each collection type.
