### PR TITLE
chore: include new JS SDK examples directory in JS snippet parser"

### DIFF
--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
@@ -13,6 +13,7 @@ export class JavascriptSnippetSourceParser extends RegexSnippetSourceParser {
       'examples/nodejs/observability/doc-example-files/doc-examples-js-apis.ts',
       'examples/nodejs/observability/utils/instrumentation.ts',
       'examples/nodejs/observability/advanced-logging.ts',
+      'examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),


### PR DESCRIPTION
Addresses [#612](https://github.com/momentohq/client-sdk-javascript/issues/612), pulls in the example in the JS SDK for the [AWS Secrets doc page](https://docs.momentohq.com/develop/integrations/aws-secrets-manager#example-code-for-aws-secrets-manager) by including the new example code directory as part of the snippet code search.