### PR TITLE
chore: add java secrets manager example and remove non SDKExamplesTabs examples

### DIFF
--- a/docs/develop/integrations/aws-secrets-manager.md
+++ b/docs/develop/integrations/aws-secrets-manager.md
@@ -5,8 +5,10 @@ title: Momento + AWS Secrets Manager
 description: Learn how to retrieve your Momento Auth Token in AWS Secrets Manager.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
 # Retrieving a Momento auth token from AWS Secrets Manager
 
@@ -26,154 +28,7 @@ When inserting the Momento auth token into AWS Secrets Manager, it should be as 
 
 ## Example Code for AWS Secrets Manager
 
-In the code examples below, you can see where the getToken function is called just before creating the Momento cache connection client as that is where the auth token is needed and the only time it is needed.
-
-<Tabs>
-  <TabItem value="nodejs" label="Node.js" default>
-
-```javascript
-const {
-    SecretsManagerClient,
-    GetSecretValueCommand,
-  } = require('@aws-sdk/client-secrets-manager');
-const { CacheGet, CacheSet, Configurations, ListCaches, CreateCache,
-    CacheClient, CredentialProvider } = require('@gomomento/sdk');
-
-// Defines name of cache to use.
-const CACHE_NAME = 'demo-cache2';
-  
-// A function that gets the Momento_Auth_Token you stored in AWS Secrets Manager.
-// The secret was stored as a plaintext string to avoid parsing JSON.
-async function getToken(secretName) {
-  try {
-    // Set up the AWS Secrets Manager client
-    const client = new SecretsManagerClient({ region: "us-west-2"});
-
-    return await client.send(
-      new GetSecretValueCommand({
-        SecretId: secretName,
-        VersionStage: "AWSCURRENT", // VersionStage defaults to AWSCURRENT if unspecified
-      })
-    );
-  } catch (error) {
-    console.error(`Error fetching secret value for "${secretName}":`, error.message);
-    // For a list of exceptions thrown, see
-    // https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-    throw error;
-  }
-}
-
-// Create a Momento cache client connection object
-async function createCacheClient() {
-    // Get the token from AWS Secrets Manager
-    const token = await getToken("Momento_Auth_Token");
-
-    return new CacheClient({
-      configuration: Configurations.Laptop.v1(),
-      credentialProvider: CredentialProvider.fromString({"authToken" : token.SecretString}),
-      defaultTtlSeconds: 600,
-    });
-}
-
-// A function to write to the cache
-async function writeToCache(client, cacheName, key, data) {
-    const setResponse = await client.set(cacheName, key, data);
-    if (setResponse instanceof CacheSet.Success) {
-      console.log('Key stored successfully!');
-    } else if (setResponse instanceof CacheSet.Error) {
-      console.log('Error setting key: ', setResponse.toString());
-    } else {
-      console.log('Some other error: ', setResponse.toString());
-    }
-  }
-  
-// A function to read scalar items from the cache
-async function readFromCache(client, cacheName, key) {
-    const fileResponse = await client.get(cacheName, key);
-    if (fileResponse instanceof CacheGet.Hit) {
-        console.log('Cache hit: ', fileResponse.valueString());
-    } else if (fileResponse instanceof CacheGet.Miss) {
-        console.log('Cache miss');
-    } else if (fileResponse instanceof CacheGet.Error) {
-        console.log('Error: ', fileResponse.message());
-    }
-}
-
-// Call the various functions
-async function run() {
-    const cacheClient = await createCacheClient();
-  
-    await writeToCache(cacheClient, CACHE_NAME, "code", "12345");
-    await readFromCache(cacheClient, CACHE_NAME, "code");
-}
-
-run();
-```
-
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript" default>
-
-This code can be copied into a library file named GetClientFunctions.ts which you import into your own code.
-
-```javascript
-import {
-  CacheClient,
-  Configurations,
-  CredentialProvider
-} from '@gomomento/sdk';
-
-import {
-  SecretsManagerClient,
-  GetSecretValueCommand,
-  GetSecretValueCommandOutput,
-} from '@aws-sdk/client-secrets-manager';
-
-/* A function that gets the Momento_Auth_Token stored in AWS Secrets Manager.
-The secret was stored as a plaintext format in Secrets Manager to avoid parsing JSON.
-
-You don't have to store the Momento auth token in something like AWS Secrets Manager,
-but it is best practice. You could pass the Momento auth token in from an environment variable.
-
-*/
-async function GetToken(
-  secretName: string,
-  regionName: string = "us-west-2"
-  ): Promise<string> {
-    try {
-      const client = new SecretsManagerClient({ region: regionName});
-      const response: GetSecretValueCommandOutput = await client.send(
-        new GetSecretValueCommand({
-          SecretId: secretName,
-          VersionStage: "AWSCURRENT",
-        })
-      );
-      return response.SecretString || '';
-    } catch (error) {
-      console.error(`Error fetching secret value for "${secretName}":`, error.message);
-      // For a list of exceptions thrown, see
-      // https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-      throw error;
-    }
-  }
-  
-// Function that calls to the GetToken function and then gets a client connection
-// object from Momento Cache and returns that for later use.
-export default async function CreateCacheClient(
-  ttl:number = 600,
-  tokenName:string = "Momento_Auth_Token", 
-  ): Promise<CacheClient> {
-  const token: string = await GetToken(tokenName);
-    return new CacheClient({
-        configuration: Configurations.Laptop.v1(),
-        credentialProvider: CredentialProvider.fromString({ "authToken" : token }),
-        defaultTtlSeconds: ttl,
-    });
-}
-```
-
-  </TabItem>
-
-</Tabs>
+<SdkExampleTabs snippetId={'API_retrieveAuthTokenFromSecretsManager'} />
 
 ## FAQ
 

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/java-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/java-snippet-source-parser.ts
@@ -11,6 +11,7 @@ export class JavaSnippetSourceParser extends RegexSnippetSourceParser {
       'examples/cache/src/main/java/momento/client/example/doc_examples';
     const codeSnippetFiles: Array<string> = [
       'examples/cache/src/main/java/momento/client/example/doc_examples/DocExamplesJavaAPIs.java',
+      'examples/cache-with-aws/src/main/java/momento/client/example/doc_examples/DocExamplesJavaAPIs.java',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),


### PR DESCRIPTION
Added secrets manager java example using SDKExamplesTabs. This, however, inadvertently warrants removal of existing code examples of TS and JS as they are using Vanilla tabs. We want to move towards all examples being injected through SDKExamples. After discussion with Chris, the existing ones also need to be reworked as a single one for JS (and not node and TS).  Captured an issue for JS one https://github.com/momentohq/client-sdk-javascript/issues/612