### PR TITLE
fix: add redirect for php cheat sheet indexed by google

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,6 +204,10 @@ const config = {
             to: '/sdks/php/cache',
           },
           {
+            from: '/develop/sdks/php/cheat-sheet',
+            to: '/sdks/php/cache',
+          },
+          {
             from: '/develop/guides/cheat-sheets/momento-cache-python-cheat-sheet',
             to: '/sdks/python/cache',
           },


### PR DESCRIPTION
Adds a redirect for the PHP cheat sheet page that was indexed by google search