### PR TITLE
chore: Revert "chore: fix broken link (#339)"

### DIFF
--- a/docs/develop/sdks/java/index.md
+++ b/docs/develop/sdks/java/index.md
@@ -25,7 +25,7 @@ The source code can be found on GitHub: [momentohq/client-sdk-java](https://gith
 ## Resources
 
 - [Java SDK Cheat Sheet](./cheat-sheet.mdx)
-- [Java SDK Examples](https://github.com/momentohq/client-sdk-java/blob/main/examples): working example projects that illustrate how to use the Java SDK
+- [Java SDK Examples](https://github.com/momentohq/client-sdk-java/blob/main/examples/README.md): working example projects that illustrate how to use the Java SDK
 - COMING SOON: Observability: Logging and Client-side Metrics with the Java SDK
 - COMING SOON: Taking your code to prod: Configuration and Error handling in the Java SDK
 


### PR DESCRIPTION
This reverts commit 92c095acbd275a29c7ea4d764d695e4b22d50c16.

Added back a small ReadMe to the top level example directory here https://github.com/momentohq/client-sdk-java/pull/300/.. We should merge this PR only once the java sdk gets merged
