### PR TITLE
chore: add vector index client to API reference

### DIFF
--- a/docs/vector-index/develop/api-reference/index.md
+++ b/docs/vector-index/develop/api-reference/index.md
@@ -13,6 +13,12 @@ import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 # Using the Momento Vector Index API
 Momento Vector Index (MVI) is a scalable, developer-friendly vector index service designed for real-time storage and retrieval of vector data for use in AI-powered applications.
 
+## TopicClient
+
+To interact with Momento Vector Indexes, you must use a VectorIndexClient.
+
+<SdkExampleTabs snippetId={'API_InstantiateVectorClient'} />
+
 ## Vector Index methods
 
 ### Create Index


### PR DESCRIPTION
This will also add python examples to the reference.