### PR TITLE
fix: update matrix generator markers in japanese docs

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/language-support.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/language-support.md
@@ -7,4 +7,4 @@ description: 各Momento SDK言語がどのAPIをサポートしているかの�
 
 ## 現在のMomento SDKでのAPIサポート状況
 
-%%%API_SUPPORT_MATRIX%%%
+%%%CACHE_API_SUPPORT_MATRIX%%%

--- a/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/api-reference/language-support.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/api-reference/language-support.md
@@ -7,4 +7,4 @@ description: 各Momento SDK言語がどのAPIをサポートしているかの�
 
 ## 現在のMomento SDKでのAPIサポート状況
 
-%%%API_SUPPORT_MATRIX%%%
+%%%TOPICS_API_SUPPORT_MATRIX%%%

--- a/plugins/example-code-snippets/src/language-api-support-matrix.ts
+++ b/plugins/example-code-snippets/src/language-api-support-matrix.ts
@@ -22,8 +22,9 @@ function isSupportMatrixNode<T extends unist.Node>(node: unknown): node is T {
 }
 
 /**
- * This is a docusaurus MDX/remark plugin.  It finds the %%%API_SUPPORT_MATRIX%%% marker
+ * This is a docusaurus MDX/remark plugin.  It finds the %%%{product}_API_SUPPORT_MATRIX%%% marker
  * in the markdown and injects the API support matrix tables in its place.
+ * Current supported markers are in the `generateApiMatrixMarkdownNodes` switch statement.
  *
  * @param options
  * @returns {unknown}


### PR DESCRIPTION
Follow up to #470 where the `%%%API_SUPPORT_MATRIX%%%` marker was changed to support a variety of markers for each separate product page, such as `%%%TOPICS_API_SUPPORT_MATRIX%%%` and `%%%CACHE_API_SUPPORT_MATRIX%%%`

I had missed the instances of `%%%API_SUPPORT_MATRIX%%%` in the Japanese docs so this PR fixes that.