### PR TITLE
fix: broken cache/topic links in the python sdk

### DIFF
--- a/docs/sdks/python/index.md
+++ b/docs/sdks/python/index.md
@@ -39,8 +39,8 @@ The source code can be found on GitHub: [momentohq/client-sdk-python](https://gi
 
 ## Resources
 
-- [Getting started with Momento Cache in Python](./cache)
-- [Getting started with Momento Topics in Python](./topics)
+- [Getting started with Momento Cache in Python](./cache.md)
+- [Getting started with Momento Topics in Python](./topics.mdx)
 - [Python SDK Examples](https://github.com/momentohq/client-sdk-python/blob/main/examples/README.md): working example projects that illustrate how to use the Python SDK
 
 ## Integrations


### PR DESCRIPTION
this is what you're seeing today if you click "Getting started with Momento Cache in Python" in the python sdk docs page: https://docs.momentohq.com/sdks/python

<img width="1173" alt="Screenshot 2024-04-02 at 2 34 26 PM" src="https://github.com/momentohq/public-dev-docs/assets/93940372/f15169ec-d36f-4c63-a738-9cd5f31deef5">

