### PR TITLE
chore: Clarify 2:1 ratio for operations throttling

### DIFF
--- a/docs/cache/manage/limits.md
+++ b/docs/cache/manage/limits.md
@@ -42,24 +42,24 @@ The below table describes how the number of operations is calculated for all cac
 | Ping                     |           | 1                                                                 |
 | ItemGetType              |           | 1                                                                 |
 | KeyExists                |           | 1                                                                 |
-| KeysExist                | X         | Number of keys in request/2                                       |
+| KeysExist                | ✅        | Number of keys in request/2                                       |
 | SetIfNotExists           |           | 1                                                                 |
 | UpdateTtl                |           | 1                                                                 |
 | IncreaseTtl              |           | 1                                                                 |
 | DecreaseTtl              |           | 1                                                                 |
 | ItemGetTtl               |           | 1                                                                 |
-| DictionaryFetch          | X         | Number of fields in response/2, or 1 if dictionary is not found   |
+| DictionaryFetch          | ✅        | Number of fields in response/2, or 1 if dictionary is not found   |
 | DictionaryGetField       |           | 1                                                                 |
-| DictionaryGetFields      | X         | Number of fields in request/2                                     |
+| DictionaryGetFields      | ✅        | Number of fields in request/2                                     |
 | DictionaryIncrement      |           | 1                                                                 |
 | DictionaryRemoveField    |           | 1                                                                 |
-| DictionaryRemoveFields   | X         | Number of fields in request/2                                     |
+| DictionaryRemoveFields   | ✅        | Number of fields in request/2                                     |
 | DictionarySetField       |           | 1                                                                 |
-| DictionarySetFields      | X         | Number of fields in request/2                                     |
+| DictionarySetFields      | ✅        | Number of fields in request/2                                     |
 | DictionaryLength         |           | 1                                                                 |
-| ListFetch                | X         | Number of elements in response/2, or 1 if list is not found       |
-| ListConcatenateBack      | X         | Number of elements in request/2                                   |
-| ListConcatenateFront     | X         | Number of elements in request/2                                   |
+| ListFetch                | ✅        | Number of elements in response/2, or 1 if list is not found       |
+| ListConcatenateBack      | ✅        | Number of elements in request/2                                   |
+| ListConcatenateFront     | ✅        | Number of elements in request/2                                   |
 | ListLength               |           | 1                                                                 |
 | ListPopBack              |           | 1                                                                 |
 | ListPopFront             |           | 1                                                                 |
@@ -68,21 +68,21 @@ The below table describes how the number of operations is calculated for all cac
 | ListRemoveValue          |           | 1                                                                 |
 | ListRetain               |           | 1                                                                 |
 | SetAddElement            |           | 1                                                                 |
-| SetAddElements           | X         | Number of elements in request/2                                   |
-| SetFetch                 | X         | Number of elements in response/2, or 1 if set is not found        |
-| SetRemoveElement         | X         | 1                                                                 |
-| SetRemoveElements        | X         | Number of elements in request/2                                   |
+| SetAddElements           | ✅        | Number of elements in request/2                                   |
+| SetFetch                 | ✅        | Number of elements in response/2, or 1 if set is not found        |
+| SetRemoveElement         |           | 1                                                                 |
+| SetRemoveElements        | ✅        | Number of elements in request/2                                   |
 | SetContainsElement       |           | 1                                                                 |
-| SetContainsElements      | X         | Number of elements in request/2                                   |
+| SetContainsElements      | ✅        | Number of elements in request/2                                   |
 | SetLength                |           | 1                                                                 |
 | SortedSetPutElement      |           | 1                                                                 |
-| SortedSetPutElements     | X         | Number of elements in request/2                                   |
-| SortedSetFetchByRank     | X         | Number of elements in response/2, or 1 if sorted set is not found |
-| SortedSetFetchByScore    | X         | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetPutElements     | ✅        | Number of elements in request/2                                   |
+| SortedSetFetchByRank     | ✅        | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetFetchByScore    | ✅        | Number of elements in response/2, or 1 if sorted set is not found |
 | SortedSetGetScore        |           | 1                                                                 |
-| SortedSetGetScores       | X         | Number of elements in request/2                                   |
+| SortedSetGetScores       | ✅        | Number of elements in request/2                                   |
 | SortedSetRemoveElement   |           | 1                                                                 |
-| SortedSetRemoveElements  | X         | Number of elements in request/2                                   |
+| SortedSetRemoveElements  | ✅        | Number of elements in request/2                                   |
 | SortedSetGetRank         |           | 1                                                                 |
 | SortedSetIncrementScore  |           | 1                                                                 |
 | SortedSetLength          |           | 1                                                                 |

--- a/docs/cache/manage/limits.md
+++ b/docs/cache/manage/limits.md
@@ -27,61 +27,63 @@ The limits on this page are soft limits that can be altered unless specifically 
 
 ## Operations
 
-Service limits are based on the number of operations performed per second. Some cache data plane APIs can perform multiple operations in a single request. Since batch operations are more efficient, the limit cost of these APIs is discounted at a 2:1 ratio. This means every two elements will count as one operation towards the limiter. For example, a `SetAddElements` request adding one or two elements costs one operation, but with three or four elements it costs two operations, etc.
+Service limits are based on the number of operations performed per second. Some cache data plane APIs can perform multiple operations in a single request.
+
+Since batch operations are more efficient, the limit cost of these APIs is discounted at a **2:1 ratio**. This means every two elements will count as one operation towards the limiter. For example, a `SetAddElements` request adding one or two elements costs one operation, but with three or four elements it costs two operations, etc.
 
 The below table describes how the number of operations is calculated for all cache APIs.
 
-| API                      | Operations                                                      |
-| ------------------------ | ------------                                                    |
-| Set                      | 1                                                               |
-| Get                      | 1                                                               |
-| Delete                   | 1                                                               |
-| Increment                | 1                                                               |
-| Ping                     | 1                                                               |
-| ItemGetType              | 1                                                               |
-| KeyExists                | 1                                                               |
-| KeysExist                | Number of keys in request                                       |
-| SetIfNotExists           | 1                                                               |
-| UpdateTtl                | 1                                                               |
-| IncreaseTtl              | 1                                                               |
-| DecreaseTtl              | 1                                                               |
-| ItemGetTtl               | 1                                                               |
-| DictionaryFetch          | Number of fields in response, or 1 if dictionary is not found   |
-| DictionaryGetField       | 1                                                               |
-| DictionaryGetFields      | Number of fields in request                                     |
-| DictionaryIncrement      | 1                                                               |
-| DictionaryRemoveField    | 1                                                               |
-| DictionaryRemoveFields   | Number of fields in request                                     |
-| DictionarySetField       | 1                                                               |
-| DictionarySetFields      | Number of fields in request                                     |
-| DictionaryLength         | 1                                                               |
-| ListFetch                | Number of elements in response, or 1 if list is not found       |
-| ListConcatenateBack      | Number of elements in request                                   |
-| ListConcatenateFront     | Number of elements in request                                   |
-| ListLength               | 1                                                               |
-| ListPopBack              | 1                                                               |
-| ListPopFront             | 1                                                               |
-| ListPushBack             | 1                                                               |
-| ListPushFront            | 1                                                               |
-| ListRemoveValue          | 1                                                               |
-| ListRetain               | 1                                                               |
-| SetAddElement            | 1                                                               |
-| SetAddElements           | Number of elements in request                                   |
-| SetFetch                 | Number of elements in response, or 1 if set is not found        |
-| SetRemoveElement         | 1                                                               |
-| SetRemoveElements        | Number of elements in request                                   |
-| SetContainsElement       | 1                                                               |
-| SetContainsElements      | Number of elements in request                                   |
-| SetLength                | 1                                                               |
-| SortedSetPutElement      | 1                                                               |
-| SortedSetPutElements     | Number of elements in request                                   |
-| SortedSetFetchByRank     | Number of elements in response, or 1 if sorted set is not found |
-| SortedSetFetchByScore    | Number of elements in response, or 1 if sorted set is not found |
-| SortedSetGetScore        | 1                                                               |
-| SortedSetGetScores       | Number of elements in request                                   |
-| SortedSetRemoveElement   | 1                                                               |
-| SortedSetRemoveElements  | Number of elements in request                                   |
-| SortedSetGetRank         | 1                                                               |
-| SortedSetIncrementScore  | 1                                                               |
-| SortedSetLength          | 1                                                               |
-| SortedSetLengthByScore   | 1                                                               |
+| API Name                 | Batch API | Operations                                                        |
+| ------------------------ | ----      | ------------                                                      |
+| Set                      |           | 1                                                                 |
+| Get                      |           | 1                                                                 |
+| Delete                   |           | 1                                                                 |
+| Increment                |           | 1                                                                 |
+| Ping                     |           | 1                                                                 |
+| ItemGetType              |           | 1                                                                 |
+| KeyExists                |           | 1                                                                 |
+| KeysExist                | X         | Number of keys in request/2                                       |
+| SetIfNotExists           |           | 1                                                                 |
+| UpdateTtl                |           | 1                                                                 |
+| IncreaseTtl              |           | 1                                                                 |
+| DecreaseTtl              |           | 1                                                                 |
+| ItemGetTtl               |           | 1                                                                 |
+| DictionaryFetch          | X         | Number of fields in response/2, or 1 if dictionary is not found   |
+| DictionaryGetField       |           | 1                                                                 |
+| DictionaryGetFields      | X         | Number of fields in request/2                                     |
+| DictionaryIncrement      |           | 1                                                                 |
+| DictionaryRemoveField    |           | 1                                                                 |
+| DictionaryRemoveFields   | X         | Number of fields in request/2                                     |
+| DictionarySetField       |           | 1                                                                 |
+| DictionarySetFields      | X         | Number of fields in request/2                                     |
+| DictionaryLength         |           | 1                                                                 |
+| ListFetch                | X         | Number of elements in response/2, or 1 if list is not found       |
+| ListConcatenateBack      | X         | Number of elements in request/2                                   |
+| ListConcatenateFront     | X         | Number of elements in request/2                                   |
+| ListLength               |           | 1                                                                 |
+| ListPopBack              |           | 1                                                                 |
+| ListPopFront             |           | 1                                                                 |
+| ListPushBack             |           | 1                                                                 |
+| ListPushFront            |           | 1                                                                 |
+| ListRemoveValue          |           | 1                                                                 |
+| ListRetain               |           | 1                                                                 |
+| SetAddElement            |           | 1                                                                 |
+| SetAddElements           | X         | Number of elements in request/2                                   |
+| SetFetch                 | X         | Number of elements in response/2, or 1 if set is not found        |
+| SetRemoveElement         | X         | 1                                                                 |
+| SetRemoveElements        | X         | Number of elements in request/2                                   |
+| SetContainsElement       |           | 1                                                                 |
+| SetContainsElements      | X         | Number of elements in request/2                                   |
+| SetLength                |           | 1                                                                 |
+| SortedSetPutElement      |           | 1                                                                 |
+| SortedSetPutElements     | X         | Number of elements in request/2                                   |
+| SortedSetFetchByRank     | X         | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetFetchByScore    | X         | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetGetScore        |           | 1                                                                 |
+| SortedSetGetScores       | X         | Number of elements in request/2                                   |
+| SortedSetRemoveElement   |           | 1                                                                 |
+| SortedSetRemoveElements  | X         | Number of elements in request/2                                   |
+| SortedSetGetRank         |           | 1                                                                 |
+| SortedSetIncrementScore  |           | 1                                                                 |
+| SortedSetLength          |           | 1                                                                 |
+| SortedSetLengthByScore   |           | 1                                                                 |

--- a/docs/cache/manage/limits.md
+++ b/docs/cache/manage/limits.md
@@ -29,7 +29,7 @@ The limits on this page are soft limits that can be altered unless specifically 
 
 Service limits are based on the number of operations performed per second. Some cache data plane APIs can perform multiple operations in a single request.
 
-Since batch operations are more efficient, the limit cost of these APIs is discounted at a **2:1 ratio**. This means every two elements will count as one operation towards the limiter. For example, a `SetAddElements` request adding one or two elements costs one operation, but with three or four elements it costs two operations, etc.
+Since multi-element operations are more efficient, the limit cost of these APIs is discounted at a **2:1 ratio**. This means every two elements will count as one operation towards the limiter. For example, a `SetAddElements` request adding one or two elements costs one operation, but with three or four elements it costs two operations, etc.
 
 The below table describes how the number of operations is calculated for all cache APIs.
 

--- a/docs/cache/manage/limits.md
+++ b/docs/cache/manage/limits.md
@@ -33,57 +33,57 @@ Since batch operations are more efficient, the limit cost of these APIs is disco
 
 The below table describes how the number of operations is calculated for all cache APIs.
 
-| API Name                 | Batch API | Operations                                                        |
-| ------------------------ | ----      | ------------                                                      |
-| Set                      |           | 1                                                                 |
-| Get                      |           | 1                                                                 |
-| Delete                   |           | 1                                                                 |
-| Increment                |           | 1                                                                 |
-| Ping                     |           | 1                                                                 |
-| ItemGetType              |           | 1                                                                 |
-| KeyExists                |           | 1                                                                 |
-| KeysExist                | ✅        | Number of keys in request/2                                       |
-| SetIfNotExists           |           | 1                                                                 |
-| UpdateTtl                |           | 1                                                                 |
-| IncreaseTtl              |           | 1                                                                 |
-| DecreaseTtl              |           | 1                                                                 |
-| ItemGetTtl               |           | 1                                                                 |
-| DictionaryFetch          | ✅        | Number of fields in response/2, or 1 if dictionary is not found   |
-| DictionaryGetField       |           | 1                                                                 |
-| DictionaryGetFields      | ✅        | Number of fields in request/2                                     |
-| DictionaryIncrement      |           | 1                                                                 |
-| DictionaryRemoveField    |           | 1                                                                 |
-| DictionaryRemoveFields   | ✅        | Number of fields in request/2                                     |
-| DictionarySetField       |           | 1                                                                 |
-| DictionarySetFields      | ✅        | Number of fields in request/2                                     |
-| DictionaryLength         |           | 1                                                                 |
-| ListFetch                | ✅        | Number of elements in response/2, or 1 if list is not found       |
-| ListConcatenateBack      | ✅        | Number of elements in request/2                                   |
-| ListConcatenateFront     | ✅        | Number of elements in request/2                                   |
-| ListLength               |           | 1                                                                 |
-| ListPopBack              |           | 1                                                                 |
-| ListPopFront             |           | 1                                                                 |
-| ListPushBack             |           | 1                                                                 |
-| ListPushFront            |           | 1                                                                 |
-| ListRemoveValue          |           | 1                                                                 |
-| ListRetain               |           | 1                                                                 |
-| SetAddElement            |           | 1                                                                 |
-| SetAddElements           | ✅        | Number of elements in request/2                                   |
-| SetFetch                 | ✅        | Number of elements in response/2, or 1 if set is not found        |
-| SetRemoveElement         |           | 1                                                                 |
-| SetRemoveElements        | ✅        | Number of elements in request/2                                   |
-| SetContainsElement       |           | 1                                                                 |
-| SetContainsElements      | ✅        | Number of elements in request/2                                   |
-| SetLength                |           | 1                                                                 |
-| SortedSetPutElement      |           | 1                                                                 |
-| SortedSetPutElements     | ✅        | Number of elements in request/2                                   |
-| SortedSetFetchByRank     | ✅        | Number of elements in response/2, or 1 if sorted set is not found |
-| SortedSetFetchByScore    | ✅        | Number of elements in response/2, or 1 if sorted set is not found |
-| SortedSetGetScore        |           | 1                                                                 |
-| SortedSetGetScores       | ✅        | Number of elements in request/2                                   |
-| SortedSetRemoveElement   |           | 1                                                                 |
-| SortedSetRemoveElements  | ✅        | Number of elements in request/2                                   |
-| SortedSetGetRank         |           | 1                                                                 |
-| SortedSetIncrementScore  |           | 1                                                                 |
-| SortedSetLength          |           | 1                                                                 |
-| SortedSetLengthByScore   |           | 1                                                                 |
+| API Name                 | Multi-Element API | Operations                                                        |
+| ------------------------ | ----              | ------------                                                      |
+| Set                      |                   | 1                                                                 |
+| Get                      |                   | 1                                                                 |
+| Delete                   |                   | 1                                                                 |
+| Increment                |                   | 1                                                                 |
+| Ping                     |                   | 1                                                                 |
+| ItemGetType              |                   | 1                                                                 |
+| KeyExists                |                   | 1                                                                 |
+| KeysExist                | ✅                | Number of keys in request/2                                       |
+| SetIfNotExists           |                   | 1                                                                 |
+| UpdateTtl                |                   | 1                                                                 |
+| IncreaseTtl              |                   | 1                                                                 |
+| DecreaseTtl              |                   | 1                                                                 |
+| ItemGetTtl               |                   | 1                                                                 |
+| DictionaryFetch          | ✅                | Number of fields in response/2, or 1 if dictionary is not found   |
+| DictionaryGetField       |                   | 1                                                                 |
+| DictionaryGetFields      | ✅                | Number of fields in request/2                                     |
+| DictionaryIncrement      |                   | 1                                                                 |
+| DictionaryRemoveField    |                   | 1                                                                 |
+| DictionaryRemoveFields   | ✅                | Number of fields in request/2                                     |
+| DictionarySetField       |                   | 1                                                                 |
+| DictionarySetFields      | ✅                | Number of fields in request/2                                     |
+| DictionaryLength         |                   | 1                                                                 |
+| ListFetch                | ✅                | Number of elements in response/2, or 1 if list is not found       |
+| ListConcatenateBack      | ✅                | Number of elements in request/2                                   |
+| ListConcatenateFront     | ✅                | Number of elements in request/2                                   |
+| ListLength               |                   | 1                                                                 |
+| ListPopBack              |                   | 1                                                                 |
+| ListPopFront             |                   | 1                                                                 |
+| ListPushBack             |                   | 1                                                                 |
+| ListPushFront            |                   | 1                                                                 |
+| ListRemoveValue          |                   | 1                                                                 |
+| ListRetain               |                   | 1                                                                 |
+| SetAddElement            |                   | 1                                                                 |
+| SetAddElements           | ✅                | Number of elements in request/2                                   |
+| SetFetch                 | ✅                | Number of elements in response/2, or 1 if set is not found        |
+| SetRemoveElement         |                   | 1                                                                 |
+| SetRemoveElements        | ✅                | Number of elements in request/2                                   |
+| SetContainsElement       |                   | 1                                                                 |
+| SetContainsElements      | ✅                | Number of elements in request/2                                   |
+| SetLength                |                   | 1                                                                 |
+| SortedSetPutElement      |                   | 1                                                                 |
+| SortedSetPutElements     | ✅                | Number of elements in request/2                                   |
+| SortedSetFetchByRank     | ✅                | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetFetchByScore    | ✅                | Number of elements in response/2, or 1 if sorted set is not found |
+| SortedSetGetScore        |                   | 1                                                                 |
+| SortedSetGetScores       | ✅                | Number of elements in request/2                                   |
+| SortedSetRemoveElement   |                   | 1                                                                 |
+| SortedSetRemoveElements  | ✅                | Number of elements in request/2                                   |
+| SortedSetGetRank         |                   | 1                                                                 |
+| SortedSetIncrementScore  |                   | 1                                                                 |
+| SortedSetLength          |                   | 1                                                                 |
+| SortedSetLengthByScore   |                   | 1                                                                 |


### PR DESCRIPTION
Based on feedback from @cprice404
- separate and bold the 2:1 ratio of operations/request used for throttling
- add a column to the table for whether the api is a "batch" api or not
- include that these operations are weighted at /2 in the table
