### PR TITLE
chore: Reduce the Elixir prominence in the SDK list

### DIFF
--- a/docs/develop/sdks/elixir/index.md
+++ b/docs/develop/sdks/elixir/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 7
 title: Momento Elixir SDK
 pagination_prev: null
 sidebar_label: Elixir


### PR DESCRIPTION
Make the Elixir SDK appear lower down in the list of SDKs in the docs. It doesn't quite deserve to be first at this time.