### PR TITLE
chore: improve wording on API keys vs auth tokens

### DIFF
--- a/docs/cache/develop/authentication/api-keys.md
+++ b/docs/cache/develop/authentication/api-keys.md
@@ -9,7 +9,15 @@ description: Learn what Momento API keys are, how to create them, and how they a
 
 ![a technical illustration of API keys and their use to secure your application.](@site/static/img/api-keys-page.jpg)
 
-API keys are *long-lived values intended for programmatic use*. These keys grant integrating applications access to certain caches and topics. When creating an API key, you are presented with two options via the [Momento console](https://console.gomomento.com/tokens):
+API keys are *long-lived values intended for programmatic use*. These keys grant integrating applications access to certain caches and topics.
+
+:::tip
+
+Not sure if you should be using an `API key` or a `token`? Check out our [authentication](./index.mdx) page for all the details!
+
+:::
+
+When creating an API key, you are presented with two options via the [Momento console](https://console.gomomento.com/tokens):
 
 1. A "super-user" key that grants access to everything in your account, like creating and deleting caches, setting and getting cache items, and publishing and subscribing to topics.
 2. A fine-grained access control (FGAC) key that is limited to data operations only, like setting and getting cache items or publishing and subscribing to topics.
@@ -61,26 +69,15 @@ When creating an API key, you have the option to create one that never expires a
 
 The Momento console offers several pre-configured options for expiration ranges or you can select your own date. Just remember to create a new API key and rotate it in your application before it expires to prevent outages!
 
-## API Keys vs. Tokens
+## Use cases
 
-For a good overview on the differences between API Keys and Tokens, check out [Allen Helton's blog on the topic](https://www.gomomento.com/blog/api-keys-vs-tokens-whats-the-difference).
+For shorter-lived authentication use cases, with targeted permission scopes, consider using [Momento tokens](./tokens.md).
 
-The most important distinctions:
+API keys are a good choice for situations where:
 
-API Keys:
-
-* Are longer-lived (days, weeks, or months) and intended mostly for programmatic, server-side use cases
-* Are usually rotated on a monthly or yearly basis using tools like AWS Secrets Manager
-* May have relatively broad permissions and thus it is important to ensure they are not compromised
-
-Tokens:
-
-* Are shorter-lived (hours) and intended for interactive use caches (e.g. from a user's browser or mobile device)
-* Usually have much more narrow permissions (only what the user needs access to)
-* Are not refreshed, so once they expire, they are gone forever
-* Due to their shorter lifespan and narrower permissions, are significantly less sensitive in the event that one is compromised
-
-For more information on Momento Tokens, see the [tokens page](./tokens.md).
+* All usage is programmatic and server-side
+* You are okay with longer-lived keys that must be rotated on a monthly/yearly basis
+* The key needs relatively broad permissions
 
 For more information on managing the permissions on either API Keys or Tokens via fine-grained access control, see the [permissions page](./permissions.md).
 

--- a/docs/cache/develop/authentication/api-keys.md
+++ b/docs/cache/develop/authentication/api-keys.md
@@ -22,7 +22,7 @@ It is not possible to create "super-user" API keys via the Momento SDK; these ma
 
 ## Creating an API key
 
-While it is possible to create API keys via the Momento SDK, it is generally recommended to use the [Momento console](https://console.gomomento.com/tokens). This allows you to monitor and maintain your long-lived keys visually, making sure you don't accidentally open up a security hole in your account. 
+While it is possible to create API keys via the Momento SDK, the simplest way to create them is to use the [Momento console](https://console.gomomento.com/tokens).
 
 ### Step 1: Sign up or log into the Momento console
 

--- a/docs/cache/develop/authentication/api-keys.md
+++ b/docs/cache/develop/authentication/api-keys.md
@@ -16,13 +16,13 @@ API keys are *long-lived values intended for programmatic use*. These keys grant
 
 :::info
 
-You are not able to create "super-user" API keys via the Momento SDK. However, you *can* create fine-grain access controlled keys! Check out our [Auth API reference page](./../api-reference/auth.md) for more details.
+It is not possible to create "super-user" API keys via the Momento SDK; these may only be created in the console. However, you *can* use the SDK to create API keys with specific permissions, via fine-grain access control! Check out our [Auth API reference page](./../api-reference/auth.md) for more details.
 
 :::
 
 ## Creating an API key
 
-While you are certainly allowed to create API keys via our SDK, it is generally recommended to use the [Momento console](https://console.gomomento.com/tokens). This allows you to monitor and maintain your long-lived keys visually, making sure you don't accidentally open up a security hole in your account. 
+While it is possible to create API keys via the Momento SDK, it is generally recommended to use the [Momento console](https://console.gomomento.com/tokens). This allows you to monitor and maintain your long-lived keys visually, making sure you don't accidentally open up a security hole in your account. 
 
 ### Step 1: Sign up or log into the Momento console
 
@@ -61,12 +61,27 @@ When creating an API key, you have the option to create one that never expires a
 
 The Momento console offers several pre-configured options for expiration ranges or you can select your own date. Just remember to create a new API key and rotate it in your application before it expires to prevent outages!
 
-## Use cases
+## API Keys vs. Tokens
 
-There are many reasons to **not** use an API key for auth but there are also a few reasons to use one. 
+For a good overview on the differences between API Keys and Tokens, check out [Allen Helton's blog on the topic](https://www.gomomento.com/blog/api-keys-vs-tokens-whats-the-difference).
 
-* All usage is programmatic and server-side
-* You are okay with longer-lived keys that must be rotated on a monthly/yearly basis
-* You need to create session tokens  (must use a "super-user" token for this)
+The most important distinctions:
+
+API Keys:
+
+* Are longer-lived (days, weeks, or months) and intended mostly for programmatic, server-side use cases
+* Are usually rotated on a monthly or yearly basis using tools like AWS Secrets Manager
+* May have relatively broad permissions and thus it is important to ensure they are not compromised
+
+Tokens:
+
+* Are shorter-lived (hours) and intended for interactive use caches (e.g. from a user's browser or mobile device)
+* Usually have much more narrow permissions (only what the user needs access to)
+* Are not refreshed, so once they expire, they are gone forever
+* Due to their shorter lifespan and narrower permissions, are significantly less sensitive in the event that one is compromised
+
+For more information on Momento Tokens, see the [tokens page](./tokens.md).
+
+For more information on managing the permissions on either API Keys or Tokens via fine-grained access control, see the [permissions page](./permissions.md).
 
 Ready to get started? Head on over to the [Momento console](https://console.gomomento.com/tokens) and get your API key!

--- a/docs/cache/develop/authentication/tokens.md
+++ b/docs/cache/develop/authentication/tokens.md
@@ -16,6 +16,14 @@ import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
 Tokens are short-lived, limited-scope values intended to be used in temporary situations like a user's session. Software lifecycle events like a user login often result in the issuing of a token only valid for the duration of that session. 
 
+:::tip
+
+Not sure if you should be using an `API key` or a `token`? Check out our [authentication](./index.mdx) page for all the details!
+
+:::
+
+Tokens cannot be refreshed. So once it expires, it's gone forever. You'll be responsible for creating and issuing a new one if the session continues.
+
 A Momento token allows access to *data plane* API operations only. The user is unable to do *control plane* operations like creating, deleting, or flushing a cache.
 
 A user with a fully privileged token will be able to perform the following actions:

--- a/docs/topics/develop/authentication/api-keys.md
+++ b/docs/topics/develop/authentication/api-keys.md
@@ -7,28 +7,36 @@ description: Learn what Momento API keys are, how to create them, and how they a
 
 # Momento API keys
 
-<img src="/img/api-keys-page.jpg" width="95%" alt="a technical illustration of API keys and their use to secure your application." />
+![a technical illustration of API keys and their use to secure your application.](@site/static/img/api-keys-page.jpg)
 
-API keys are *long-lived values intended for programmatic use*. These keys grant integrating applications access to certain caches and topics. When creating an API key, you are presented with two options via the [Momento console](https://console.gomomento.com/tokens):
+API keys are *long-lived values intended for programmatic use*. These keys grant integrating applications access to certain caches and topics.
+
+:::tip
+
+Not sure if you should be using an `API key` or a `token`? Check out our [authentication](./index.mdx) page for all the details!
+
+:::
+
+When creating an API key, you are presented with two options via the [Momento console](https://console.gomomento.com/tokens):
 
 1. A "super-user" key that grants access to everything in your account, like creating and deleting caches, setting and getting cache items, and publishing and subscribing to topics.
 2. A fine-grained access control (FGAC) key that is limited to data operations only, like setting and getting cache items or publishing and subscribing to topics.
 
 :::info
 
-You are not able to create "super-user" API keys via the Momento SDK. However, you *can* create fine-grain access controlled keys! Check out our [Auth API reference page](./../api-reference/auth.md) for more details.
+It is not possible to create "super-user" API keys via the Momento SDK; these may only be created in the console. However, you *can* use the SDK to create API keys with specific permissions, via fine-grain access control! Check out our [Auth API reference page](./../api-reference/auth.md) for more details.
 
 :::
 
 ## Creating an API key
 
-While you are certainly allowed to create API keys via our SDK, it is generally recommended to use the [Momento console](https://console.gomomento.com/tokens). This allows you to monitor and maintain your long-lived keys visually, making sure you don't accidentally open up a security hole in your account. 
+While it is possible to create API keys via the Momento SDK, the simplest way to create them is to use the [Momento console](https://console.gomomento.com/tokens).
 
 ### Step 1: Sign up or log into the Momento console
 
 Go to the [Momento console](https://console.gomomento.com/tokens) and follow the instructions to log in with your email address, Google account, or GitHub account.
 
-![Image of Momento console landing page](/img/getting-started/console.png)
+![Image of Momento console landing page](@site/static/img/getting-started/console.png)
 
 ### Step 2: Generate your API key
 
@@ -41,7 +49,7 @@ Once on the API key page, select the information that matches where your caches 
 3. Key Type
 3. (Optional) Expiration date
 
-![Image showing the fields to create a new API key](/img/getting-started/select-provider-region.png)
+![Image showing the fields to create a new API key](@site/static/img/getting-started/select-provider-region.png)
 
 Once complete, click on the **Generate** button to create your API Key!
 
@@ -63,10 +71,14 @@ The Momento console offers several pre-configured options for expiration ranges 
 
 ## Use cases
 
-There are many reasons to **not** use an API key for auth but there are also a few reasons to use one. 
+For shorter-lived authentication use cases, with targeted permission scopes, consider using [Momento tokens](./tokens.md).
+
+API keys are a good choice for situations where:
 
 * All usage is programmatic and server-side
 * You are okay with longer-lived keys that must be rotated on a monthly/yearly basis
-* You need to create session tokens  (must use a "super-user" token for this)
+* The key needs relatively broad permissions
+
+For more information on managing the permissions on either API Keys or Tokens via fine-grained access control, see the [permissions page](./permissions.md).
 
 Ready to get started? Head on over to the [Momento console](https://console.gomomento.com/tokens) and get your API key!

--- a/docs/topics/develop/authentication/tokens.md
+++ b/docs/topics/develop/authentication/tokens.md
@@ -12,9 +12,17 @@ import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
 # Momento tokens for short-lived permissions
 
-<img src="/img/tokens-page.jpg" width="90%" alt="a technical illustration of Momento authentication and access control." />
+![a technical illustration of Momento authentication and access control.](@site/static/img/tokens-page.jpg)
 
 Tokens are short-lived, limited-scope values intended to be used in temporary situations like a user's session. Software lifecycle events like a user login often result in the issuing of a token only valid for the duration of that session. 
+
+:::tip
+
+Not sure if you should be using an `API key` or a `token`? Check out our [authentication](./index.mdx) page for all the details!
+
+:::
+
+Tokens cannot be refreshed. So once it expires, it's gone forever. You'll be responsible for creating and issuing a new one if the session continues.
 
 A Momento token allows access to *data plane* API operations only. The user is unable to do *control plane* operations like creating, deleting, or flushing a cache.
 


### PR DESCRIPTION
Erika pinged me this morning with some questions about API keys vs tokens, and after going over her questions together in Slack we felt that the wording wasn't entirely clear for some of the stuff in the docs pertaining to auth tokens. This commit takes a swing at clarifying some of it a bit.

This content is repeated in the topics part of the docs so I will need to duplicate these changes there, but I wanted to get stakeholders aligned on the wording first and then I will add a commit to duplicate it.