### PR TITLE
fix broken reference in nodejs sdk docs

### DIFF
--- a/docs/sdks/nodejs/style-guide.mdx
+++ b/docs/sdks/nodejs/style-guide.mdx
@@ -65,7 +65,7 @@ Here's how to enable `withThrowOnErrors`:
 
 <SdkExampleCodeBlock language={'javascript'} snippetId={'configuration_ConstructWithThrowOnErrorsConfig'} />
 
-For more information on this topic, see the [Configuration and Error Handling](./config-and-error-handling.mdx) page.
+For more information on this topic, see the [Configuration and Error Handling](./config-and-error-handling) page.
 
 Once you've enabled `withThrowOnErrors`, you can write code like this:
 


### PR DESCRIPTION
See [discussion](https://gomomento.slack.com/archives/C037XLHFC79/p1708198720286379) in Slack. This fixes the issue that is blocking #734.

I'm not sure what the implications are of removing the file suffix. Including the suffix is a fairly common practice across the repo:
```
tvald@Tonys-MacBook-Pro public-dev-docs % grep -o -e '](\([.][^)]\+\)\+\([^.)]\+\))' -r docs | grep -o -e '\.[^.]\+)' | sort | uniq -c | sort --reverse | head -10
 156 .md)
  17 .mdx)
   6 ./limits)
   6 ./cache)
   4 ./topics)
   4 ./)
   3 .png)
   2 .md#sortedsetfetchbyscore)
   2 ./manage/pricing)
   2 ./learn/how-it-works/expire-data-with-ttl)
```