### PR TITLE
chore: add style guide for node.js

### DIFF
--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -64,6 +64,7 @@ The Momento Web SDK allows you to create rich browser applications in TypeScript
   gap: '10px'
 }}>
   <LinkButton text="Overview" link="/sdks/web"/>
+  <LinkButton text="Style Guide" link="/sdks/nodejs/style-guide.html"/>
   <LinkButton text="Cache" link="/sdks/nodejs/cache.html"/>
   <LinkButton text="Topics" link="/sdks/nodejs/topics.html"/>
   <LinkButton text="Vector Index" link="/sdks/nodejs/vector-index.html"/>
@@ -148,6 +149,7 @@ Momento server-side SDKs allow you to take advantage of Momento's low-latency Ca
   gap: '10px'
 }}>
   <LinkButton text="Overview" link="/sdks/nodejs"/>
+  <LinkButton text="Style Guide" link="/sdks/nodejs/style-guide.html"/>
   <LinkButton text="Cache" link="/sdks/nodejs/cache.html"/>
   <LinkButton text="Topics" link="/sdks/nodejs/topics.html"/>
   <LinkButton text="Vector Index" link="/sdks/nodejs/vector-index.html"/>

--- a/docs/sdks/nodejs/cache.mdx
+++ b/docs/sdks/nodejs/cache.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 sidebar_label: Cache
 title: Getting started with Momento Cache in JavaScript
 description: Learn the basic building blocks for writing TypeScript and JavaScript code to interact with Momento Cache.

--- a/docs/sdks/nodejs/config-and-error-handling.mdx
+++ b/docs/sdks/nodejs/config-and-error-handling.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 sidebar_label: Config and Error Handling
 title: Manage Momento Configuration and Error Handling in TypeScript and Node.js
 description: Learn how to configure your Momento CacheClient and write production-ready error handling code in TypeScript and Node.js

--- a/docs/sdks/nodejs/index.md
+++ b/docs/sdks/nodejs/index.md
@@ -44,6 +44,7 @@ The source code can be found on GitHub: [momentohq/client-sdk-javascript](https:
 - [Getting started with Momento Cache in JavaScript](/sdks/nodejs/cache.mdx)
 - [Getting started with Momento Topics in JavaScript](/sdks/nodejs/topics.mdx)
 - [Node.js SDK Configuration and Error Handling](./config-and-error-handling.mdx): Taking your code to production
+- [Node.js SDK Style Guide](./style-guide.mdx): Learn about the two different code styles you can use to interact with Momento
 - [Node.js SDK Observability](./observability.mdx): Logging and Client-side Metrics with the Node.js SDK
 
 ## Integrations

--- a/docs/sdks/nodejs/observability.mdx
+++ b/docs/sdks/nodejs/observability.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 sidebar_label: Observability
 title: Observe your Momento Cache client metrics in TypeScript and Node.js
 description: Learn how to improve observability of your Momento Cache client by configuring logging, client-side metrics, and traces.

--- a/docs/sdks/nodejs/style-guide.mdx
+++ b/docs/sdks/nodejs/style-guide.mdx
@@ -1,0 +1,79 @@
+import { SdkExampleTabs } from "../../../src/components/SdkExampleTabs";
+---
+sidebar_position: 2
+sidebar_label: Style Guide
+title: Style guide for Momento Node.js code
+description: Learn about the two different styles you can use when writing Momento Node.js code: the pattern matching style, or the simplified style.
+keywords:
+  - momento
+  - cache
+  - configuration
+  - error handling
+  - exceptions
+  - sdk
+  - production ready
+  - typescript
+  - node.js
+  - nodejs
+  - javascript
+  - style guide
+  - style
+  - pattern matching
+  - undefined
+---
+
+import { SdkExampleCodeBlock } from "@site/src/components/SdkExampleCodeBlock";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleCodeBlock to SdkExampleCodeBlockImpl
+import { SdkExampleCodeBlockImpl } from "@site/src/components/SdkExampleCodeBlockImpl";
+
+# Momento Node.js Style Guide
+
+When writing Momento Node.js code, you can choose between two different styles: the pattern matching style, or the simplified style. This guide will help you understand the differences between the two styles, so that you can choose which one will work best for your project.
+
+## Pattern matching style
+
+If you're not familiar with pattern matching, it is a mechanism that has become increasingly popular in modern programming languages. It allows you to match a value against a pattern to determine the type of the value, and then extract its properties. It's very useful when making network requests, where the type of the response can vary a great deal depending on whether the request was successful or not, because it gives you a way to write exhaustive, type-safe code that handles all possible response types.
+
+For example, when you issue a Momento `get` request (or any other cache read request), the response can be one of three types:
+
+* `Hit` - the key was found in the cache, and the value was returned
+* `Miss` - the key was not found in the cache, so no value was returned
+* `Error` - an error occurred while trying to read the value from the cache
+
+As you can imagine, a type-safe model of these different cases will expose very different properties depending on which type of response you recieve:
+* A `Hit` response will have a `value` property - and it is guaranteed not to be `undefined`, so you don't have to write any `if` statements to handle the `undefined` case.
+* A `Miss` response will have no properties because no value was returned.
+* An `Error` response will have an `errorCode` property, indicating what type of error occurred.
+
+Using pattern matching, you can write code like this:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'configuration_ErrorHandlingHitMiss'} />
+
+In each branch of the `if` statement, the TypeScript compiler is smart enough to recognize that it now knows the exact type of the `result` object, so it will give you access to the correct properties based on which type it is. Because of this, you can catch many types of errors at compile time rather than finding out about them at run time. It also gives you a safer way to interact with the error objects than a normal try/catch block would.
+
+If your primary goal is to write thorough, production-ready code with exhaustive handling of each different type of response you might receive for a request, then this pattern matching style is the way to go.
+
+However, it can be more verbose and take longer to write than code you might be used to writing against other client libraries. If you prefer something more succinct, you might want to consider the simplified style.
+
+## Simplified style
+
+With the simplified style, you won't be doing any pattern matching or type checking. Instead, you will simply call the `.value()` method on the response object. For the case of a `Hit`, you will get the value back; otherwise you will get back an `undefined`.
+
+When using the simplified style you will probably want to enable the `withThrowOnErrors` setting. By default, Momento always returns errors as part of the return value, as opposed to throwing them. But when using the simplified code style, if you call `.value()` on a response and you get back `undefined`, you won't be able to tell if the response was a `Miss` or an `Error`. By enabling `withThrowOnErrors`, you can tell the Momento client that you prefer for it to actually throw the errors when they occur.
+
+Here's how to enable `withThrowOnErrors`:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'configuration_ConstructWithThrowOnErrorsConfig'} />
+
+For more information on this topic, see the [Configuration and Error Handling](./config-and-error-handling.mdx) page.
+
+Once you've enabled `withThrowOnErrors`, you can write code like this:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'configuration_SimplifiedGet'} />
+
+And if an error occurs, it will be thrown as an exception. You can catch the exception and handle it with a normal try/catch block, like this:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'configuration_ErrorHandlingExceptionErrorCode'} />
+
+The simplified style probably looks and feels more familiar to you compared to other Node.js client libraries you might have used in the past. It's also more succinct and faster to write than the pattern matching style. If you prefer to write code that is more concise, and you don't mind the trade-off of not having exhaustive type checking, then this style may be the right fit for you!

--- a/docs/sdks/nodejs/style-guide.mdx
+++ b/docs/sdks/nodejs/style-guide.mdx
@@ -1,9 +1,8 @@
-import { SdkExampleTabs } from "../../../src/components/SdkExampleTabs";
 ---
 sidebar_position: 2
 sidebar_label: Style Guide
 title: Style guide for Momento Node.js code
-description: Learn about the two different styles you can use when writing Momento Node.js code: the pattern matching style, or the simplified style.
+description: "Learn about the two different styles you can use when writing Momento Node.js code: the pattern matching style, or the simplified style."
 keywords:
   - momento
   - cache

--- a/docs/sdks/nodejs/topics.mdx
+++ b/docs/sdks/nodejs/topics.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 sidebar_label: Topics
 title: Getting started with Momento Topics in JavaScript
 description: Learn the basic building blocks for writing TypeScript and JavaScript code to interact with Momento Topics.

--- a/docs/sdks/nodejs/vector-index.md
+++ b/docs/sdks/nodejs/vector-index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 5
 sidebar_label: Vector Index
 title: Getting started with Momento Vector Index in JavaScript
 description: Learn the basic building blocks for writing TypeScript and JavaScript code to interact with Momento Vector Index.


### PR DESCRIPTION
This commit adds a new page, "Style Guide", for the node.js SDK.
It explains the tradeoffs between our traditional "pattern matching"
code style, vs. a more traditional "simplified" code style.
