### PR TITLE
fix: correct paths to JS code files, add missing imports for API ref pages

### DIFF
--- a/README.code-injection.md
+++ b/README.code-injection.md
@@ -91,7 +91,7 @@ https://github.com/momentohq/public-dev-docs/blob/04716fc6f508985881cf2c5efef118
 To inject a whole file from an SDK as a code sample:
 
 ```
-<SdkExampleCodeBlock language={'javascript'} file={'cheat-sheet-main.ts'} />
+<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/cache/doc-example-files/cheat-sheet-main.ts'} />
 ```
 
 https://github.com/momentohq/public-dev-docs/blob/04716fc6f508985881cf2c5efef1182bef496617/docs/develop/sdks/nodejs/cheat-sheet.mdx?plain=1#L38

--- a/docs/develop/api-reference/dictionary-collections.md
+++ b/docs/develop/api-reference/dictionary-collections.md
@@ -6,6 +6,11 @@ description: Learn how to interact with the API for dictionary collection data t
 slug: /develop/api-reference/collections/dictionary
 ---
 
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
+
 # Dictionary API reference for Momento Cache
 This page details the Momento API methods for the [dictionary collection data type](./../datatypes.md#dictionary-collections).
 

--- a/docs/develop/api-reference/list-collections.md
+++ b/docs/develop/api-reference/list-collections.md
@@ -6,6 +6,11 @@ description: Learn how to interact with the API for list collection data types i
 slug: /develop/api-reference/collections/list
 ---
 
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
+
 # List API reference for Momento Cache
 This page details the Momento API methods for the [list collection data types](./../datatypes.md#list-collections).
 

--- a/docs/develop/api-reference/set-collections.md
+++ b/docs/develop/api-reference/set-collections.md
@@ -6,6 +6,11 @@ description: Learn how to interact with the API for set collection data types in
 slug: /develop/api-reference/collections/sets
 ---
 
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
+
 # Set API reference for Momento Cache
 
 A set is a collection of elements, but each element can appear only once and order is not guaranteed.

--- a/docs/develop/api-reference/sorted-set-collections.md
+++ b/docs/develop/api-reference/sorted-set-collections.md
@@ -6,6 +6,11 @@ description: Learn how to interact with the API for sorted set collection data t
 slug: /develop/api-reference/collections/sortedsets
 ---
 
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
+
 # Sorted set collections
 
 A sorted set in Momento Cache is a collection of unique elements with a value (String, Byte[], etc.) and score (signed double 64-bit float) pair. The elements in the item are ordered by the score.

--- a/docs/develop/api-reference/topics.md
+++ b/docs/develop/api-reference/topics.md
@@ -6,8 +6,10 @@ description: Learn how to interact programmatically with Momento Topics pub/sub 
 slug: /develop/api-reference/topics
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
 # Using the Momento Topics (pub/sub) API with Momento Cache
 Momento Topics is a messaging pattern that allows for real-time communication between parts of a distributed application. It enables you to publish (produce) values to a topic, as well as subscribe (consume) from a topic. This page details the Momento API methods for interacting with Momento Topics.
@@ -24,14 +26,6 @@ This method subscribes to a topic to receive new values with a stateful connecti
 | cacheName       | String          | Name of the cache where the topic exists.     |
 | topicName       | String          | Name of the topic to subscribe to.            |
 
-<Tabs>
-  <TabItem value="golang" label="Go" default>
-    This is <a href="https://github.com/momentohq/client-sdk-go/blob/main/examples/pubsub-example/main.go#L26">example code</a>.
-  </TabItem>
-  <TabItem value="nodejs" label="Node.js" default>
-    Coming soon.
-  </TabItem>
-</Tabs>
 
 <details>
   <summary>Method response object</summary>

--- a/docs/develop/sdks/nodejs/cheat-sheet.mdx
+++ b/docs/develop/sdks/nodejs/cheat-sheet.mdx
@@ -35,7 +35,7 @@ export MOMENTO_AUTH_TOKEN=<your Momento token here>
 ## Import libraries and connect to return a CacheClient object
 This code sets up the main function, the necessary imports,  and the CacheClient instantiation that each of the other functions will need to call.
 
-<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/basic/doc-example-files/cheat-sheet-main.ts'} />
+<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/cache/doc-example-files/cheat-sheet-main.ts'} />
 
 ## Create a new cache in Momento Cache
 Use this function to create a new cache in your account.
@@ -65,5 +65,5 @@ You can find complete, working examples in the [JavaScript SDK github repo examp
 :::info
 Beyond these basic API calls check out the [API reference page](/develop/api-reference/index.mdx) for more information on the full assortment of Momento API calls.
 
-Follow this link to see this same type of code but for [more advanced calls](https://github.com/momentohq/client-sdk-javascript/blob/main/examples/nodejs/basic/advanced.ts).
+Follow this link to see this same type of code but for [more advanced calls](https://github.com/momentohq/client-sdk-javascript/blob/main/examples/nodejs/cache/advanced.ts).
 :::

--- a/docs/develop/sdks/nodejs/observability.mdx
+++ b/docs/develop/sdks/nodejs/observability.mdx
@@ -52,7 +52,7 @@ First, set up metrics in your application:
 
 Then, create a middleware that captures the metric:
 
-<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/basic/doc-example-files/example-metric-middleware.ts'} />
+<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/observability/example-metric-middleware.ts'} />
 
 When you create the Momento `CacheClient`, add the middleware and the metric will be incremented with each request:
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/sdks/nodejs/cheat-sheet.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/sdks/nodejs/cheat-sheet.mdx
@@ -35,7 +35,7 @@ export MOMENTO_AUTH_TOKEN=<your Momento token here>
 ## Import libraries and connect to return a CacheClient object
 This code sets up the main function, the necessary imports,  and the CacheClient instantiation that each of the other functions will need to call.
 
-<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/basic/doc-example-files/cheat-sheet-main.ts'} />
+<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/cache/doc-example-files/cheat-sheet-main.ts'} />
 
 ## Create a new cache in Momento Cache
 Use this function to create a new cache in your account.
@@ -65,5 +65,5 @@ You can find complete, working examples in the [JavaScript SDK github repo examp
 :::info
 Beyond these basic API calls check out the [API reference page](/develop/api-reference/index.mdx) for more information on the full assortment of Momento API calls.
 
-Follow this link to see this same type of code but for [more advanced calls](https://github.com/momentohq/client-sdk-javascript/blob/main/examples/nodejs/basic/advanced.ts).
+Follow this link to see this same type of code but for [more advanced calls](https://github.com/momentohq/client-sdk-javascript/blob/main/examples/nodejs/cache/advanced.ts).
 :::

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/sdks/nodejs/observability.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/sdks/nodejs/observability.mdx
@@ -52,7 +52,7 @@ First, set up metrics in your application:
 
 Then, create a middleware that captures the metric:
 
-<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/basic/doc-example-files/example-metric-middleware.ts'} />
+<SdkExampleCodeBlock language={'javascript'} file={'examples/nodejs/observability/example-metric-middleware.ts'} />
 
 When you create the Momento `CacheClient`, add the middleware and the metric will be incremented with each request:
 

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
@@ -9,9 +9,10 @@ export class JavascriptSnippetSourceParser extends RegexSnippetSourceParser {
   constructor(repoSourceDir: string) {
     const wholeFileExamplesDir = '.';
     const codeSnippetFiles: Array<string> = [
-      'examples/nodejs/basic/doc-examples-js-apis.ts',
-      'examples/nodejs/basic/utils/instrumentation.ts',
-      'examples/nodejs/basic/docs-advanced-logging-example.ts',
+      'examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts',
+      'examples/nodejs/observability/doc-example-files/doc-examples-js-apis.ts',
+      'examples/nodejs/observability/utils/instrumentation.ts',
+      'examples/nodejs/observability/advanced-logging.ts',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/typescript-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/typescript-snippet-source-parser.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 
 export class TypescriptSnippetSourceParser extends RegexSnippetSourceParser {
   constructor(repoSourceDir: string) {
-    const wholeFileExamplesDir = 'examples/nodejs/basic/doc-example-files';
+    const wholeFileExamplesDir = '.';
     const codeSnippetFiles: Array<string> = [
       // For now we don't have any typescript examples, only javascript ones.  We
       // can add a list of files containing TS examples in the future if we have some.


### PR DESCRIPTION
This fixes a bunch of paths that had changed for JS code samples.
Also adds missing imports to the API reference pages for lists, collections,
etc., so now the JS samples for collection APIs all show up properly.
