### PR TITLE
feat: add info about TopicScopes

### DIFF
--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -312,6 +312,8 @@ Generates a new Momento Auth token with the specified permissions and expiry.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+
 ### RefreshAuthToken
 
 Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
@@ -333,7 +335,7 @@ Refreshes an existing, unexpired Momento auth token.  Produces a new auth token 
 
 </details>
 
-
+<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
 
 
 

--- a/docs/develop/guides/working-with-momento-auth-tokens.md
+++ b/docs/develop/guides/working-with-momento-auth-tokens.md
@@ -1,15 +1,17 @@
 ---
 sidebar_position: 4
 sidebar_label: Momento Authentication
-title: Momento Authentication With Expiring Tokens
+title: Working with Momento auth tokens
 description: Learn how to use expiring tokens to enhance the security of your application
 pagination_next: null
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
-# Momento authentication with expiring tokens
+# Working with Momento auth tokens
 
 To access Momento services from your application, a Momento auth token is required. The auth token is an alphanumeric string Momento generates that is unique to your account and the cloud provider's Region you select. When creating an auth token, you can set up one of two types of expiration:
 
@@ -47,10 +49,28 @@ Scroll down and you will see your token in a grey box. The tokens in the screens
 If you wish to quickly test out Momento, click on the copy icon beside the auth token to copy the token to your clipboard and supply it to the Momento SDK. We recommend you also click the "Download JSON" button to store both the auth token and refresh token. Tokens are like passwords, the best practice is to store it in and retrieve it from a secure location such as [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) or [GCP Secret Manager](https://cloud.google.com/secret-manager).
 
 ### Step 4: Automating token refresh
+
+To refresh an expiring token, you will use the Momento `AuthClient` and its `refreshAuthToken` API.
+
+To instantiate an `AuthClient`:
+
+<SdkExampleTabs snippetId={'API_InstantiateAuthClient'} />
+
+To use the `refreshAuthToken` API:
+
+<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+
 Once your application is running in production. You will need an automated script that periodically refreshes the auth token, **before** it expires. If you are running in AWS, scheduling a function in AWS Lambda that does this for you. For GCP, Google Cloud Functions is likely your solution of choice. For an example using AWS Lambda, check out our [1-click deploy example Lambda function](https://github.com/momentohq/auth-token-refresh-lambda) that will automatically refresh your token stored in AWS Secrets Manager.
 
 :::note
 While a Lambda function, Google Cloud Function, or another automated script refreshes the auth token, your application also needs to check AWS Secrets Manager (or wherever you are storing your tokens) periodically for newly refreshed tokens if it is caching the token locally!
 :::
+
+## Token Scopes
+
+Momento auth tokens have an associated `TokenScope` which controls their level of access to Momento resources. Here is a list of the available `TokenScope`s:
+
+- `SuperUser`: these tokens have full access to all control plane and data plane operations. They can also be used to generate new tokens via the [`generateAuthToken`](/develop/api-reference#generateauthtoken) API. The only way to create a `SuperUser` token is through the [Momento web console](https://console.gomomento.com).
+- `AllDataReadWrite`: these tokens have full read/write access to all data plane operations, but no access to control plane operations. They can be used to read/write any cache, and to publish and subscribe to any topic. They cannot be used to create or delete caches, nor to generate new Momento auth tokens. `AllDataReadWrite` tokens are created via the [`generateAuthToken`](/develop/api-reference#generateauthtoken) API. 
 
 Got more questions or feedback for us? Join our [Discord community](https://discord.gg/GDStRczm) or reach out to [Momento support](mailto:support@momentohq.com) for help.

--- a/docs/develop/sdks/web/index.md
+++ b/docs/develop/sdks/web/index.md
@@ -61,8 +61,7 @@ Then you will use the `generateAuthToken` API to create a token that you can ven
 
 <SdkExampleCodeBlock language={'javascript'} snippetId={'API_GenerateAuthToken'} />
 
-For more information on Momento auth tokens, including `TokenScope` for authorization, and how to refresh expiring tokens,
-see [Working with Momento auth tokens](/develop/guides/working-with-momento-auth-tokens).
+For more information on Momento auth tokens, including `TokenScope` for authorization, and how to refresh expiring tokens, see [Working with Momento auth tokens](/develop/guides/working-with-momento-auth-tokens).
 
 ## FAQ
 

--- a/docs/develop/sdks/web/index.md
+++ b/docs/develop/sdks/web/index.md
@@ -6,6 +6,11 @@ sidebar_label: JS Web SDK
 description: Information about the Momento web SDK
 ---
 
+import { SdkExampleCodeBlock } from "@site/src/components/SdkExampleCodeBlock";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleCodeBlock to SdkExampleCodeBlockImpl
+import { SdkExampleCodeBlockImpl } from "@site/src/components/SdkExampleCodeBlockImpl";
+
 # Momento web SDK for Javascript in browsers
 
 Momento provides two JavaScript SDKs; [one for Node.js](/develop/sdks/nodejs) and one for other web applications. The two SDKs have identical APIs, so your code will look the same except for `import` statements, but under the hood they are built for optimal performance and compatibility in different JavaScript runtime environments.
@@ -48,28 +53,16 @@ Here's an example import statement for the web SDK:
 
 In order for your browser application to communicate with Momento services, you will need to provide the browser with a Momento auth token. The recommended practice is to generate a Momento auth token that has expiring credentials for each browser session. This enables the app to distribute tokens without worrying about your data being compromised.
 
-To create a Momento auth token for use in the browser, use the `generateAuthToken` API. Here is a code sample:
+To create a Momento auth token for use in the browser, you will generally have a web application using another Momento SDK such as the node.js SDK. First, you will need to instantiate a Momento `AuthClient`:
 
-```javascript
-const authClient = new AuthClient({
-  credentialProvider: CredentialProvider.fromEnvironmentVariable({
-    environmentVariableName: 'MOMENTO_AUTH_TOKEN',
-  })
-});
-const generateResponse = await sessionTokenAuthClient.generateAuthToken(
-    	AllDataReadWrite,
-    	ExpiresIn.minutes(30)
-);
-if (generateResponse instanceof GenerateAuthToken.Success) {
-  // if you get here, the auth token that you can send to the browser is available as:
-  //
-  //  generateResponse.authToken
-  //
-  // The expiration date is also available as:
-  //
-  //  generateResponse.expiresAt.epoch
-}
-```
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_InstantiateAuthClient'} />
+
+Then you will use the `generateAuthToken` API to create a token that you can vend to the browser:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_GenerateAuthToken'} />
+
+For more information on Momento auth tokens, including `TokenScope` for authorization, and how to refresh expiring tokens,
+see [Working with Momento auth tokens](/develop/guides/working-with-momento-auth-tokens).
 
 ## FAQ
 


### PR DESCRIPTION
This commit adds some initial information about TopicScopes for
auth tokens.

Also updates the web SDK page to use injected code samples for
auth/refresh, and adds some injected example code for refresh
on the auth tokens page.
