### PR TITLE
chore: add us-east-2 to list of available regions

### DIFF
--- a/docs/cache/develop/api-reference/http-api.md
+++ b/docs/cache/develop/api-reference/http-api.md
@@ -31,9 +31,10 @@ To access the Momento HTTP API, use one of the following endpoints in the region
 |---|----------------|--------------------------------------------------------------|
 | 1 | us-west-2      | https://api.cache.cell-4-us-west-2-1.prod.a.momentohq.com    |
 | 2 | us-east-1      | https://api.cache.cell-us-east-1-1.prod.a.momentohq.com      |
-| 3 | ap-northeast-1 | https://api.cache.cell-ap-northeast-1-1.prod.a.momentohq.com |
-| 4 | eu-west-1      | https://api.cache.cell-1-eu-west-1-1.prod.a.momentohq.com    |
-| 5 | ap-south-1     | https://api.cache.cell-1-ap-south-1-1.prod.a.momentohq.com   |
+| 3 | us-east-2      | https://api.cache.cell-us-east-2-1.prod.a.momentohq.com      |
+| 4 | ap-northeast-1 | https://api.cache.cell-ap-northeast-1-1.prod.a.momentohq.com |
+| 5 | eu-west-1      | https://api.cache.cell-1-eu-west-1-1.prod.a.momentohq.com    |
+| 6 | ap-south-1     | https://api.cache.cell-1-ap-south-1-1.prod.a.momentohq.com   |
 
 
 If you do not see a Region you require, let’s discuss. Please contact [Support](mailto:support@momentohq.com).

--- a/docs/cache/index.md
+++ b/docs/cache/index.md
@@ -15,7 +15,7 @@ Momento Cache is the world's first truly serverless caching service. It provides
 
 Momento Cache is available in the following cloud providers and Regions:
 
-**AWS Regions**: us-west-2, us-east-1, eu-west-1, ap-south-1, ap-northeast-1
+**AWS Regions**: us-west-2, us-east-1, us-east-2, eu-west-1, ap-south-1, ap-northeast-1
 
 **GCP Regions**: us-central1
 


### PR DESCRIPTION
Noticed in multiple convos that we needed `us-east-2` updated in docs and I was in the repo so added it.