### PR TITLE
feat: add examples for CollectionTtl

### DIFF
--- a/docs/cache/develop/api-reference/collection-ttl.md
+++ b/docs/cache/develop/api-reference/collection-ttl.md
@@ -5,11 +5,19 @@ title: CollectionTTL API reference
 description: Learn how to interact with the CollectionTTL object in Momento Cache.
 ---
 
+import { SdkExampleTabs } from "@site/src/components/SdkExampleTabs";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleTabs to SdkExampleTabsImpl
+import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
+
 # CollectionTTL object API reference
 
-This object is passed into API methods to say whether a TTL should be updated and if so, what the new TTL value should be.
+The CollectionTtl type is used when performing write operations on a collection.
 
-This tries to make the process more intuitive by providing named constructors and copiers for various situations.
+Sometimes, when you update a collection, you want to refresh the TTL. Other times you want to keep the TTL the same. The
+CollectionTtl parameter allows you to specify this behavior.
+
+The default behavior is that the collection TTL is modified whenever a write operation occurs.
 
 See [Expire Data with TTL](./../../learn/how-it-works/expire-data-with-ttl.md) for more information on how TTL works with Momento Cache.
 
@@ -28,10 +36,31 @@ You cannot provide a CollectionTTL object when performing a read operation like 
 
 :::
 
-## Common method behaviors
+## Default Behavior
 
-- If a CollectionTTL is not passed in a function call, a default value of `CollectionTtl.fromCacheTtl()` will be used. This value is the TTL configured on the cache client. 
+- The `CollectionTtl` parameter is optional for all collection write operations.
+- If a CollectionTTL is not specified, a default value of `CollectionTtl.fromCacheTtl()` will be used. This value is the default TTL configured on the cache client. 
 - The TTL for the collection will be refreshed any time the collection is modified.
+
+## Examples
+
+If you need a behavior other than the default, you can provide a CollectionTtl object for any collection write operation.
+
+To specify an explicit TTL to refresh the collection to on a write operation, you can use `CollectionTtl.of()`:
+
+<SdkExampleTabs snippetId={'API_CollectionTtlOf'} />
+
+This is a convenience method that is equivalent to calling the constructor directly:
+
+<SdkExampleTabs snippetId={'API_CollectionTtlNew'} />
+
+If you want to specify a TTL that is only set when the collection is created, but not refreshed on subsequent writes, you can use `withNoRefreshTtlOnUpdates()`:
+
+<SdkExampleTabs snippetId={'API_CollectionTtlOfNoRefresh'} />
+
+This is also a convenience method that is equivalent to calling the constructor directly:
+
+<SdkExampleTabs snippetId={'API_CollectionTtlNewNoRefresh'} />
 
 ## Constructor parameters
 

--- a/docs/cache/develop/api-reference/dictionary-collections.md
+++ b/docs/cache/develop/api-reference/dictionary-collections.md
@@ -15,6 +15,13 @@ This page details the Momento API methods for the [dictionary collection data ty
 
 <img src="/img/dictionary-collections.jpg" width="90%" alt="a technical illustration of stacks of books. some dusty, so not. All collected into groups." />
 
+
+:::info
+
+Momento collection types use a [CollectionTTL](./collection-ttl.md) to specify their TTL behavior. This is an optional argument for all "write" operations.
+
+:::
+
 ## Dictionary methods
 
 ### DictionaryFetch

--- a/docs/cache/develop/api-reference/list-collections.md
+++ b/docs/cache/develop/api-reference/list-collections.md
@@ -17,6 +17,12 @@ This page details the Momento API methods for the [list collection data types](.
 
 ![a technical illustration of a scroll with lists of information. All collected into groups.](@site/static/img/list-collections.jpg)
 
+:::info
+
+Momento collection types use a [CollectionTTL](./collection-ttl.md) to specify their TTL behavior. This is an optional argument for all "write" operations.
+
+:::
+
 ## List methods
 
 ### ListFetch

--- a/docs/cache/develop/api-reference/set-collections.md
+++ b/docs/cache/develop/api-reference/set-collections.md
@@ -16,6 +16,12 @@ A set is a collection of elements, but each element can appear only once and ord
 
 ![a diagram of luggage as sets, but in any old order and not organized at all.](@site/static/img/sets.jpg)
 
+:::info
+
+Momento collection types use a [CollectionTTL](./collection-ttl.md) to specify their TTL behavior. This is an optional argument for all "write" operations.
+
+:::
+
 Example: if your set contains `[1, 2, 3]` and you add 2, the set remains `[1, 2, 3].`
 
 See [Sets](./../basics/datatypes.md#set-collections) for more information on their usage.

--- a/docs/cache/develop/api-reference/sorted-set-collections.md
+++ b/docs/cache/develop/api-reference/sorted-set-collections.md
@@ -16,6 +16,12 @@ A sorted set in Momento Cache is a collection of unique elements with a value (S
 
 ![A diagram of luggage as sets, but organized and stacked nicely.](@site/static/img/sorted-sets.jpg)
 
+:::info
+
+Momento collection types use a [CollectionTTL](./collection-ttl.md) to specify their TTL behavior. This is an optional argument for all "write" operations.
+
+:::
+
 ## Sorted set methods
 
 ### SortedSetPutElement


### PR DESCRIPTION
Based on some user feedback, we needed some examples and more
clarification around how CollectionTtl works; this commit adds
examples, plus an info box in each collection page.
