### PR TITLE
feat: add support for description paragraphs on the feature matrix page

### DIFF
--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -104,7 +104,7 @@ interface ApiGroup {
 const CONFIG_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Configuration',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento configuration APIs',
     apis: [
       {
         displayName: 'ClientTimeout',
@@ -119,7 +119,7 @@ const CONFIG_API_GROUPS: Array<ApiGroup> = [
 const CACHE_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Global',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento global APIs',
     apis: [
       'ping',
       'flushCache',
@@ -135,12 +135,12 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Scalars',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento scalar APIs',
     apis: ['get', 'set', 'setIfNotExists', 'increment'],
   },
   {
     groupName: 'Lists',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento list APIs.',
     apis: [
       'listConcatenateBack',
       'listConcatenateFront',
@@ -156,7 +156,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Dictionaries',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento dictionary APIs.',
     apis: [
       'dictionaryFetch',
       'dictionaryLength',
@@ -171,7 +171,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Sets',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento set APIs',
     apis: [
       'setAddElement',
       'setAddElements',
@@ -185,7 +185,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Sorted Sets',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento sorted set APIs',
     apis: [
       'sortedSetFetchByRank',
       'sortedSetFetchByScore',
@@ -203,7 +203,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Signing Keys',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento signing key APIs',
     apis: ['createSigningKey', 'listSigningKeys', 'revokeSigningKey'],
   },
 ];
@@ -211,7 +211,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
 const TOPIC_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Topics',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento Topics APIs',
     apis: ['subscribe', 'publish'],
   },
 ];
@@ -219,7 +219,7 @@ const TOPIC_API_GROUPS: Array<ApiGroup> = [
 const AUTH_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Auth',
-    groupDescription: 'DESCRIPTION GOES HERE',
+    groupDescription: 'A matrix of SDK support for Momento auth token APIs',
     apis: ['generateAuthToken', 'refreshAuthToken'],
   },
 ];

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -3,7 +3,14 @@ import * as path from 'path';
 import {SdkSourceProvider} from '../examples/sdk-source/sdk-source-provider';
 import {SdkGithubRepoSourceProvider} from '../examples/sdk-source/sdk-github-repo-source-provider';
 import * as fs from 'fs';
-import {heading, Heading, table, Table} from '../utils/markdown-nodes';
+import {
+  heading,
+  Heading,
+  Paragraph,
+  paragraph,
+  table,
+  Table,
+} from '../utils/markdown-nodes';
 
 interface SdkInfo {
   sdk: Sdk;
@@ -90,12 +97,14 @@ type Api = string | {displayName: string; functionName: string | RegExp};
 
 interface ApiGroup {
   groupName: string;
+  groupDescription: string;
   apis: Array<Api>;
 }
 
 const CONFIG_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Configuration',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       {
         displayName: 'ClientTimeout',
@@ -110,6 +119,7 @@ const CONFIG_API_GROUPS: Array<ApiGroup> = [
 const CACHE_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Global',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       'ping',
       'flushCache',
@@ -125,10 +135,12 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Scalars',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: ['get', 'set', 'setIfNotExists', 'increment'],
   },
   {
     groupName: 'Lists',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       'listConcatenateBack',
       'listConcatenateFront',
@@ -144,6 +156,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Dictionaries',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       'dictionaryFetch',
       'dictionaryLength',
@@ -158,6 +171,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Sets',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       'setAddElement',
       'setAddElements',
@@ -171,6 +185,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Sorted Sets',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: [
       'sortedSetFetchByRank',
       'sortedSetFetchByScore',
@@ -188,20 +203,29 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   },
   {
     groupName: 'Signing Keys',
+    groupDescription: 'DESCRIPTION GOES HERE',
     apis: ['createSigningKey', 'listSigningKeys', 'revokeSigningKey'],
   },
 ];
 
 const TOPIC_API_GROUPS: Array<ApiGroup> = [
-  {groupName: 'Topics', apis: ['subscribe', 'publish']},
+  {
+    groupName: 'Topics',
+    groupDescription: 'DESCRIPTION GOES HERE',
+    apis: ['subscribe', 'publish'],
+  },
 ];
 
 const AUTH_API_GROUPS: Array<ApiGroup> = [
-  {groupName: 'Auth', apis: ['generateAuthToken', 'refreshAuthToken']},
+  {
+    groupName: 'Auth',
+    groupDescription: 'DESCRIPTION GOES HERE',
+    apis: ['generateAuthToken', 'refreshAuthToken'],
+  },
 ];
 
 export class ApiSupportMatrixGenerator {
-  generateApiMatrixMarkdownNodes(): Array<Heading | Table> {
+  generateApiMatrixMarkdownNodes(): Array<Heading | Paragraph | Table> {
     const sourceProvider: SdkSourceProvider = new SdkGithubRepoSourceProvider();
 
     const allSdksCacheApiSupport = new Map<string, Map<string, boolean>>();
@@ -240,7 +264,7 @@ export class ApiSupportMatrixGenerator {
       allSdksAuthApiSupport.set(sdkName, authApiSupport);
     }
 
-    const nodes: Array<Heading | Table> = [];
+    const nodes: Array<Heading | Paragraph | Table> = [];
     nodes.push(...renderApiGroups(CACHE_API_GROUPS, allSdksCacheApiSupport));
     nodes.push(...renderApiGroups(TOPIC_API_GROUPS, allSdksTopicsApiSupport));
     nodes.push(...renderApiGroups(AUTH_API_GROUPS, allSdksAuthApiSupport));
@@ -252,10 +276,11 @@ export class ApiSupportMatrixGenerator {
 function renderApiGroups(
   apiGroups: Array<ApiGroup>,
   allSdksApiSupport: Map<string, Map<string, boolean>>
-): Array<Heading | Table> {
-  const nodes: Array<Heading | Table> = [];
+): Array<Heading | Paragraph | Table> {
+  const nodes: Array<Heading | Paragraph | Table> = [];
   for (const apiGroup of apiGroups) {
     nodes.push(heading(apiGroup.groupName, 3));
+    nodes.push(paragraph(apiGroup.groupDescription));
     nodes.push(
       table([
         ['Feature', ...SDKS.map(s => sdkDisplayName(s.sdk))],

--- a/plugins/example-code-snippets/src/utils/markdown-nodes.ts
+++ b/plugins/example-code-snippets/src/utils/markdown-nodes.ts
@@ -33,6 +33,18 @@ export interface Heading {
   children: [Text];
 }
 
+export function paragraph(value: string): Paragraph {
+  return {
+    type: 'paragraph',
+    children: [
+      {
+        type: 'text',
+        value: value,
+      },
+    ],
+  };
+}
+
 export function heading(value: string, depth: number): Heading {
   return {
     type: 'heading',


### PR DESCRIPTION
This commit adds an extra field in the code that generates the API
feature matrix. It can be used to add a descriptive paragraph between
each section header and the API support table.
