### PR TITLE
fix: use generateDisposableToken code snippet on tokens page instead of deprecated generateAuthToken

### DIFF
--- a/docs/develop/authentication/tokens.md
+++ b/docs/develop/authentication/tokens.md
@@ -32,7 +32,7 @@ Unlike our [API keys](/develop/authentication/api-keys.md), the only way to crea
 
 Below are some examples to create tokens with different sets of permissions:
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateDisposableToken'} />
 
 For detailed information on creating a token, please refer to the [API reference page](/develop/api-reference/auth.md).
 


### PR DESCRIPTION
Addresses docs sweep part of [#453](https://github.com/momentohq/dev-eco-issue-tracker/issues/453).

Tokens page should use the `generateDisposableToken` code snippets instead of `generateAuthToken`.