### PR TITLE
chore: update documentation with go-redis compatibility client

### DIFF
--- a/docs/develop/integrations/redis-client-compatibility.md
+++ b/docs/develop/integrations/redis-client-compatibility.md
@@ -133,7 +133,7 @@ func initRedisClient() redis.Cmdable {
 }
 ```
 
-For more in-depth information, with example code, please see [Momento StackExchange compatibility client](https://github.com/momentohq/momento-go-redis-client) on GitHub.
+For more in-depth information, with example code, please see [Go-redis compatibility client](https://github.com/momentohq/momento-go-redis-client) on GitHub.
 
 </TabItem>
 </Tabs>

--- a/docs/develop/integrations/redis-client-compatibility.md
+++ b/docs/develop/integrations/redis-client-compatibility.md
@@ -97,5 +97,44 @@ var db = MomentoRedisDatabase(
 For more in-depth information, with example code, please see [Momento StackExchange compatibility client](https://github.com/momentohq/momento-dotnet-stackexchange-redis) on GitHub.
 
 </TabItem>
+
+<TabItem value="go" label="Go" default>
+
+```go
+package redis
+
+import (
+	"context"
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/momento"
+	momentoredis "github.com/momentohq/momento-go-redis-client/momento-redis"
+	"github.com/redis/go-redis/v9"
+	"time"
+)
+
+func initRedisClient() redis.Cmdable {
+	credential, eErr := auth.NewEnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+	if eErr != nil {
+		panic("Failed to initialize credentials through auth token " + eErr.Error())
+	}
+	cacheClient, cErr := momento.NewCacheClient(config.LaptopLatest(), credential, 60*time.Second)
+	if cErr != nil {
+		panic("Failed to initialize Momento cache client " + cErr.Error())
+	}
+	// create cache; it resumes execution normally incase the cache already exists
+	_, createErr := cacheClient.CreateCache(context.Background(),
+		&momento.CreateCacheRequest{CacheName: "default_cache"})
+	if createErr != nil {
+		panic("Failed to create cache with cache name default cache \n" + createErr.Error())
+	}
+	redisClient := momentoredis.NewMomentoRedisClient(cacheClient, "default_cache")
+	return redisClient
+}
+```
+
+For more in-depth information, with example code, please see [Momento StackExchange compatibility client](https://github.com/momentohq/momento-go-redis-client) on GitHub.
+
+</TabItem>
 </Tabs>
 

--- a/docs/develop/sdks/go/index.md
+++ b/docs/develop/sdks/go/index.md
@@ -30,4 +30,4 @@ The source code can be found on GitHub: [momentohq/client-sdk-go](https://github
 
 ## Integrations
 
-COMING SOON
+- [Redis Compatibility Client for `@go-redis`](https://github.com/momentohq/momento-go-redis-client) - a drop-in replacement that allows you to use Momento Cache with your existing `go-redis` code! See also our [Redis Client Compatibility](/develop/integrations/redis-client-compatibility.md) page.


### PR DESCRIPTION
Tested locally and able to access and see changes in both pages. I really wanted to use our snippets for this and change existing ones, however, I also want the imports to be present for this particular section. @cprice404 I remember we spoke over Slack a couple weeks back that the ```SdkExampleCodeBlock ```can inject files as is but doesn't support the Tab view which we want here. Until we get that out and working, defaulting to adding the code inline.