### PR TITLE
chore: add auto ja translation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:20-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	}

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -1,0 +1,44 @@
+name: Translate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**/*.md"
+      - "docs/**/*.mdx"
+
+jobs:
+  ja:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: |
+          node translate/list.mjs ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tee /tmp/modified
+      - run: |
+          node translate/translate.mjs $(cat /tmp/modified)
+        env:
+          SIMPLEEN_AUTH_KEY: ${{ secrets.SIMPLEEN_AUTH_KEY }}
+          SIMPLEEN_TRANSLATOR_ID: ${{ secrets.SIMPLEEN_TRANSLATOR_ID }}
+          TARGET_LANG: ja
+      - run: git diff
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: i18n/ja/docusaurus-plugin-content-docs/current/
+          base: main
+          branch: ja/${{ github.event.pull_request.head.ref }}
+          author: GitHub <noreply@github.com>
+          commit-message: ${{ github.event.pull_request.title }} [ja]
+          title: ${{ github.event.pull_request.title }} [ja]
+          body: |
+            Auto translated PR from #${{ github.event.pull_request.number }}
+            cc: @MomentoBigFun @Yoshiitaka
+          assignees: MomentoBigFun,Yoshiitaka

--- a/translate/list.mjs
+++ b/translate/list.mjs
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process";
+
+const listFiles = (base, commit) =>
+  execFileSync("git", [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMRT",
+    base,
+    commit,
+    "docs/",
+  ])
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((file) => file.endsWith(".md") || file.endsWith(".mdx"));
+
+const main = async () => {
+  const base = process.argv[2];
+  const commit = process.argv[3];
+  for (const file of listFiles(base, commit)) {
+    console.log(file);
+  }
+};
+
+main();

--- a/translate/translate.mjs
+++ b/translate/translate.mjs
@@ -1,0 +1,50 @@
+import { createWriteStream } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+
+const { SIMPLEEN_AUTH_KEY, SIMPLEEN_TRANSLATOR_ID, TARGET_LANG } = process.env;
+if (!SIMPLEEN_AUTH_KEY) throw new Error("SIMPLEEN_AUTH_KEY is not defined.");
+if (!SIMPLEEN_TRANSLATOR_ID)
+  throw new Error("SIMPLEEN_TRANSLATOR_ID is not defined.");
+if (!TARGET_LANG) throw new Error("TARGET_LANG is not defined.");
+
+// TODO: Handle frontmatter separately.
+const translate = async (src) => {
+  if (!src.startsWith("docs/"))
+    throw new Error(`File must starts with "docs/": ${src}`);
+  const text = (await readFile(src)).toString();
+  const dest = src.replace(
+    /^docs/,
+    `i18n/${TARGET_LANG}/docusaurus-plugin-content-docs/current`
+  );
+  const stream = createWriteStream(dest);
+  console.log(`Translating ${src} => ${dest}`);
+  const url = new URL(
+    `https://api.simpleen.io/translators/${SIMPLEEN_TRANSLATOR_ID}/translate`
+  );
+  url.searchParams.set("auth_key", SIMPLEEN_AUTH_KEY);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) throw new Error(res.statusText);
+  await finished(Readable.fromWeb(res.body).pipe(stream));
+};
+
+const main = async () => {
+  const files = process.argv.slice(2);
+  for (const file of files) {
+    try {
+      await translate(file);
+    } catch (error) {
+      console.log(`Failed to translate ${file} (${error})`);
+    }
+  }
+};
+
+main();


### PR DESCRIPTION
This commit adds scripts and workflow to automate translation to Japanese when a PR is opened for any markdown files under `docs/`.

cc @poppoerika 

## Background
@poppoerika asked me to create a workflow to create a auto translation PR for Japanese when any markdown files are updated so that we can get notified
and catch up Japanese translation.

## Design
A new GitHub Actions workflow "Translate" will be kicked when any markdown (or MDX) files are updated by any PR against `main`.

The workflow first lists all the modified files (See `translate/list.mjs`), then call Simpleen API for each file and update translated files under `i18n/` (See `translate/translate.mjs`) . Lastly, it pushes the change to a new branch and creates another PR.

## Usage
To test these script locally:

```
> edit docs/cache/indx.md
> git add . && git commit

> node translate/list.mjs HEAD^ HEAD
docs/cache/indx.md
```

```
> export SIMPLEEN_AUTH_KEY=...
> export SIMPLEEN_TRANSLATOR_ID=...
> export TARGET_LANG=ja

> node translate/translate.mjs docs/cache/index.md
Translating docs/cache/index.md => i18n/ja/docusaurus-plugin-content-docs/current/cache/index.md

> git diff
```

Note: I'll share @poppoerika how to setup Simpleen account and GitHub Secrets separately.

## Caveats
Due to limitation of Simpleen, the auto translation PR has some manual fixes like below:

1. Frontmatter won't be translated. Thus, every PR reverts previous Frontmatter translation so that the assignees need to manually re-revert before merge.
2. MDX is not supported by Simpleen so that inline MDX code will be translated as if it is a natural language. The assignees need to re-revert here, too.
3. This workflow always runs when the original PR (branch) gets update. Thus, any new commits added to the PR will be dismissed.
4. Some markdown syntaxes doesn't work well, like `_`. The assignees need to fix them manually.

## Test
See an example PR created on our forked repository: https://github.com/opsbr/momento-public-dev-docs/pull/8




