### PR TITLE
fix: Fix path for java sdk client after it was moved around

### DIFF
--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/java-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/java-snippet-source-parser.ts
@@ -8,9 +8,9 @@ import * as path from 'path';
 export class JavaSnippetSourceParser extends RegexSnippetSourceParser {
   constructor(repoSourceDir: string) {
     const wholeFileExamplesDir =
-      'examples/lib/src/main/java/momento/client/example/doc_examples';
+      'examples/cache/src/main/java/momento/client/example/doc_examples';
     const codeSnippetFiles: Array<string> = [
-      'examples/lib/src/main/java/momento/client/example/doc_examples/DocExamplesJavaAPIs.java',
+      'examples/cache/src/main/java/momento/client/example/doc_examples/DocExamplesJavaAPIs.java',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),


### PR DESCRIPTION
### Description

We changed the directory structure and renamed a few directories on our java client sdk to incorporate more variants of examples and not piling them under the same directory. Reference: https://github.com/momentohq/client-sdk-java/pull/297

The build is expected to fail until we merge the aforementioned PR. We can restart the build once it's merged and it will succeed.