### PR TITLE
fix: disable the translate action if a PR comes from a fork

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   ja:
     runs-on: ubuntu-latest
+    # Do not run translation on PRs from forks since they don't have access to the SIMPLEEN secret
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Don't run the translate action if a PR comes from a fork. Forks don't have access to the SIMPLEEN secret, so the translate job always fails.

Code for conditionally skipping in a job is a fork comes from here: https://til.cazzulino.com/devops-ci-cd/how-to-skip-steps-or-jobs-in-github-actions-for-prs-from-forks