### PR TITLE
chore: update more examples with factory method to create cache client

### DIFF
--- a/docs/develop/guides/working-with-files-cache.md
+++ b/docs/develop/guides/working-with-files-cache.md
@@ -40,7 +40,7 @@ async function readFile(filePath) {
 
 // Creates the Momento cache client object
 async function createCacheClient() {
-  return new CacheClient({
+  return CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/docs/develop/integrations/redis-client-compatibility.md
+++ b/docs/develop/integrations/redis-client-compatibility.md
@@ -59,7 +59,7 @@ import {
 
 // Instantiate Momento Adapter Directly
 const Redis = new MomentoRedisAdapter(
-    new CacheClient({
+    await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromEnvironmentVariable({
             environmentVariableName: authTokenEnvVarName,
@@ -85,7 +85,7 @@ using Momento.StackExchange.Redis;
 
 // Create a Momento-backed Redis client
 var db = MomentoRedisDatabase(
-  new CacheClient(
+  await CacheClient.create(
     config: Configurations.Laptop.v1(),
     authProvider: new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN"),
     defaultTtl: TimeSpan.FromSeconds(60),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,7 +92,7 @@ dotenv.config();
 
 // Creates the Momento cache client object
 async function createCacheClient() {
-  return new CacheClient({
+  return CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/docs/learn/how-it-works/expire-data-with-ttl.md
+++ b/docs/learn/how-it-works/expire-data-with-ttl.md
@@ -31,7 +31,7 @@ There are three locations to set a TTL value:
 
     ```javascript
     const MY_DEFAULT_TTL = 60; // This value is in seconds
-    const momento = new CacheClient(authToken, MY_DEFAULT_TTL);
+    const momento = await CacheClient.create(authToken, MY_DEFAULT_TTL);
     ```
 
 2. In a SET operation, you can set a TTL value just for this operation and it will override the TTL value set in the CacheClient object.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/guides/working-with-files-cache.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/guides/working-with-files-cache.md
@@ -43,7 +43,7 @@ async function readFile(filePath) {
 
 // Creates the Momento cache client object
 async function createCacheClient() {
-    return new CacheClient({
+    return await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromEnvironmentVariable({
             environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/integrations/aws-secrets-manager.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/integrations/aws-secrets-manager.md
@@ -68,7 +68,7 @@ async function createCacheClient() {
     // Get the token from AWS Secrets Manager
     const token = await getToken("Momento_Auth_Token");
 
-    return new CacheClient({
+    return await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromString({"authToken": token.SecretString}),
         defaultTtlSeconds: 600,
@@ -163,7 +163,7 @@ export default async function CreateCacheClient(
     tokenName: string = "Momento_Auth_Token",
 ): Promise<CacheClient> {
     const token: string = await GetToken(tokenName);
-    return new CacheClient({
+    return await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromString({"authToken": token}),
         defaultTtlSeconds: ttl,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/develop/integrations/redis-client-compatibility.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/develop/integrations/redis-client-compatibility.md
@@ -59,7 +59,7 @@ import {
 
 // Instantiate Momento Adapter Directly
 const Redis = new MomentoRedisAdapter(
-    new CacheClient({
+    await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromEnvironmentVariable({
             environmentVariableName: authTokenEnvVarName,

--- a/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -84,7 +84,7 @@ dotenv.config();
 
 // Creates the Momento cache client object
 async function createCacheClient() {
-    return new CacheClient({
+    return await CacheClient.create({
         configuration: Configurations.Laptop.v1(),
         credentialProvider: CredentialProvider.fromEnvironmentVariable({
             environmentVariableName: 'MOMENTO_AUTH_TOKEN',


### PR DESCRIPTION
Updating more JS examples to use the cache client factory instead of the constructor. One that is left is the node-redis-compatibility-client which is directly pulled from that repo so will be updating that as another PR for that repo.