### PR TITLE
feat: add dotnet snippet parser

### DIFF
--- a/plugins/example-code-snippets/src/examples/resolvers/sdk-repo-snippet-resolver.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/sdk-repo-snippet-resolver.ts
@@ -8,6 +8,7 @@ import {JavascriptSnippetSourceParser} from './source-parsers/languages/javascri
 import {TypescriptSnippetSourceParser} from './source-parsers/languages/typescript-snippet-source-parser';
 import {GolangSnippetSourceParser} from './source-parsers/languages/golang-snippet-source-parser';
 import {PythonSnippetSourceParser} from './source-parsers/languages/python-snippet-source-parser';
+import {CsharpSnippetSourceParser} from './source-parsers/languages/csharp-snippet-source-parser';
 
 export class SdkRepoSnippetResolver implements SnippetResolver {
   private readonly sourceProvider: SdkSourceProvider =
@@ -74,7 +75,7 @@ export class SdkRepoSnippetResolver implements SnippetResolver {
       case ExampleLanguage.JAVASCRIPT:
         return new JavascriptSnippetSourceParser(sourceDir);
       case ExampleLanguage.CSHARP:
-        return undefined;
+        return new CsharpSnippetSourceParser(sourceDir);
       case ExampleLanguage.PYTHON:
         return new PythonSnippetSourceParser(sourceDir);
       case ExampleLanguage.GO:

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/csharp-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/csharp-snippet-source-parser.ts
@@ -1,0 +1,37 @@
+import {
+  RegexSnippetSourceParser,
+  RegexSnippetTypeOptions,
+} from '../regex-snippet-source-parser';
+import {ExampleSnippetType} from '../../../examples';
+import * as path from 'path';
+
+export class CsharpSnippetSourceParser extends RegexSnippetSourceParser {
+  constructor(repoSourceDir: string) {
+    const wholeFileExamplesDir = 'examples/DocExampleFiles';
+    const codeSnippetFiles: Array<string> = [
+      'examples/DocExampleApis/Program.cs',
+    ];
+    super({
+      wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),
+      snippetTypeParseOptions: new Map<
+        ExampleSnippetType,
+        RegexSnippetTypeOptions
+      >([
+        [
+          ExampleSnippetType.CODE,
+          {
+            snippetSourceFiles: codeSnippetFiles.map(f =>
+              path.join(repoSourceDir, f)
+            ),
+            startRegex: snippetId =>
+              new RegExp(
+                `^public async Task.*? example_${snippetId.valueOf()}\\(`
+              ),
+            endRegex: () => /^}/,
+            numLeadingSpacesToStrip: 4,
+          },
+        ],
+      ]),
+    });
+  }
+}

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/csharp-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/csharp-snippet-source-parser.ts
@@ -25,10 +25,11 @@ export class CsharpSnippetSourceParser extends RegexSnippetSourceParser {
             ),
             startRegex: snippetId =>
               new RegExp(
-                `^public async Task.*? example_${snippetId.valueOf()}\\(`
+                `^ {4}public static async Task Example_${snippetId.valueOf()}\\(`
               ),
-            endRegex: () => /^}/,
-            numLeadingSpacesToStrip: 4,
+            endRegex: () => /^ {4}}/,
+            numLeadingSpacesToStrip: 8,
+            skipFirstLine: true,
           },
         ],
       ]),

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/regex-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/regex-snippet-source-parser.ts
@@ -8,6 +8,11 @@ export interface RegexSnippetTypeOptions {
   startRegex: (snippetId: string) => RegExp;
   endRegex: (snippetId: string) => RegExp;
   numLeadingSpacesToStrip: number;
+  /**
+   * Number of lines after the start of the snippet to skip.
+   * In C# the first line is an opening curly, so we skip it.
+   */
+  skipFirstLine?: true;
 }
 
 export interface RegexSnippetSourceParserOptions {
@@ -66,7 +71,8 @@ export class RegexSnippetSourceParser implements SnippetSourceParser {
         return this.captureUntilEndOfSnippet(
           contentLinesIterator,
           endRegex,
-          options.numLeadingSpacesToStrip
+          options.numLeadingSpacesToStrip,
+          options.skipFirstLine
         );
       }
       nextLine = contentLinesIterator.next();
@@ -87,10 +93,14 @@ export class RegexSnippetSourceParser implements SnippetSourceParser {
   private captureUntilEndOfSnippet(
     remainingLines: IterableIterator<string>,
     endRegex: RegExp,
-    numLeadingSpacesToStrip: number
+    numLeadingSpacesToStrip: number,
+    skipFirstLine?: true
   ): string | undefined {
     const result = [];
     let nextLine = remainingLines.next();
+    if (skipFirstLine) {
+      nextLine = remainingLines.next();
+    }
     while (!nextLine.done) {
       const line = nextLine.value;
       if (line.match(endRegex)) {


### PR DESCRIPTION
Add the .NET SDK snippet parser. Because C# functions start with an opening curly brace on a separate line, we also add an option to the regex parser to skip the first line of a matched snippet.