### PR TITLE
fix: remove generics from function signatures when building api matrix

### DIFF
--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -338,7 +338,8 @@ function determineApiSupport(
       if (line.trim().startsWith('//')) continue;
       if (line.trim().startsWith('#')) continue;
       const unSnaked = line.replaceAll('_', '');
-      const unAsynced = unSnaked.replaceAll('Async(', '(');
+      const unGenericked = unSnaked.replaceAll(/<[^>]+>/g, '');
+      const unAsynced = unGenericked.replaceAll('Async(', '(');
       for (const apiGroup of apiGroups) {
         for (const api of apiGroup.apis) {
           const functionName = typeof api === 'string' ? api : api.functionName;


### PR DESCRIPTION
This commit removes generic type info from function signatures before
we try to populate the API support matrix. In some languages (at least
Rust) there is a generic type clause (`<...>`) after the function
name but before the opening parens and this was causing the generator
to miss some APIs in Rust that are actually implemented.
