### PR TITLE
feat: add remaining sdk example tags to API reference

### DIFF
--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -38,6 +38,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionaryFetch'} />
+
 ### DictionaryGetField
 Get one field from a dictionary item in the cache.
 
@@ -70,6 +72,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionaryGetField'} />
+
 ### DictionaryGetFields
 Get one or more fields from a dictionary in the cache.
 
@@ -94,6 +98,8 @@ Get one or more fields from a dictionary in the cache.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_DictionaryGetFields'} />
 
 ### DictionaryIncrement
 Adds to the value of a field, if and only if the existing value is a UTF-8 string representing a base 10 integer. If the field is missing from the dictionary, this method sets the field's value to the amount to increment by.
@@ -130,6 +136,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionaryIncrement'} />
+
 ### DictionaryRemoveField
 
 Removes a field from a dictionary item.
@@ -150,6 +158,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionaryRemoveField'} />
+
 ### DictionaryRemoveFields
 Removes multiple fields from a dictionary item.
 
@@ -168,6 +178,8 @@ Removes multiple fields from a dictionary item.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_DictionaryRemoveFields'} />
 
 ### DictionarySetField
 Sets a field:value pair in an existing dictionary item. If the dictionary item does not exist, it is created with the new field:value pair.
@@ -190,6 +202,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionarySetField'} />
+
 ### DictionarySetFields
 Sets several field:value pairs in a dictionary item. If the dictionary item does not exist, it is created with the new fields.
 
@@ -209,6 +223,8 @@ Sets several field:value pairs in a dictionary item. If the dictionary item does
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_DictionarySetFields'} />
 
 ### DictionaryLength
 Get the length of an existing dictionary item
@@ -230,3 +246,4 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_DictionaryLength'} />

--- a/docs/develop/api-reference/index.mdx
+++ b/docs/develop/api-reference/index.mdx
@@ -124,6 +124,8 @@ The resulting incremented value must be between -9223372036854775808 and 9223372
 
 :::
 
+<SdkExampleTabs snippetId={'API_Increment'} />
+
 ### Ping
 Sends a ping to the server. This API can be used for checking connectivity to confirm that the client can connect to the server successfully.
 
@@ -136,6 +138,8 @@ Sends a ping to the server. This API can be used for checking connectivity to co
     See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_Ping'} />
 
 ### ItemGetType
 
@@ -159,6 +163,7 @@ For a given key, returns the type (SCALAR, DICTIONARY, LIST, etc.) of the corres
 
 </details>
 
+<SdkExampleTabs snippetId={'API_ItemGetType'} />
 
 ### KeyExists
 
@@ -180,6 +185,8 @@ Checks if a provided key exists in the cache.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_KeyExists'} />
+
 ### KeysExist
 
 Checks if provided keys exist in the cache.
@@ -199,6 +206,8 @@ Checks if provided keys exist in the cache.
     See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_KeysExist'} />
 
 ### SetIfNotExists
 
@@ -222,6 +231,8 @@ Associates the provided value to a cache item with a given key.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetIfNotExists'} />
+
 ## Time to Live APIs
 
 These APIs apply across all cache types.
@@ -235,6 +246,8 @@ Overwrites the TTL of a cache item with the provided value in seconds.
 | cacheName | String | Name of the cache.                              |
 | key       | String \| Bytes | The key under which the value's TTL is to be updated. |
 | ttl       | Duration | Time to live that you want to update in cache in seconds. |
+
+<SdkExampleTabs snippetId={'API_UpdateTtl'} />
 
 ### IncreaseTtl
 
@@ -250,6 +263,8 @@ Examples
 | key       | String \| Bytes | The key under which the value's TTL is to be increased. |
 | ttl       | Duration | Time to live that you want to increase to. |
 
+<SdkExampleTabs snippetId={'API_IncreaseTtl'} />
+
 ### DecreaseTtl
 
 Decrease the TTL seconds for a key to the provided value only if it would decrease the TTL.
@@ -263,6 +278,8 @@ Examples
 | cacheName | String | Name of the cache.                              |
 | key       | String \| Bytes | The key under which the value's TTL is to be decreased. |
 | ttl       | Duration | Time to live that you want to decrease to. |
+
+<SdkExampleTabs snippetId={'API_DecreaseTtl'} />
 
 ### ItemGetTtl
 
@@ -285,6 +302,8 @@ For a given key, returns the duration of time remaining (Time To Live) before th
   See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ItemGetTtl'} />
 
 ## Auth APIs
 
@@ -336,9 +355,6 @@ Refreshes an existing, unexpired Momento auth token.  Produces a new auth token 
 </details>
 
 <SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
-
-
-
 
 ### Collection data types
 

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -38,6 +38,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_ListFetch'} />
+
 ### ListConcatenateBack
 Appends the supplied list to the end of an existing list item.
 
@@ -64,6 +66,8 @@ If you have [1, 2, 3] and listConcatenateBack [4, 5, 6] you will have [1, 2, 3, 
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListConcatenateBack'} />
 
 ### ListConcatenateFront
 Appends the supplied list to the front of an existing list item.
@@ -92,6 +96,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_ListConcatenateFront'} />
+
 ### ListLength
 Get the length of an existing list item
 
@@ -111,6 +117,8 @@ Get the length of an existing list item
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListLength'} />
 
 ### ListPopBack
 Remove and return the last element from a list item.
@@ -134,6 +142,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_ListPopBack'} />
+
 ### ListPopFront
 Remove and return the first element from a list item.
 
@@ -155,6 +165,8 @@ Remove and return the first element from a list item.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListPopFront'} />
 
 ### ListPushBack
 Push a value to the end of a list item. This is exactly like passing just one value to [ListConcatenateBack](#listconcatenateback).
@@ -179,6 +191,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_ListPushBack'} />
+
 ### ListPushFront
 Push a value to the beginning of a list item. Just like [ListPushBack](#listpushback), but to the front.
 
@@ -201,6 +215,8 @@ Push a value to the beginning of a list item. Just like [ListPushBack](#listpush
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListPushFront'} />
 
 ### ListRemoveValue
 Remove all elements in a list item equal to a particular value.
@@ -226,6 +242,8 @@ Responses
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListRemoveValue'} />
 
 ### ListRetain
 
@@ -253,6 +271,8 @@ Responses
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_ListRetain'} />
 
 
 ## Truncate to size

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -36,6 +36,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetAddElement'} />
+
 ### SetAddElements
 Adds multiple elements to a set item.
 
@@ -55,6 +57,8 @@ Adds multiple elements to a set item.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SetAddElements'} />
 
 ### SetFetch
 
@@ -81,6 +85,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetFetch'} />
+
 ### SetRemoveElement
 Removes a single element from an existing set item.
 
@@ -100,6 +106,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetRemoveElement'} />
+
 ### SetRemoveElements
 Removes multiple elements from an existing set item.
 
@@ -118,6 +126,8 @@ Removes multiple elements from an existing set item.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SetRemoveElements'} />
 
 ### SetContainsElement
 Checks if a provided element is in the given set.
@@ -142,6 +152,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetContainsElement'} />
+
 ### SetContainsElements
 Checks if provided elements are in the given set.
 
@@ -165,6 +177,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SetContainsElements'} />
+
 ### SetLength
 Get the length of an existing set item
 
@@ -184,3 +198,5 @@ Get the length of an existing set item
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SetLength'} />

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -38,6 +38,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetPutElement'} />
+
 ### SortedSetPutElements
 
 Adds new or updates existing [sorted set elements](#sortedsetelement) in a sorted set item.
@@ -63,6 +65,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetPutElements'} />
+
 ### SortedSetFetchByRank
 
 Fetch elements of sorted set, optionally filtered by rank, and return them in ascending or descending order.
@@ -86,6 +90,8 @@ Fetch elements of sorted set, optionally filtered by rank, and return them in as
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SortedSetFetchByRank'} />
 
 ### SortedSetFetchByScore
 
@@ -113,6 +119,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetFetchByScore'} />
+
 ### SortedSetGetScore
 
 Gets an element's score from the sorted set, indexed by value.
@@ -134,6 +142,8 @@ Gets an element's score from the sorted set, indexed by value.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SortedSetGetScore'} />
 
 ### SortedSetGetScores
 
@@ -160,6 +170,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetGetScores'} />
+
 ### SortedSetRemoveElement
 
 Removes an element from a sorted set, indexed by value.
@@ -179,6 +191,8 @@ Removes an element from a sorted set, indexed by value.
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SortedSetRemoveElement'} />
 
 ### SortedSetRemoveElements
 
@@ -202,6 +216,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetRemoveElements'} />
+
 ### SortedSetGetRank
 
 What position is the element, in the specified sorted set?
@@ -223,6 +239,8 @@ What position is the element, in the specified sorted set?
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SortedSetGetRank'} />
 
 ### SortedSetIncrementScore
 
@@ -258,6 +276,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetIncrementScore'} />
+
 ## SortedSetElement
 
 A value and score makes up each element in a sorted set.
@@ -292,6 +312,8 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_SortedSetLength'} />
+
 ### SortedSetLengthByScore
 For an existing sorted set item, it finds all of the values between the specified min and max score and returns the length.
 
@@ -313,3 +335,5 @@ For an existing sorted set item, it finds all of the values between the specifie
 See [response objects](./response-objects.md) for specific information.
 
 </details>
+
+<SdkExampleTabs snippetId={'API_SortedSetLengthByScore'} />

--- a/docs/develop/api-reference/topics.md
+++ b/docs/develop/api-reference/topics.md
@@ -45,6 +45,8 @@ With the returned subscription object, once put in a for loop, your code will re
 
 </details>
 
+<SdkExampleTabs snippetId={'API_TopicSubscribe'} />
+
 ### Publish
 Publishes a message to a topic.
 
@@ -73,6 +75,10 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
+<SdkExampleTabs snippetId={'API_TopicPublish'} />
+
 ## TopicClient
 
 Instead of the CacheClient, as used in most Momento Cache API calls, for Topics you use a TopicClient object.
+
+<SdkExampleTabs snippetId={'API_InstantiateTopicClient'} />


### PR DESCRIPTION
This commit adds <SdkExampleTabs> tags for all of the APIs that
didn't already have them. None of the SDKs actually have examples
for these yet, so these will not actually render on the website
for now. But this allows us to start adding them to the example
code in the various SDKs.
