### PR TITLE
Swapping auth token for API token

### DIFF
--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -43,7 +43,7 @@ Attributes:
 
 ### List caches
 
-Lists all caches for the provided Momento API token.
+Lists all caches.
 
 | Name      | Type   | Description                     |
 | --------- | ------ | ------------------------------- |

--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -43,7 +43,7 @@ Attributes:
 
 ### List caches
 
-Lists all caches for the provided auth token.
+Lists all caches for the provided Momento API token.
 
 | Name      | Type   | Description                     |
 | --------- | ------ | ------------------------------- |

--- a/docs/develop/sdks-integrations/aws-secrets-manager.md
+++ b/docs/develop/sdks-integrations/aws-secrets-manager.md
@@ -3,31 +3,31 @@ sidebar_position: 3
 sidebar_label: AWS Secrets Manager
 pagination_next: null
 title: Momento + AWS Secrets Manager
-description: Learn how to retreive your Momento Auth Token in AWS Secrets Manager.
+description: Learn how to retreive your Momento API Token in AWS Secrets Manager.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Retrieving a Momento auth token from AWS Secrets Manager
+# Retrieving a Momento API token from AWS Secrets Manager
 
-It's best practice to securely store your Momento authentication token. If you are using AWS, you can securely store the auth token in [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html). With that, only code running with the correct IAM credentials will be able to fetch the auth token and use it to access Momento Cache or Momento Topics.
+It's best practice to securely store your Momento authentication token. If you are using AWS, you can securely store the API token in [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html). With that, only code running with the correct IAM credentials will be able to fetch the API token and use it to access Momento Cache or Momento Topics.
 
 :::info
 
-Just as you should reuse your Momento `CacheClient` and `TopicClient` objects when possible, so should you with the Momento auth token from AWS Secrets Manager. Otherwise you risk adding cost, both in time and money, to each Momento API call for the round trip to AWS Secrets Manager.
+Just as you should reuse your Momento `CacheClient` and `TopicClient` objects when possible, so should you with the Momento API token from AWS Secrets Manager. Otherwise you risk adding cost, both in time and money, to each Momento API call for the round trip to AWS Secrets Manager.
 
 :::
 
 ## Entry in AWS Secrets Manager
 
-When inserting the Momento auth token into AWS Secrets Manager, it should be as plaintext with no JSON as in this screenshot. (Token blurred for security.)
+When inserting the Momento API token into AWS Secrets Manager, it should be as plaintext with no JSON as in this screenshot. (Token blurred for security.)
 
 ![AWS Secrets Manager](/img/aws-secrets-manager.png)
 
 ## Example Code for AWS Secrets Manager
 
-In the code examples below, you can see where the getToken function is called just before creating the Momento cache connection client as that is where the auth token is needed and the only time it is needed.
+In the code examples below, you can see where the getToken function is called just before creating the Momento cache connection client as that is where the API token is needed and the only time it is needed.
 
 <Tabs>
   <TabItem value="nodejs" label="Node.js" default>
@@ -43,7 +43,7 @@ const { CacheGet, CacheSet, Configurations, ListCaches, CreateCache,
 // Defines name of cache to use.
 const CACHE_NAME = 'demo-cache2';
   
-// A function that gets the Momento_Auth_Token you stored in AWS Secrets Manager.
+// A function that gets the Momento_API_Token you stored in AWS Secrets Manager.
 // The secret was stored as a plaintext string to avoid parsing JSON.
 async function getToken(secretName) {
   try {
@@ -67,7 +67,7 @@ async function getToken(secretName) {
 // Create a Momento cache client connection object
 async function createCacheClient() {
     // Get the token from AWS Secrets Manager
-    const token = await getToken("Momento_Auth_Token");
+    const token = await getToken("Momento_API_Token");
 
     return new CacheClient({
       configuration: Configurations.Laptop.v1(),
@@ -129,11 +129,11 @@ import {
   GetSecretValueCommandOutput,
 } from '@aws-sdk/client-secrets-manager';
 
-/* A function that gets the Momento_Auth_Token stored in AWS Secrets Manager.
+/* A function that gets the Momento_API_Token stored in AWS Secrets Manager.
 The secret was stored as a plaintext format in Secrets Manager to avoid parsing JSON.
 
-You don't have to store the Momento auth token in something like AWS Secrets Manager,
-but it is best practice. You could pass the Momento auth token in from an environment variable.
+You don't have to store the Momento API token in something like AWS Secrets Manager,
+but it is best practice. You could pass the Momento API token in from an environment variable.
 
 */
 async function GetToken(
@@ -161,7 +161,7 @@ async function GetToken(
 // object from Momento Cache and returns that for later use.
 export default async function CreateCacheClient(
   ttl:number = 600,
-  tokenName:string = "Momento_Auth_Token", 
+  tokenName:string = "Momento_API_Token", 
   ): Promise<CacheClient> {
   const token: string = await GetToken(tokenName);
     return new CacheClient({
@@ -180,5 +180,5 @@ export default async function CreateCacheClient(
 
 <details>
   <summary>Do I have to do this?</summary>
-No. You can store your Momento auth token in an environment variable or a file, but that is not best practice as it is not as secure as storing it in something like AWS Secrets Manager.
+No. You can store your Momento API token in an environment variable or a file, but that is not best practice as it is not as secure as storing it in something like AWS Secrets Manager.
 </details>

--- a/docs/develop/sdks-integrations/momento-cache-laravel-php.md
+++ b/docs/develop/sdks-integrations/momento-cache-laravel-php.md
@@ -26,7 +26,7 @@ If you would like to see a working example of a Laravel app that uses Momento ca
 ## Setting up your own Laravel project
 
 ### Prerequisites
-* A Momento auth token is required. You can generate one using [the Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API token is required. You can generate one using [the Momento CLI](https://github.com/momentohq/momento-cli).
 * Installation of PHP 8.0 or higher
 * Installation of Laravel 9.x or higher
 * Installation of the [gRPC PHP extension](https://github.com/grpc/grpc/blob/v1.46.3/src/php/README.md).

--- a/docs/develop/sdks-integrations/momento-cache-laravel-php.md
+++ b/docs/develop/sdks-integrations/momento-cache-laravel-php.md
@@ -26,7 +26,7 @@ If you would like to see a working example of a Laravel app that uses Momento ca
 ## Setting up your own Laravel project
 
 ### Prerequisites
-* A Momento API token is required. You can generate one using [the Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API token is required. Generate one using [the Momento console](https://console.momentohq.com/).
 * Installation of PHP 8.0 or higher
 * Installation of Laravel 9.x or higher
 * Installation of the [gRPC PHP extension](https://github.com/grpc/grpc/blob/v1.46.3/src/php/README.md).

--- a/docs/develop/sdks-integrations/redis-client-compatibility.md
+++ b/docs/develop/sdks-integrations/redis-client-compatibility.md
@@ -63,7 +63,7 @@ const redisClient = createClient(
   new momento.CacheClient({
     configuration: momento.Configurations.Laptop.v1(),
     credentialProvider: momento.CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+      environmentVariableName: 'MOMENTO_API_TOKEN',
     }),
     defaultTtlSeconds: 60,
   }),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,9 +37,9 @@ Scroll down and you will see your token in a grey box. The token in the screensh
 
 ![image](/img/getting-started/generated-token.jpg)
 
-## Step 3: Store auth token
+## Step 3: Store API token
 
-There are multiple places you can store the auth token used to authenticate with Momento. For this simple example, we'll store the auth token in an environment variable, but best practice is to store the auth token in something like AWS Secrets Manager or GCP Secret Manager.
+There are multiple places you can store the API token used to authenticate with Momento. For this simple example, we'll store the API token in an environment variable, but best practice is to store the API token in something like AWS Secrets Manager or GCP Secret Manager.
 
 ## Step 4: Grab the SDK, create a cache, and read/write data
 
@@ -55,10 +55,10 @@ npm install dotenv
 
 **Create a .env file**
 
-Create a .env file in the directory to hold your Momento auth token and the TTL (in seconds) you want to use by default.
+Create a .env file in the directory to hold your Momento API token and the TTL (in seconds) you want to use by default.
 
 ```cli
-export MOMENTO_AUTH_TOKEN=<your Momento token here>
+export MOMENTO_API_TOKEN=<your Momento token here>
 export MOMENTO_TTL_SECONDS=300
 ```
 
@@ -83,7 +83,7 @@ async function createCacheClient() {
   return new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+      environmentVariableName: 'MOMENTO_API_TOKEN',
     }),
     defaultTtlSeconds: 600,
   });
@@ -186,14 +186,14 @@ Momento Cache is a fully-managed, API-based, serverless service. It does not dep
 
 <br />
 
-First, request your free auth token, create a cache, configure your CLI, and start running `set` and `get` commands on your cache. Launch below.
+First, request your free API token, create a cache, configure your CLI, and start running `set` and `get` commands on your cache. Launch below.
 
 <a href="https://play.instruqt.com/embed/momento/tracks/sandbox-container-1challenge?token=em_54kTDywfWaG95-rC&finish_btn_target=_top&finish_btn_text=Return+to+Docs&finish_btn_url=https%3A%2F%2Fdocs.momentohq.com%2Fgetting-started#try-our-cli-and-an-sdk-in-your-browser" target="_top"><img src="/img/cli_lab.png" alt="CLI lab" /></a>
 
 <br />
 <br />
 
-Then, use the auth token and cache you just created to run a JavaScript application using our Node.js SDK. Launch below.
+Then, use the API token and cache you just created to run a JavaScript application using our Node.js SDK. Launch below.
 
 <a href="https://play.instruqt.com/embed/momento/tracks/momento-nodejs-demo?token=em_f8PM8Aob-mHIfOTT&finish_btn_target=_top&finish_btn_text=Return+to+Docs&finish_btn_url=https%3A%2F%2Fdocs.momentohq.com%2Fgetting-started#try-our-cli-and-an-sdk-in-your-browser" target="_top"><img src="/img/sdk_lab.png" alt="SDK lab" /></a>
 

--- a/docs/introduction/what-is-serverless-caching.md
+++ b/docs/introduction/what-is-serverless-caching.md
@@ -66,7 +66,7 @@ Finally, _serverless developers prefer services that can be provisioned quickly 
 
 Momento is a great addition to serverless applications that use AWS Lambda and other popular serverless services.
 
-First, Momento Cache is [available via HTTPS](./../learn/how-it-works#networking). This simplifies the configuration required to add Momento to your serverless application. You simply add the authentication token to your application and start using your cache. With this HTTPS-based connection pattern, you can still reuse an existing connection within your Lambda function to avoid the overhead of establishing a new connection on each request. Additionally, Memento has a VPC peering option available if you prefer using a VPC for your application.
+First, Momento Cache is [available via HTTPS](./../learn/how-it-works#networking). This simplifies the configuration required to add Momento to your serverless application. You simply add the Momento API token to your application and start using your cache. With this HTTPS-based connection pattern, you can still reuse an existing connection within your Lambda function to avoid the overhead of establishing a new connection on each request. Additionally, Memento has a VPC peering option available if you prefer using a VPC for your application.
 
 Second, Momento Cache can scale your cache quickly and achieve a high number of requests per second without pre-provisioning. There are no connection limits to your Momento cache, so a burst of traffic won't lead to availability issues in your application.
 
@@ -92,7 +92,7 @@ Second, _these developers are looking for a generous free tier as they start usi
 
 If you're an indie hacker or an early-stage startup that's looking to save money, Momento is a great fit for you as well.
 
-First, Momento Cache has a painless self-service sign up. You can get a Momento authentication token and [start writing to your cache in less than five minutes](./../getting-started). You don't need to talk to a salesperson or sign an upfront contract. In fact, you don't even need to enter a credit card to enjoy the free tier.
+First, Momento Cache has a painless self-service sign up. You can get a Momento API token and [start writing to your cache in less than five minutes](./../getting-started). You don't need to talk to a salesperson or sign an upfront contract. In fact, you don't even need to enter a credit card to enjoy the free tier.
 
 Second, Momento Cache has a generous free tier. You get 50 GB free each month (see [pricing](./../manage/pricing) for details). Our goal is to allow a wide variety of applications to run on Momento without ever paying us a cent. We want to provide a top-tier, robust service for applications that need it while also supporting a broad community of applications to use Momento as they grow.
 

--- a/docs/learn/how-it-works/expire-data-with-ttl.md
+++ b/docs/learn/how-it-works/expire-data-with-ttl.md
@@ -28,7 +28,7 @@ There are three locations to set a TTL value:
 
     ```javascript
     const MY_DEFAULT_TTL = 60; // This value is in seconds
-    const momento = new SimpleCacheClient(APIToken, MY_DEFAULT_TTL);
+    const momento = new SimpleCacheClient(apiToken, MY_DEFAULT_TTL);
     ```
 
 

--- a/docs/learn/how-it-works/expire-data-with-ttl.md
+++ b/docs/learn/how-it-works/expire-data-with-ttl.md
@@ -28,7 +28,7 @@ There are three locations to set a TTL value:
 
     ```javascript
     const MY_DEFAULT_TTL = 60; // This value is in seconds
-    const momento = new SimpleCacheClient(authToken, MY_DEFAULT_TTL);
+    const momento = new SimpleCacheClient(APIToken, MY_DEFAULT_TTL);
     ```
 
 

--- a/docs/learn/how-it-works/index.mdx
+++ b/docs/learn/how-it-works/index.mdx
@@ -101,7 +101,7 @@ The data plane includes the standard "set" and "get" cache functionality allowin
 
 The SimpleCache object will be your main way of interacting with the Momento Cache API. Let's talk a little bit about what is happening under the hood. We'll discuss the authentication mechanism, the communication format, and the networking configuration for the Momento API.
 
-### API authentication token
+### API token
 
 Your SimpleCache object will use an API authentication token when communicating with the Momento Cache service. This token is a [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) (or "JWT") that contains signed account information to authenticate you when making cache requests. It also includes information like the hostname of your cache instance, which helps the SimpleCache object to make more efficient requests to the Momento service.
 

--- a/docs/learn/how-it-works/index.mdx
+++ b/docs/learn/how-it-works/index.mdx
@@ -101,11 +101,11 @@ The data plane includes the standard "set" and "get" cache functionality allowin
 
 The SimpleCache object will be your main way of interacting with the Momento Cache API. Let's talk a little bit about what is happening under the hood. We'll discuss the authentication mechanism, the communication format, and the networking configuration for the Momento API.
 
-### Authentication token
+### API authentication token
 
-Your SimpleCache object will use an authentication token when communicating with the Momento Cache service. This token is a [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) (or "JWT") that contains signed account information to authenticate you when making cache requests. It also includes information like the hostname of your cache instance, which helps the SimpleCache object to make more efficient requests to the Momento service.
+Your SimpleCache object will use an API authentication token when communicating with the Momento Cache service. This token is a [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) (or "JWT") that contains signed account information to authenticate you when making cache requests. It also includes information like the hostname of your cache instance, which helps the SimpleCache object to make more efficient requests to the Momento service.
 
-You will receive the Momento authentication token when signing up for the Momento service. To get your Momento authentication token and begin using the Momento service, [follow the quickstart here](/getting-started).
+You will receive the Momento API token when signing up for the Momento service. To get your Momento API token and begin using the Momento service, [follow the quickstart here](/getting-started).
 
 ### gRPC
 


### PR DESCRIPTION
We are no longer calling them Auth Tokens, so I am swapping out for the new name API Tokens.

The only place I did not change this yet is in the code on the API Reference page as I need more time on that one not to mess up the code examples.