### PR TITLE
fix: collectionttl docs improvement and fix missing code snippets

### DIFF
--- a/docs/cache/develop/api-reference/auth.md
+++ b/docs/cache/develop/api-reference/auth.md
@@ -18,7 +18,7 @@ The auth APIs create and manage API keys and tokens for Momento services. These 
 
 <img src="/img/momento-auth-tokens.png" width="60%"/>
 
-## GenerateAuthToken API
+## GenerateApiKey API
 
 Generates a new Momento auth token with the specified permissions and expiry.
 
@@ -47,9 +47,9 @@ Tokens to access the Momento control plane APIs can only be generated using the 
 
 :::
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-## RefreshAuthToken API
+## RefreshApiKey API
 
 Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
 
@@ -71,7 +71,7 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ## TokenScope objects
 | Name            | Type                                      | Description                                  |

--- a/docs/cache/develop/api-reference/auth.md
+++ b/docs/cache/develop/api-reference/auth.md
@@ -20,7 +20,7 @@ The auth APIs create and manage API keys and tokens for Momento services. These 
 
 ## GenerateApiKey API
 
-Generates a new Momento auth token with the specified permissions and expiry.
+Generates a new Momento API key with the specified permissions and expiry.
 
 | Name            | Type                      | Description                                                                                                                                                                             |
 | --------------- |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -31,8 +31,8 @@ Generates a new Momento auth token with the specified permissions and expiry.
   <summary>Method response object</summary>
 
 * Success
-  - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh a token before it expires
+  - `apiKey`: string - the new API key
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshapikey-api) to refresh a token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -51,18 +51,18 @@ Tokens to access the Momento control plane APIs can only be generated using the 
 
 ## RefreshApiKey API
 
-Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
+Refreshes an existing, unexpired Momento API key.  Produces a new API key with the same permissions and expiry duration as the original API key.
 
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
-| refreshToken    | String          | The refreshToken for the current auth token, acquired from the original call to `GenerateAuthToken`. |
+| refreshToken    | String          | The refreshToken for the current API key, acquired from the original call to `GenerateApiKey`. |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-  - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh the token before it expires
+  - `apiKey`: string - the new API key
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshapikey-api) to refresh the token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error

--- a/docs/cache/develop/api-reference/collection-ttl.md
+++ b/docs/cache/develop/api-reference/collection-ttl.md
@@ -17,24 +17,28 @@ The CollectionTtl type is used when performing write operations on a collection.
 Sometimes, when you update a collection, you want to refresh the TTL. Other times you want to keep the TTL the same. The
 CollectionTtl parameter allows you to specify this behavior.
 
-The default behavior is that the collection TTL is modified whenever a write operation occurs.
+The default behavior is that the collection TTL is reset whenever a write operation occurs. You cannot provide a CollectionTTL object when performing a read operation like `dictionaryFetch` or `listLength`. 
 
 See [Expire Data with TTL](./../../learn/how-it-works/expire-data-with-ttl.md) for more information on how TTL works with Momento Cache.
 
+:::caution
+
+The CollectionTTL specifies the TTL for the entire collection, *not* for setting the TTL of individual elements within a collection. The elements within will not expire if the collection does not expire.
+
+:::
+
 ## Compatible data types
 
-The CollectionTTL object is compatible with the following data types *when performing write operations*:
+The CollectionTTL object is compatible with the following [collection data types](/cache/develop/basics/datatypes#collection-data-types-cdts) *when performing write operations*:
 
 * [Dictionary](../api-reference/dictionary-collections.md)
 * [List](../api-reference/list-collections.md)
 * [Set](../api-reference/set-collections.md)
 * [Sorted Set](../api-reference/sorted-set-collections.md)
 
-:::info
+As the image below illustrates, collections are considered `items` that may contain `elements`. 
 
-You cannot provide a CollectionTTL object when performing a read operation like `dictionaryFetch` or `listLength`. 
-
-:::
+<img src="/img/collection_data_types.png" alt="Collection data types drawing | Momento Cache" width="80%"/>
 
 ## Default Behavior
 
@@ -64,23 +68,23 @@ This is also a convenience method that is equivalent to calling the constructor 
 
 ## Constructor parameters
 
-- ttl: duration - (optional)
+- `ttl`: duration - (optional)
     * If no TTL is given, the TTL set in the current client connection object is used.
-- refreshTtl: boolean = true
+- `refreshTtl`: boolean = true
     * If set to true, the collection’s TTL will be reset to the provided value.
-    * If set to false, the existing TTL set on the item is retained.
+    * If set to false, the existing TTL set on the collection is retained.
 
 ## Additional constructors
 
-- fromCacheTtl(): CollectionTtl - uses the client’s TTL, equivalent to `CollectionTtl(null, true)`
-- of(ttl: duration): CollectionTtl - equivalent to `CollectionTtl(ttl, true)`
-- refreshTtlIfProvided(ttl?: duration): CollectionTtl - if a value is provided, it will refresh the item's TTL. If no value is provided, it will not refresh the TTL.
+- `fromCacheTtl()`: CollectionTtl - uses the client’s TTL, equivalent to `CollectionTtl(null, true)`
+- `of(ttl: duration)`: CollectionTtl - equivalent to `CollectionTtl(ttl, true)`
+- `refreshTtlIfProvided(ttl?: duration)`: CollectionTtl - if a value is provided, it will refresh the collection's TTL. If no value is provided, it will not refresh the TTL.
 
 ## Instance methods
 
-- ttlSeconds(): duration - Returns the TTL in seconds
-- ttlMilliseconds(): duration - Returns the TTL in milliseconds
-- refreshTtl(): boolean - Sets if the TTL should be refreshed when the item is modified
-- withRefreshTtlOnUpdates(): CollectionTtl - a copy, but refresh is true
-- withNoRefreshTtlOnUpdates(): CollectionTtl - a copy, but refresh is false
-- toString(): displays the TTL in seconds and the refreshTtl configuration
+- `ttlSeconds()`: duration - Returns the TTL in seconds
+- `ttlMilliseconds()`: duration - Returns the TTL in milliseconds
+- `refreshTtl()`: boolean - Sets if the TTL should be refreshed when the item is modified
+- `withRefreshTtlOnUpdates()`: CollectionTtl - a copy, but refresh is true
+- `withNoRefreshTtlOnUpdates()`: CollectionTtl - a copy, but refresh is false
+- `toString()`: displays the TTL in seconds and the refreshTtl configuration

--- a/docs/cache/develop/api-reference/sorted-set-collections.md
+++ b/docs/cache/develop/api-reference/sorted-set-collections.md
@@ -12,7 +12,7 @@ import { SdkExampleTabsImpl } from "@site/src/components/SdkExampleTabsImpl";
 
 # Sorted set collections
 
-A sorted set in Momento Cache is a collection of unique elements with a value (String, Byte[], etc.) and score (signed double 64-bit float) pair. The elements in the item are ordered by the score.
+A sorted set in Momento Cache is a collection of unique elements with a value (String, Byte[], etc.) and score (signed double 64-bit float) pair. The elements in a sorted set are ordered by score.
 
 ![A diagram of luggage as sets, but organized and stacked nicely.](@site/static/img/sorted-sets.jpg)
 
@@ -26,19 +26,19 @@ Momento collection types use a [CollectionTTL](./collection-ttl.md) to specify t
 
 ### SortedSetPutElement
 
-Adds a new or updates an existing [sorted set element](#sortedsetelement) in a sorted set item.
+Adds a new or updates an existing [sorted set element](#sortedsetelement) in a sorted set.
 
-- If the set does not exist, this method creates a new sorted set item with the element passed in.
+- If the set does not exist, this method creates a new sorted set collection with the element passed in.
 
 - If the set exists, the element is added to the sorted set if that **value** doesn't exist. If the value of that element does exist, that element is overwritten.
 
 | Name            | Type               | Description                                   |
 | --------------- | ------------------ | --------------------------------------------- |
 | cacheName       | String             | Name of the cache.                            |
-| setName         | String             | Name of the sorted set item to be altered. |
-| value        | String \| Byte[] | The value of the element to be added to the sorted set by this operation. |
-| score        | number | The score of the element to be added to the sorted set by this operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| setName         | String             | Name of the sorted set collection to be altered. |
+| value           | String \| Byte[]   | The value of the element to be added to the sorted set by this operation. |
+| score           | number             | The score of the element to be added to the sorted set by this operation. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set collection. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -54,18 +54,18 @@ See [response objects](./response-objects.md) for specific information.
 
 ### SortedSetPutElements
 
-Adds new or updates existing [sorted set elements](#sortedsetelement) in a sorted set item.
+Adds new or updates existing [sorted set elements](#sortedsetelement) in a sorted set collection.
 
-- If the set does not exist, this method creates a new sorted set item with the element(s) passed in.
+- If the set does not exist, this method creates a new sorted set collection with the element(s) passed in.
 
 - If the set exists, for each [SortedSetElement](#sortedsetelement) in the array, each element is added to the sorted set if that **value** doesn't exist. If the value of that element does exist, that element is overwritten.
 
 | Name            | Type               | Description                                   |
 | --------------- | ------------------ | --------------------------------------------- |
 | cacheName       | String             | Name of the cache.                            |
-| setName         | String             | Name of the sorted set item to be altered. |
+| setName         | String             | Name of the sorted set collection to be altered. |
 | elements        | [SortedSetElement](#sortedsetelement)[] | Elements to be added to the sorted set by this operation. |
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set collection. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -86,7 +86,7 @@ Fetch elements of sorted set, optionally filtered by rank, and return them in as
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the sorted set item. |
+| setName         | String          | Name of the sorted set collection. |
 | startRank | Optional[integer]   | The inclusive start rank of the results. Default is zero. |
 | endRank | Optional[integer]   | The exclusive end rank of the results. Default is `null`, ie up to and including the element ranked last. |
 | order           | Ascending \| Descending | The order you want the sorted set returned. |
@@ -112,7 +112,7 @@ Fetch elements of sorted set, optionally filtered by score, and return them in a
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the sorted set item. |
+| setName         | String          | Name of the sorted set collection. |
 | minScore | Optional[double]   | The inclusive low score of the results. Default is `-inf`, ie include through the lowest score. |
 | maxScore | Optional[double]   | The inclusive high score of the results. Default is `+inf`, ie include through the highest score. |
 | order           | Ascending \| Descending | The order you want the sorted set returned. |
@@ -140,7 +140,7 @@ Gets an element's score from the sorted set, indexed by value.
 | Name             | Type                | Description                                   |
 | ---------------- | ------------------- | --------------------------------------------- |
 | cacheName        | String              | Name of the cache.                            |
-| setName          | String              | Name of the sorted set item. |
+| setName          | String              | Name of the sorted set collection. |
 | value           | String \| Bytes | The value to get the score of. |
 
 <details>
@@ -164,7 +164,7 @@ Gets the scores associated with a list of elements from the sorted set, indexed 
 | Name             | Type                | Description                                   |
 | ---------------- | ------------------- | --------------------------------------------- |
 | cacheName        | String              | Name of the cache.                            |
-| setName          | String              | Name of the sorted set item. |
+| setName          | String              | Name of the sorted set collection. |
 | values           | String[] \| Bytes[] | An array of values to get the score of. |
 
 <details>
@@ -191,7 +191,7 @@ Removes an element from a sorted set, indexed by value.
 | Name            | Type             | Description                                   |
 | --------------- | ---------------- | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
-| setName         | String           | Name of the set item to be altered. |
+| setName         | String           | Name of the set collection to be altered. |
 | value          | String \| Bytes | Value of the element to be removed by this operation. |
 
 <details>
@@ -213,7 +213,7 @@ Removes elements from a sorted set, indexed by values.
 | Name            | Type             | Description                                   |
 | --------------- | ---------------- | --------------------------------------------- |
 | cacheName       | String           | Name of the cache.                            |
-| setName         | String           | Name of the set item to be altered. |
+| setName         | String           | Name of the set collection to be altered. |
 | values          | String[] \| Bytes[] | Values of the elements to be removed by this operation. |
 
 You can remove either one or a specific group of elements.
@@ -237,7 +237,7 @@ What position is the element, in the specified sorted set?
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the sorted set item to be altered.    |
+| setName         | String          | Name of the sorted set collection to be altered.    |
 | value           | String \| Bytes | Value of the element to retrieve the score of. |
 
 <details>
@@ -272,10 +272,10 @@ Examples:
 | Name            | Type            | Description                                   |
 | --------------- | --------------- | --------------------------------------------- |
 | cacheName       | String          | Name of the cache.                            |
-| setName         | String          | Name of the sorted set item to be altered. |
+| setName         | String          | Name of the sorted set collection to be altered. |
 | value           | String \| Bytes | Value for the element to be incremented by this operation. |
 | amount          | Number          | The quantity to add to the score. May be positive, negative, or zero. Defaults to 1. |          
-| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set item. This TTL takes precedence over the TTL used when initializing a cache connection client. |
+| ttl             | [CollectionTTL object](./collection-ttl.md) | TTL for the sorted set collection. This TTL takes precedence over the TTL used when initializing a cache connection client. |
 
 <details>
   <summary>Method response object</summary>
@@ -305,12 +305,12 @@ Example:
 A SortedSetElement can exist by itself or as part of an array of SortedSetElements.
 
 ### SortedSetLength
-Get the number of entries in a sorted set item.
+Get the number of entries in a sorted set collection.
 
 | Name           | Type         | Description                                |
 |----------------| ------------ |--------------------------------------------|
 | cacheName      | String       | Name of the cache.                         |
-| sortedSetName | String       | Name of the sorted set item to be checked. |
+| sortedSetName | String       | Name of the sorted set collection to be checked. |
 
 <details>
   <summary>Method response object</summary>
@@ -327,12 +327,12 @@ See [response objects](./response-objects.md) for specific information.
 <SdkExampleTabs snippetId={'API_SortedSetLength'} />
 
 ### SortedSetLengthByScore
-For an existing sorted set item, it finds all of the values between the specified min and max score and returns the length.
+For an existing sorted set collection, it finds all of the values between the specified min and max score and returns the length.
 
 | Name           | Type         | Description                                |
 |----------------| ------------ |--------------------------------------------|
 | cacheName      | String       | Name of the cache.                         |
-| sortedSetName | String       | Name of the sorted set item to be checked. |
+| sortedSetName | String       | Name of the sorted set collection to be checked. |
 | minScore | Optional[double]   | The inclusive low score of the results. Default is `-inf`, ie include through the lowest score. |
 | maxScore | Optional[double]   | The inclusive high score of the results. Default is `+inf`, ie include through the highest score. |
 

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -158,7 +158,7 @@ const CACHE_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Scalars',
     groupDescription: 'A matrix of SDK support for Momento scalar APIs',
-    apis: ['get', 'set', 'setIfNotExists', 'increment'],
+    apis: ['get', 'set', 'delete', 'setIfNotExists', 'increment'],
   },
   {
     groupName: 'Lists',

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -53,7 +53,7 @@ const SDKS: Array<SdkInfo> = [
     cacheClientFile: 'src/Momento.Sdk/ICacheClient.cs',
     configObjectFile: 'src/Momento.Sdk/Config/Configuration.cs',
     topicClientFile: 'src/Momento.Sdk/ITopicClient.cs',
-    authClientFile: undefined,
+    authClientFile: 'src/Momento.Sdk/IAuthClient.cs',
     leaderboardClientFile: undefined,
   },
   {

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/javascript-snippet-source-parser.ts
@@ -15,6 +15,7 @@ export class JavascriptSnippetSourceParser extends RegexSnippetSourceParser {
       'examples/nodejs/observability/advanced-logging.ts',
       'examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts',
       'examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts',
+      'examples/nodejs/cache/doc-example-files/collection-ttl.ts',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/598

Also had to add a couple files and rename some snippetIds to account for missing collectionTtl and auth-related code snippets. Also includes a little more "auth token" -> "api key" fixes on the Auth API reference page.