### PR TITLE
feat: add some missing APIs to the API reference and feature matrix

### DIFF
--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -209,3 +209,24 @@ Sets several field:value pairs in a dictionary item. If the dictionary item does
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+### DictionaryLength
+Get the length of an existing dictionary item
+
+| Name           | Type         | Description                                |
+|----------------| ------------ |--------------------------------------------|
+| cacheName      | String       | Name of the cache.                         |
+| dictionaryName | String       | Name of the dictionary item to be checked. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Hit
+  * `length()`: Number
+* Miss
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+

--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -137,6 +137,29 @@ Sends a ping to the server. This API can be used for checking connectivity to co
 
 </details>
 
+### ItemGetType
+
+For a given key, returns the type (SCALAR, DICTIONARY, LIST, etc.) of the corresponding item, if it exists.
+
+| Name            | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| cacheName       | String          | Name of the cache.                            |
+| key        | String \| Byte          | Key whose item type should be returned.              |
+
+<details>
+  <summary>Method response object</summary>
+
+  * Cache hit
+  - `type()`: enum: SCALAR, DICTIONARY, SET, LIST, SORTED_SET
+
+  * Cache miss
+  * Cache error
+
+  See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+
 ### KeyExists
 
 Checks if a provided key exists in the cache.
@@ -241,7 +264,81 @@ Examples
 | key       | String \| Bytes | The key under which the value's TTL is to be decreased. |
 | ttl       | Duration | Time to live that you want to decrease to. |
 
-### Collection data types (CDTs)
+### ItemGetTtl
+
+For a given key, returns the duration of time remaining (Time To Live) before the item expires from the cache.
+
+| Name            | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| cacheName       | String          | Name of the cache.                            |
+| key        | String \| Byte          | Key whose item type should be returned.              |
+
+<details>
+  <summary>Method response object</summary>
+
+  * Cache hit
+  - `remainingTtl()`: Duration
+
+  * Cache miss
+  * Cache error
+
+  See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+## Auth APIs
+
+These APIs are used to manage Momento auth tokens and access.
+
+### GenerateAuthToken
+
+Generates a new Momento Auth token with the specified permissions and expiry.
+
+| Name            | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| scope           | TokenScope      | The permissions to grant to the new token.  Pre-built TokenScope objects are provided by the SDKs. |
+| expiresIn       | ExpiresIn       | The number of seconds until the token expires, or `never`.              |
+
+<details>
+  <summary>Method response object</summary>
+
+  * Success
+  - `authToken`: string - the new auth token
+  - `refreshToken`: string - a refresh token that can be used with the `RefreshAuthToken` API to refresh the token before it expires
+  - `expiresAt`: Timestamp - the timestamp at which the token will expire
+  * Error
+
+  See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+### RefreshAuthToken
+
+Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
+
+| Name            | Type            | Description                                   |
+| --------------- | --------------- | --------------------------------------------- |
+| refreshToken    | String          | The refreshToken for the current auth token, acquired from the original call to `GenerateAuthToken`. |
+
+<details>
+  <summary>Method response object</summary>
+
+  * Success
+  - `authToken`: string - the new auth token
+  - `refreshToken`: string - a refresh token that can be used with the `RefreshAuthToken` API to refresh the token before it expires
+  - `expiresAt`: Timestamp - the timestamp at which the token will expire
+  * Error
+
+  See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+
+
+
+
+
+### Collection data types
 
 Collections may contain different types of structures depending on your use case. Supported data types are:
 

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -105,7 +105,6 @@ Get the length of an existing list item
 
 * Hit
     * `length()`: Number
-    * `toString()`: include the length
 * Miss
 * Error
 

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -164,3 +164,23 @@ The response object for SetContainsElements returns three possible options, a ca
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+### SetLength
+Get the length of an existing set item
+
+| Name      | Type         | Description                         |
+|-----------| ------------ |-------------------------------------|
+| cacheName | String       | Name of the cache.                  |
+| setName   | String       | Name of the set item to be checked. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Hit
+  * `length()`: Number
+* Miss
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -273,7 +273,7 @@ Example:
 A SortedSetElement can exist by itself or as part of an array of SortedSetElements
 
 ### SortedSetLength
-Get the length of an existing sorted set item
+Get the number of entries in a sorted set item.
 
 | Name           | Type         | Description                                |
 |----------------| ------------ |--------------------------------------------|

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -293,7 +293,7 @@ See [response objects](./response-objects.md) for specific information.
 </details>
 
 ### SortedSetLengthByScore
-For an existing sorted set item, finds all of the values between the specified min and max score and 
+For an existing sorted set item, it finds all of the values between the specified min and max score and returns the length.
 
 | Name           | Type         | Description                                |
 |----------------| ------------ |--------------------------------------------|

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -271,3 +271,45 @@ Example:
 | Score           | Signed double 64-bit float   | Score the element. |
 
 A SortedSetElement can exist by itself or as part of an array of SortedSetElements
+
+### SortedSetLength
+Get the length of an existing sorted set item
+
+| Name           | Type         | Description                                |
+|----------------| ------------ |--------------------------------------------|
+| cacheName      | String       | Name of the cache.                         |
+| sortedSetName | String       | Name of the sorted set item to be checked. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Hit
+    * `length()`: Number
+* Miss
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>
+
+### SortedSetLengthByScore
+For an existing sorted set item, finds all of the values between the specified min and max score and 
+
+| Name           | Type         | Description                                |
+|----------------| ------------ |--------------------------------------------|
+| cacheName      | String       | Name of the cache.                         |
+| sortedSetName | String       | Name of the sorted set item to be checked. |
+| minScore | Optional[double]   | The inclusive low score of the results. Default is `-inf`, ie include through the lowest score. |
+| maxScore | Optional[double]   | The inclusive high score of the results. Default is `+inf`, ie include through the highest score. |
+
+<details>
+  <summary>Method response object</summary>
+
+* Hit
+    * `length()`: Number
+* Miss
+* Error
+
+See [response objects](./response-objects.md) for specific information.
+
+</details>

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -270,7 +270,7 @@ Example:
 | Value           | String \| Bytes              | Value for the sorted set element.                            |
 | Score           | Signed double 64-bit float   | Score the element. |
 
-A SortedSetElement can exist by itself or as part of an array of SortedSetElements
+A SortedSetElement can exist by itself or as part of an array of SortedSetElements.
 
 ### SortedSetLength
 Get the number of entries in a sorted set item.

--- a/docs/develop/sdks-integrations/deploying-javascript-web-sdk.md
+++ b/docs/develop/sdks-integrations/deploying-javascript-web-sdk.md
@@ -22,7 +22,7 @@ This server-side complexity is eliminated by incorporating Momento Topics with t
 
 ## Using the web SDK for browsers
 
-While the API calls are [identical to the Momento node.js SDK](/develop/guides/cheat-sheets/momento-cache-nodejs-cheat-sheet.md), the import/require statement will consume the `@gomomento/sdk-web` package from npm, instead of `@gomomento/sdk` (which is the Node.js SDK).
+While the API calls are [identical to the Momento node.js SDK](/develop/guides/cheat-sheets/momento-cache-nodejs-cheat-sheet.mdx), the import/require statement will consume the `@gomomento/sdk-web` package from npm, instead of `@gomomento/sdk` (which is the Node.js SDK).
 
 Here's an example import statement for the web SDK:
 
@@ -36,7 +36,7 @@ Here are some other useful links for getting started with the Momento web SDK:
 
 ![chat screenshot](/img/web-sdk-chat-app.png)
 
-* [Momento Node.js Cheat Sheet](/develop/guides/cheat-sheets/momento-cache-nodejs-cheat-sheet.md)
+* [Momento Node.js Cheat Sheet](/develop/guides/cheat-sheets/momento-cache-nodejs-cheat-sheet.mdx)
 * [Example web SDK scripts on github](https://github.com/momentohq/client-sdk-javascript/examples/web)
 
 ## Credentials for Browsers

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -105,11 +105,12 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
       'flushCache',
       'keysExist',
       'keyExists',
+      'itemGetType',
       'delete',
       'updateTtl',
       'increaseTtl',
       'decreaseTtl',
-      'itemGetType',
+      'itemGetTtl',
     ],
   },
   {
@@ -135,6 +136,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
     groupName: 'Dictionaries',
     apis: [
       'dictionaryFetch',
+      'dictionaryLength',
       'dictionaryGetField',
       'dictionaryGetFields',
       'dictionaryIncrement',
@@ -150,6 +152,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
       'setAddElement',
       'setAddElements',
       'setFetch',
+      'setLength',
       'setRemoveElement',
       'setRemoveElements',
       'setContainsElement',
@@ -161,6 +164,8 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
     apis: [
       'sortedSetFetchByRank',
       'sortedSetFetchByScore',
+      'sortedSetLength',
+      'sortedSetLengthByScore',
       'sortedSetGetRank',
       'sortedSetGetScore',
       'sortedSetGetScores',
@@ -175,7 +180,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
     groupName: 'Signing Keys',
     apis: ['createSigningKey', 'listSigningKeys', 'revokeSigningKey'],
   },
-  {groupName: 'SSO', apis: ['generateApiToken']},
+  {groupName: 'SSO', apis: ['generateAuthToken', 'refreshAuthToken']},
 ];
 
 const TOPIC_API_GROUPS: Array<ApiGroup> = [


### PR DESCRIPTION
This commit adds the following missing APIs to the reference and
feature matrix:

* itemGetType
* itemGetTtl
* setLength
* dictionaryLength
* sortedSetLength
* sortedSetLengthByScore
* generateAuthToken
* refreshAuthToken
