### PR TITLE
fix: malformed line of SetContainsElements

### DIFF
--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -149,7 +149,7 @@ Checks if provided elements are in the given set.
 |-----------|------------|-------------------------------------|
 | cacheName | String     | Name of the cache.                  |
 | setName   | String     | Name of the set item. |
-| elements  | String[] \ | Bytes                             | Array of element names to check existence of.   |
+| elements  | String[] \| Bytes[]                             | Array of element names to check existence of.   |
 
 <details>
   <summary>Method response object</summary>


### PR DESCRIPTION
`SetContainsElements` should take an array of strings or an array of
byte arrays. The previous version incorrectly had a space between the
type separator, which rendered malformed; and lacked the array modifier for `Bytes`.
