### PR TITLE
Python cheat sheet refactor to reuse CacheClient object

### DIFF
--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -30,7 +30,7 @@ The response object for DictionaryFetch returns three possible options, a cache 
     - `valueDictionaryStringString()`: Map<String, String>
     - `valueDictionaryStringBytes()`: Map<String, Bytes>
     - `valueDictionaryBytesString()`: Map<Bytes, String>
-    - `toString()`: string - displays the field/value pairs, truncated.
+    - `toString()`: String - displays the field/value pairs, truncated.
 * Cache miss
 * Cache error
 
@@ -45,26 +45,26 @@ Get one field from a dictionary item in the cache.
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be retrieved. |
-| field           | String/bytes | Name of the field in the dictionary item to be retrieved. |
+| field           | String/Bytes | Name of the field in the dictionary item to be retrieved. |
 
 <details>
   <summary>Method response object</summary>
 
 * Cache hit
-    - `fieldString()`: string
-    - `fieldBytes()`: bytes
-    - `valueString()`: string
-    - `valueBytes()`: bytes
+    - `fieldString()`: String
+    - `fieldBytes()`: Bytes
+    - `valueString()`: String
+    - `valueBytes()`: Bytes
 
         These return the field and its value from the dictionary.
 
 * Cache miss
-    - `fieldString()`: string
-    - `fieldBytes()`: bytes
+    - `fieldString()`: String
+    - `fieldBytes()`: Bytes
 
 * Cache error
-    - `fieldString()`: string
-    - `fieldBytes()`: bytes
+    - `fieldString()`: String
+    - `fieldBytes()`: Bytes
 
 See [response objects](./response-objects.md) for specific information.
 
@@ -77,7 +77,7 @@ Get one or more fields from a dictionary in the cache.
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be retrieved.  |
-| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retrieved. |
+| fields          | String[]/Bytes[] | Name of the field in the dictionary item to be retrieved. |
 
 <details>
   <summary>Method response object</summary>
@@ -87,7 +87,7 @@ Get one or more fields from a dictionary in the cache.
     - valueDictionaryStringString(): Map<String, String>
     - valueDictionaryStringBytes(): Map<String, Bytes>
     - valueDictionaryBytesString(): Map<Bytes, String>
-    - toString(): string - displays truncated valueDictionaryStringString()
+    - toString(): String - displays truncated valueDictionaryStringString()
 * Cache miss
 * Error
 
@@ -114,7 +114,7 @@ Examples:
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be retrieved.  |
-| field           | String|bytes | Name of the field in the dictionary item to be retrieved. |
+| field           | String/Bytes | Name of the field in the dictionary item to be retrieved. |
 | amount          | Integer      | The quantity to add to the value. May be positive, negative, or zero. Defaults to 1. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | This will come back as a TTL construct. |
 
@@ -123,7 +123,7 @@ Examples:
 
 * Success
     - `value()`: integer - the new value after incrementing
-    - `toString()`: string - displays the value()
+    - `toString()`: String - displays the value()
 * Error
 
 See [response objects](./response-objects.md) for specific information.
@@ -138,7 +138,7 @@ Removes a field from a dictionary item.
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be retrieved. |
-| field           | String|bytes | Name of the field in the dictionary item to be retrieved. |
+| field           | String/Bytes | Name of the field in the dictionary item to be retrieved. |
 
 <details>
   <summary>Method response object</summary>
@@ -157,7 +157,7 @@ Removes multiple fields from a dictionary item.
 | --------------- | ------------     | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
 | dictionaryName  | String           | Name of the dictionary item to be retrieved. |
-| fields          | String[]/bytes[] | Name of the field in the dictionary item to be retrieved. |
+| fields          | String[]/Bytes[] | Name of the field in the dictionary item to be retrieved. |
 
 <details>
   <summary>Method response object</summary>
@@ -176,8 +176,8 @@ Sets a field:value pair in an existing dictionary item. If the dictionary item d
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be set. |
-| field           | String/bytes | Name of the field in the dictionary item to be set. |
-| value           | String/bytes | Value for the field to be set. |
+| field           | String/Bytes | Name of the field in the dictionary item to be set. |
+| value           | String/Bytes | Value for the field to be set. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>
@@ -197,7 +197,7 @@ Sets several field:value pairs in a dictionary item. If the dictionary item does
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | dictionaryName  | String       | Name of the dictionary item to be set. |
-| fields          | String[]/bytes[] | Field:value pair to be added to the dictionary item by the set operation. |
+| fields          | String[]/Bytes[] | Field:value pair to be added to the dictionary item by the set operation. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the dictionary item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 
 <details>

--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -144,7 +144,7 @@ Checks if a provided key exists in the cache.
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| key        | String \| byte          | Key which is to be checked for its existence in the cache.              |
+| key        | String \| Byte          | Key which is to be checked for its existence in the cache.              |
 
 <details>
     <summary>Method response object</summary>
@@ -164,7 +164,7 @@ Checks if provided keys exist in the cache.
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| keys        | String[] \| byte[]          | Keys which are to be checked for their existence in the cache.              |
+| keys        | String[] \| Byte[]          | Keys which are to be checked for their existence in the cache.              |
 
 <details>
     <summary>Method response object</summary>
@@ -184,8 +184,8 @@ Associates the provided value to a cache item with a given key.
 | Name       | Type   | Description                                   |
 | ---------- | ------ | --------------------------------------------- |
 | cacheName  | String | Name of the cache.                            |
-| key        | String /| bytes | The key to be set. |
-| value      | String /| bytes | The value to be stored.                       |
+| key        | String /| Bytes | The key to be set. |
+| value      | String /| Bytes | The value to be stored.                       |
 | ttlSeconds | Duration    | Time to Live for the item in Cache.           |
 
 <details>
@@ -210,7 +210,7 @@ Overwrites the TTL of a cache item with the provided value in seconds.
 | Name      | Type   | Description                                     |
 | --------- | ------ | ----------------------------------------------- |
 | cacheName | String | Name of the cache.                              |
-| key       | String \| bytes | The key under which the value's TTL is to be updated. |
+| key       | String \| Bytes | The key under which the value's TTL is to be updated. |
 | ttl       | Duration | Time to live that you want to update in cache in seconds. |
 
 ### IncreaseTtl
@@ -224,7 +224,7 @@ Examples
 | Name      | Type   | Description                                     |
 | --------- | ------ | ----------------------------------------------- |
 | cacheName | String | Name of the cache.                              |
-| key       | String \| bytes | The key under which the value's TTL is to be increased. |
+| key       | String \| Bytes | The key under which the value's TTL is to be increased. |
 | ttl       | Duration | Time to live that you want to increase to. |
 
 ### DecreaseTtl
@@ -238,7 +238,7 @@ Examples
 | Name      | Type   | Description                                     |
 | --------- | ------ | ----------------------------------------------- |
 | cacheName | String | Name of the cache.                              |
-| key       | String \| bytes | The key under which the value's TTL is to be decreased. |
+| key       | String \| Bytes | The key under which the value's TTL is to be decreased. |
 | ttl       | Duration | Time to live that you want to decrease to. |
 
 ### Collection data types (CDTs)

--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -150,7 +150,7 @@ Checks if a provided key exists in the cache.
     <summary>Method response object</summary>
 
     * Success
-    - `exists()`: bool
+    - `exists()`: Bool
     * Error
 
     See [response objects](./response-objects.md) for specific information.
@@ -170,7 +170,7 @@ Checks if provided keys exist in the cache.
     <summary>Method response object</summary>
 
     * Success
-    - `exists()`: bool[]
+    - `exists()`: Bool[]
     * Error
 
     See [response objects](./response-objects.md) for specific information.
@@ -184,8 +184,8 @@ Associates the provided value to a cache item with a given key.
 | Name       | Type   | Description                                   |
 | ---------- | ------ | --------------------------------------------- |
 | cacheName  | String | Name of the cache.                            |
-| key        | String /| Bytes | The key to be set. |
-| value      | String /| Bytes | The value to be stored.                       |
+| key        | String \| Bytes | The key to be set. |
+| value      | String \| Bytes | The value to be stored.                       |
 | ttlSeconds | Duration    | Time to Live for the item in Cache.           |
 
 <details>

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -28,9 +28,9 @@ Gets a list item from a cache, with optional slices.
 The response object for ListFetch returns three possible options, a cache hit, miss, or an error.
 
 * Hit
-    * valueListBytes(): bytes[]
-    * valueListString(): string[]
-    * toString(): string - Display a truncated valueListString(). See [truncation](#truncate-to-size).
+    * valueListBytes(): Bytes[]
+    * valueListString(): String[]
+    * toString(): String - Display a truncated valueListString(). See [truncation](#truncate-to-size).
 * Miss
 * Error
 
@@ -49,7 +49,7 @@ If you have [1, 2, 3] and listConcatenateBack [4, 5, 6] you will have [1, 2, 3, 
 | --------------- | ------------------- | --------------------------------------------- |
 | cacheName       | String              | Name of the cache.                            |
 | listName        | String              | Name of the list item to be set. |
-| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
+| values          | String[] \| Bytes[] | Values to be added as elements to the list item. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client connection object. |
 | truncateFrontToSize | Number | See [truncate to size](#truncate-to-size). |
 
@@ -57,8 +57,8 @@ If you have [1, 2, 3] and listConcatenateBack [4, 5, 6] you will have [1, 2, 3, 
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list
-    * `toString()`: string - add the listLength
+    * `listLength()`: Number - the new length of the list
+    * `toString()`: String - add the listLength
 * Error
 
 See [response objects](./response-objects.md) for specific information.
@@ -76,7 +76,7 @@ If you have [1, 2, 3] and listConcatenateFront [4, 5, 6] you will have [4, 5, 6,
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | listName        | String       | Name of the list item to be set.              |
-| values          | String[] \| bytes[] | Values to be added as elements to the list item. |
+| values          | String[] \| Bytes[] | Values to be added as elements to the list item. |
 | ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
@@ -84,8 +84,8 @@ If you have [1, 2, 3] and listConcatenateFront [4, 5, 6] you will have [4, 5, 6,
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list item
-    * `toString()`: string - add the listLength
+    * `listLength()`: Number - the new length of the list item
+    * `toString()`: String - add the listLength
 * Error
 
 See [response objects](./response-objects.md) for specific information.
@@ -104,7 +104,7 @@ Get the length of an existing list item
   <summary>Method response object</summary>
 
 * Hit
-    * `length()`: number
+    * `length()`: Number
     * `toString()`: include the length
 * Miss
 * Error
@@ -125,8 +125,8 @@ Remove and return the last element from a list item.
   <summary>Method response object</summary>
 
 * Hit
-    * `valueString()`: string
-    * `valueBytes()`: bytes
+    * `valueString()`: String
+    * `valueBytes()`: Bytes
     * `toString()`: truncated valueString()
 * Miss
 * Error
@@ -147,8 +147,8 @@ Remove and return the first element from a list item.
   <summary>Method response object</summary>
 
 * Hit
-    * `valueString()`: string
-    * `valueBytes()`: bytes
+    * `valueString()`: String
+    * `valueBytes()`: Bytes
     * `toString()`: truncated valueString()
 * Miss
 * Error
@@ -164,7 +164,7 @@ Push a value to the end of a list item. This is exactly like passing just one va
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | listName        | String          | Name of the list to be set.                   |
-| value           | String \| bytes | Value to be added.              |
+| value           | String \| Bytes | Value to be added.              |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
@@ -172,8 +172,8 @@ Push a value to the end of a list item. This is exactly like passing just one va
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list item
-    * `toString()`: string - add the listLength
+    * `listLength()`: Number - the new length of the list item
+    * `toString()`: String - add the listLength
 * Error
 
 See [response objects](./response-objects.md) for specific information.
@@ -187,7 +187,7 @@ Push a value to the beginning of a list item. Just like [ListPushBack](#listpush
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | listName        | String          | Name of the list to be set. |
-| value           | String \| bytes | Value to be added to the list item by the operation. |
+| value           | String \| Bytes | Value to be added to the list item by the operation. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the list item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 | truncateBackToSize | Number | See [truncate to size](#truncate-to-size). |
 
@@ -195,8 +195,8 @@ Push a value to the beginning of a list item. Just like [ListPushBack](#listpush
   <summary>Method response object</summary>
 
 * Success
-    * `listLength()`: number - the new length of the list
-    * `toString()`: string - add the listLength
+    * `listLength()`: Number - the new length of the list
+    * `toString()`: String - add the listLength
 * Error
 
 See [response objects](./response-objects.md) for specific information.
@@ -214,7 +214,7 @@ Examples
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | listName        | String          | Name of the list item to be set.              |
-| value           | String \| bytes | Value to be added to the list item by the operation. |
+| value           | String \| Bytes | Value to be added to the list item by the operation. |
 
 <details>
   <summary>Method response object</summary>

--- a/docs/develop/api-reference/response-objects.md
+++ b/docs/develop/api-reference/response-objects.md
@@ -23,10 +23,10 @@ Returned in lieu of an exception.
 
 #### Methods
 
-- message(): string - a human readable error message
+- message(): String - a human readable error message
 - innerException(): Exception - the original exception.
 - errorCode(): MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
-- toString(): string - alias for message()
+- toString(): String - alias for message()
 
 ### Success
 

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -23,7 +23,7 @@ Adds an element to a set. If the set item does not already exist, this method wi
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | setName         | String          | Name of the set item to be altered. |
-| element         | String \| bytes | Element to be added by this operation. |
+| element         | String \| Bytes | Element to be added by this operation. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
@@ -43,7 +43,7 @@ Adds multiple elements to a set item.
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | setName         | String       | Name of the set item to be altered. |
-| elements        | String[] \| bytes[] | Elements to be added by this operation. |
+| elements        | String[] \| Bytes[] | Elements to be added by this operation. |
 | ttl          | [CollectionTTL object](./collection-ttl.md) | TTL for the set item in cache. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
@@ -71,9 +71,9 @@ Gets a set item from a cache.
 The response object for SetFetch returns three possible options, a cache hit, miss, or an error.
 
 * Hit
-    * valueSetBytes(): bytes[]
-    * valueSetString(): string[]
-    * toString(): string
+    * valueSetBytes(): Bytes[]
+    * valueSetString(): String[]
+    * toString(): String
 * Miss
 * Error
 
@@ -88,7 +88,7 @@ Removes a single element from an existing set item.
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | setName         | String          | Name of the set item to be altered.           |
-| element         | String \| bytes | Element to be removed by this operation.   |
+| element         | String \| Bytes | Element to be removed by this operation.   |
 
 <details>
   <summary>Method response object</summary>
@@ -107,7 +107,7 @@ Removes multiple elements from an existing set item.
 | --------------- | ------------ | --------------------------------------------- |
 | cacheName       | String       | Name of the cache.                            |
 | setName         | String       | Name of the set item to be altered. |
-| element         | String \| bytes | Element to be removed by this operation.   |
+| element         | String \| Bytes | Element to be removed by this operation.   |
 
 <details>
   <summary>Method response object</summary>
@@ -126,7 +126,7 @@ Checks if a provided element is in the given set.
 |-----------| --------------- |-----------------------|
 | cacheName | String          | Name of the cache.    |
 | setName   | String          | Name of the set item. |
-| element   | String \| bytes                 | Name of the element to check existence of.   |
+| element   | String \| Bytes                 | Name of the element to check existence of.   |
 
 <details>
   <summary>Method response object</summary>
@@ -149,7 +149,7 @@ Checks if provided elements are in the given set.
 |-----------|------------|-------------------------------------|
 | cacheName | String     | Name of the cache.                  |
 | setName   | String     | Name of the set item. |
-| elements  | String[] \ | bytes                             | Array of element names to check existence of.   |
+| elements  | String[] \ | Bytes                             | Array of element names to check existence of.   |
 
 <details>
   <summary>Method response object</summary>

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -8,7 +8,7 @@ slug: /develop/api-reference/collections/sortedsets
 
 # Sorted set collections
 
-A sorted set in Momento Cache is a collection of unique elements with a value (string, byte[], etc.) and score (signed double 64-bit float) pair. The elements in the item are ordered by the score.
+A sorted set in Momento Cache is a collection of unique elements with a value (String, Byte[], etc.) and score (signed double 64-bit float) pair. The elements in the item are ordered by the score.
 
 ## Sorted set methods
 
@@ -24,7 +24,7 @@ Adds a new or updates an existing [sorted set element](#sortedsetelement) in a s
 | --------------- | ------------------ | --------------------------------------------- |
 | cacheName       | String             | Name of the cache.                            |
 | setName         | String             | Name of the sorted set item to be altered. |
-| value        | String \| byte[] | The value of the element to be added to the sorted set by this operation. |
+| value        | String \| Byte[] | The value of the element to be added to the sorted set by this operation. |
 | score        | number | The score of the element to be added to the sorted set by this operation. |
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
@@ -121,7 +121,7 @@ Gets an element's score from the sorted set, indexed by value.
 | ---------------- | ------------------- | --------------------------------------------- |
 | cacheName        | String              | Name of the cache.                            |
 | setName          | String              | Name of the sorted set item. |
-| value           | String \| bytes | The value to get the score of. |
+| value           | String \| Bytes | The value to get the score of. |
 
 <details>
   <summary>Method response object</summary>
@@ -143,7 +143,7 @@ Gets the scores associated with a list of elements from the sorted set, indexed 
 | ---------------- | ------------------- | --------------------------------------------- |
 | cacheName        | String              | Name of the cache.                            |
 | setName          | String              | Name of the sorted set item. |
-| values           | String[] \| bytes[] | An array of values to get the score of. |
+| values           | String[] \| Bytes[] | An array of values to get the score of. |
 
 <details>
   <summary>Method response object</summary>
@@ -168,7 +168,7 @@ Removes an element from a sorted set, indexed by value.
 | --------------- | ---------------- | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
 | setName         | String           | Name of the set item to be altered. |
-| value          | String \| bytes | Value of the element to be removed by this operation. |
+| value          | String \| Bytes | Value of the element to be removed by this operation. |
 
 <details>
   <summary>Method response object</summary>
@@ -188,7 +188,7 @@ Removes elements from a sorted set, indexed by values.
 | --------------- | ---------------- | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
 | setName         | String           | Name of the set item to be altered. |
-| values          | String[] \| bytes[] | Values of the elements to be removed by this operation. |
+| values          | String[] \| Bytes[] | Values of the elements to be removed by this operation. |
 
 You can remove either one or a specific group of elements.
 
@@ -210,7 +210,7 @@ What position is the element, in the specified sorted set?
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | setName         | String          | Name of the sorted set item to be altered.    |
-| value           | String \| bytes | Value of the element to retrieve the score of. |
+| value           | String \| Bytes | Value of the element to retrieve the score of. |
 
 <details>
   <summary>Method response object</summary>
@@ -243,7 +243,7 @@ Examples:
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
 | setName         | String          | Name of the sorted set item to be altered. |
-| value           | String \| bytes | Value for the element to be incremented by this operation. |
+| value           | String \| Bytes | Value for the element to be incremented by this operation. |
 | amount          | Number          | The quantity to add to the score. May be positive, negative, or zero. Defaults to 1. |          
 | ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
@@ -267,7 +267,7 @@ Example:
 
 | Name            | Type                         | Description                                   |
 | --------------- | ---------------------------- | --------------------------------------------- |
-| Value           | String \| bytes              | Value for the sorted set element.                            |
+| Value           | String \| Bytes              | Value for the sorted set element.                            |
 | Score           | Signed double 64-bit float   | Score the element. |
 
 A SortedSetElement can exist by itself or as part of an array of SortedSetElements

--- a/static/code/cheat-sheets/MomentoBasics.py
+++ b/static/code/cheat-sheets/MomentoBasics.py
@@ -4,66 +4,90 @@ from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches, Cache
 
 import os
 
-class MomentoBasics:
-  def client():
-    momento_auth_token = CredentialProvider.from_environment_variable('MOMENTO_AUTH_TOKEN')
-    ttl  = timedelta(seconds=int(os.getenv('MOMENTO_TTL_SECONDS', '60')))
-    config = {
-      'configuration': Configurations.Laptop.v1(),
-      'credential_provider': momento_auth_token,
-      'default_ttl':  ttl
-    }
-    return CacheClient(**config)
+cache_name = "default_cache"
 
-  def create_cache(client, cache_name) -> None:
-    resp = client.create_cache(cache_name)
-    match resp:
-      case CreateCache.Success():
-          print("Cache created.")
-      case CreateCache.Error() as error:
-          print(f"Error creating cache: {error.message}")
-      case _ as error:
-          print(f"Unreachable with {error.message}")
+# A function that creates the CacheClient connection and returns it.
+# It gets values from environment variables, but you could get them from
+# a programatic encrypted data manager like AWS Secrets Manager.
+def create_client():
+  momento_auth_token = CredentialProvider.from_environment_variable('MOMENTO_AUTH_TOKEN')
+  ttl  = timedelta(seconds=int(os.getenv('MOMENTO_TTL_SECONDS', '600')))
+  config = {
+    'configuration': Configurations.Laptop.v1(),
+    'credential_provider': momento_auth_token,
+    'default_ttl':  ttl
+  }
+  return CacheClient(**config)
 
-  def list_caches(client) -> None:
-      print("Listing caches:")
-      list_caches_response = client.list_caches()
-      match list_caches_response:
-          case ListCaches.Success() as success:
-              for cache_info in success.caches:
-                  print(f"- {cache_info.name!r}")
-          case ListCaches.Error() as error:
-              print(f"Error listing caches: {error.message}")
-          case _:
-              print("Unreachable")
-      print("")
+# A function to create a new cache.
+def create_cache(client, cache_name: str) -> None:
+  resp = client.create_cache(cache_name)
+  match resp:
+    case CreateCache.Success():
+        print("Cache created.")
+    case CreateCache.Error() as error:
+        print(f"Error creating cache: {error.message}")
+    case _ as error:
+        print(f"Unreachable with {error.message}")
 
-  def set(client, cache_name, key, value, ttl=None):
-    resp = client.set(cache_name, key, value, ttl)
-    match resp:
-      case CacheSet.Success():
-          pass
-      case CacheSet.Error() as error:
-          print(f"Error setting value: {error.message}")
-      case _:
-          print("Unreachable")
+# A function that lists the caches for this account.
+def list_caches(client) -> None:
+    print("Listing caches:")
+    list_caches_response = client.list_caches()
+    match list_caches_response:
+        case ListCaches.Success() as success:
+            for cache_info in success.caches:
+                print(f"- {cache_info.name!r}")
+        case ListCaches.Error() as error:
+            print(f"Error listing caches: {error.message}")
+        case _:
+            print("Unreachable")
+    print("")
 
-  def get(client, cache_name, key):
-    resp = client.get(cache_name, key)
-    match resp:
-      case CacheGet.Hit():
-          print("value is " + resp.value_string)
-      case CacheGet.Miss() as error:
-          print(f"Error getting key: {error.message}")
-      case _:
-          print("Unreachable")
-      
-  def incr(client, cache_name, key, value:int = 1):
-    resp = client.increment(cache_name, key, value)
-    match resp:
-      case CacheIncrement.Success():
-          pass
-      case CacheIncrement.Error() as error:
-          print(f"Error incrementing value: {error.message}")
-      case _:
-          print("Unreachable")
+# A function to write an item to the cache.
+def set(client, cache_name, key, value, ttl=None):
+  resp = client.set(cache_name, key, value, ttl)
+  match resp:
+    case CacheSet.Success():
+        pass
+    case CacheSet.Error() as error:
+        print(f"Error setting value: {error.message}")
+    case _:
+        print("Unreachable")
+
+# A function to get an item from the cache.
+def get(client, cache_name, key):
+  resp = client.get(cache_name, key)
+  match resp:
+    case CacheGet.Hit():
+        print("value is " + resp.value_string)
+    case CacheGet.Miss() as error:
+        print(f"Error getting key: {error.message}")
+    case _:
+        print("Unreachable")
+
+# A function to increment the value of a key.    
+def incr(client, cache_name, key, value:int = 1):
+  resp = client.increment(cache_name, key, value)
+  match resp:
+    case CacheIncrement.Success():
+        pass
+    case CacheIncrement.Error() as error:
+        print(f"Error incrementing value: {error.message}")
+    case _:
+        print("Unreachable")
+
+# Call all of the functions to interact with Momento Cache
+with create_client() as client:
+   
+   create_cache(client, cache_name)
+
+   list_caches(client)
+
+   set(client, cache_name, "test", "12345")
+
+   get(client, cache_name, "test")
+
+   incr(client, cache_name, "test2")
+
+   get(client, cache_name, "test2")

--- a/static/code/cheat-sheets/MomentoBasics.py
+++ b/static/code/cheat-sheets/MomentoBasics.py
@@ -15,60 +15,55 @@ class MomentoBasics:
     }
     return CacheClient(**config)
 
-  def create_cache(cache_name) -> None:
-    with MomentoBasics.client() as client:
-      resp = client.create_cache(cache_name)
-      match resp:
-        case CreateCache.Success():
-            print("Cache created.")
-        case CreateCache.Error() as error:
-            print(f"Error creating cache: {error.message}")
-        case _ as error:
-            print(f"Unreachable with {error.message}")
+  def create_cache(client, cache_name) -> None:
+    resp = client.create_cache(cache_name)
+    match resp:
+      case CreateCache.Success():
+          print("Cache created.")
+      case CreateCache.Error() as error:
+          print(f"Error creating cache: {error.message}")
+      case _ as error:
+          print(f"Unreachable with {error.message}")
 
-  def list_caches() -> None:
+  def list_caches(client) -> None:
       print("Listing caches:")
-      with MomentoBasics.client() as client:
-        list_caches_response = client.list_caches()
-        match list_caches_response:
-            case ListCaches.Success() as success:
-                for cache_info in success.caches:
-                    print(f"- {cache_info.name!r}")
-            case ListCaches.Error() as error:
-                print(f"Error listing caches: {error.message}")
-            case _:
-                print("Unreachable")
-        print("")
+      list_caches_response = client.list_caches()
+      match list_caches_response:
+          case ListCaches.Success() as success:
+              for cache_info in success.caches:
+                  print(f"- {cache_info.name!r}")
+          case ListCaches.Error() as error:
+              print(f"Error listing caches: {error.message}")
+          case _:
+              print("Unreachable")
+      print("")
 
-  def set(cache_name, key, value, ttl=None):
-    with MomentoBasics.client() as client:
-      resp = client.set(cache_name, key, value, ttl)
-      match resp:
-        case CacheSet.Success():
-            pass
-        case CacheSet.Error() as error:
-            print(f"Error setting value: {error.message}")
-        case _:
-            print("Unreachable")
+  def set(client, cache_name, key, value, ttl=None):
+    resp = client.set(cache_name, key, value, ttl)
+    match resp:
+      case CacheSet.Success():
+          pass
+      case CacheSet.Error() as error:
+          print(f"Error setting value: {error.message}")
+      case _:
+          print("Unreachable")
 
-  def get(cache_name, key):
-    with MomentoCounter.client() as client:
-      resp = client.get(cache_name, key)
-      match resp:
-        case CacheGet.Hit():
-            print("value is " + resp.value_string)
-        case CacheGet.Miss() as error:
-            print(f"Error getting key: {error.message}")
-        case _:
-            print("Unreachable")
+  def get(client, cache_name, key):
+    resp = client.get(cache_name, key)
+    match resp:
+      case CacheGet.Hit():
+          print("value is " + resp.value_string)
+      case CacheGet.Miss() as error:
+          print(f"Error getting key: {error.message}")
+      case _:
+          print("Unreachable")
       
-  def incr(cache_name, key, value:int = 1):
-    with MomentoBasics.client() as client:
-      resp = client.increment(cache_name, key, value)
-      match resp:
-        case CacheIncrement.Success():
-            pass
-        case CacheIncrement.Error() as error:
-            print(f"Error incrementing value: {error.message}")
-        case _:
-            print("Unreachable")
+  def incr(client, cache_name, key, value:int = 1):
+    resp = client.increment(cache_name, key, value)
+    match resp:
+      case CacheIncrement.Success():
+          pass
+      case CacheIncrement.Error() as error:
+          print(f"Error incrementing value: {error.message}")
+      case _:
+          print("Unreachable")


### PR DESCRIPTION
I also changed some of the text on the page as well.