### PR TITLE
feat: print summary of missing SDK examples after `yarn build`

### DIFF
--- a/docs/develop/index.md
+++ b/docs/develop/index.md
@@ -66,7 +66,7 @@ You can find the pre-built configurations in our `Configurations` namespace in m
 
 `Configurations.Lambda` is a configuration that is available in some SDKs, and is optimized for the AWS Lambda environment. It has some configuration settings designed to pre-warm the client on Lambda cold starts, and to ensure the connection is re-established proactively if a Lambda remains idle for long enough for the connection to time out.
 
-<SdkExampleTabs snippetId={'API_ConfigurationILambda'} />
+<SdkExampleTabs snippetId={'API_ConfigurationLambda'} />
 
 If you do need to customize your configuration beyond what our pre-builts provide, you can build your own `Configuration`
 object.  See the examples in the `Configurations` namespace in the source code of your SDK to see how they are constructed.

--- a/plugins/example-code-snippets/src/example-code-snippets-post-build.ts
+++ b/plugins/example-code-snippets/src/example-code-snippets-post-build.ts
@@ -11,12 +11,27 @@ module.exports = function (context, options) {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     postBuild({siteConfig = {}, routesPaths = [], outDir}) {
-      console.log('SNIPPETS PLUGINS POST-BUILD');
-      console.log(
-        `MISSING SNIPPETS: ${MISSING_SNIPPETS_REGISTRY.missingSnippets()
-          .map(s => JSON.stringify(s, null, 2))
-          .join('\n')}`
-      );
+      console.log('\n\n\nMISSING SDK EXAMPLES REPORT\n\n\n');
+      const missingSnippets = MISSING_SNIPPETS_REGISTRY.missingSnippets();
+      const missingFiles = MISSING_SNIPPETS_REGISTRY.missingFiles();
+      for (const [language, snippets] of missingSnippets.entries()) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const files = missingFiles.get(language) ?? [];
+        console.log(
+          `SDK '${language.valueOf()}' is missing ${
+            snippets.length
+          } snippets and ${files.length} files.`
+        );
+        if (snippets.length > 0) {
+          console.log(
+            `\tMissing snippets: ${snippets.map(s => s.snippetId).join(',')}`
+          );
+        }
+        if (files.length > 0) {
+          console.log(`\tMissing files: ${files.join(',')}`);
+        }
+        console.log();
+      }
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     configureWebpack(config: unknown, isServer: unknown, utils: unknown) {

--- a/plugins/example-code-snippets/src/examples/missing-snippets-registry.ts
+++ b/plugins/example-code-snippets/src/examples/missing-snippets-registry.ts
@@ -1,19 +1,41 @@
 import {ExampleLanguage, ExampleSnippetCoordinates} from './examples';
 
 export class MissingSnippetsRegistry {
-  private readonly _missingSnippets = new Set<string>();
-  private readonly _missingFiles = new Set<string>();
+  private readonly _missingSnippets = new Map<ExampleLanguage, Set<string>>();
+  private readonly _missingFiles = new Map<ExampleLanguage, Set<string>>();
   registerMissingSnippet(coords: ExampleSnippetCoordinates): void {
-    this._missingSnippets.add(JSON.stringify(coords));
+    if (!this._missingSnippets.has(coords.language)) {
+      this._missingSnippets.set(coords.language, new Set());
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this._missingSnippets.get(coords.language)!.add(JSON.stringify(coords));
   }
 
   registerMissingFile(language: ExampleLanguage, file: string): void {
-    this._missingFiles.add(JSON.stringify({language: language, file: file}));
+    if (!this._missingFiles.has(language)) {
+      this._missingFiles.set(language, new Set());
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this._missingFiles.get(language)!.add(file);
   }
 
-  missingSnippets(): Array<ExampleSnippetCoordinates> {
-    return Array.from(this._missingSnippets).map(
-      s => JSON.parse(s) as ExampleSnippetCoordinates
+  missingSnippets(): Map<ExampleLanguage, Array<ExampleSnippetCoordinates>> {
+    return new Map(
+      Array.from(this._missingSnippets.entries()).map(([lang, snippets]) => [
+        lang,
+        Array.from(snippets).map(
+          coords => JSON.parse(coords) as ExampleSnippetCoordinates
+        ),
+      ])
+    );
+  }
+
+  missingFiles(): Map<ExampleLanguage, Array<string>> {
+    return new Map(
+      Array.from(this._missingFiles.entries()).map(([lang, files]) => [
+        lang,
+        Array.from(files),
+      ])
     );
   }
 }


### PR DESCRIPTION
This commit updates the post-build plugin to print out a concise summary of all of the missing SDK examples for each language at the end of the `yarn build`.  This can be used to quickly identify which languages we need to go add missing examples for.