### PR TITLE
fix: add redirects from old SDK links to new ones

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -279,6 +279,67 @@ const config = {
             from: '/leaderboards/develop/language-support',
             to: '/leaderboards/language-support'
           },
+          // we moved all of the SDKs to the top level
+          {
+            from: '/develop/sdks/dart',
+            to: '/sdks/dart'
+          },
+          {
+            from: '/develop/sdks/dotnet',
+            to: '/sdks/dotnet'
+          },
+          {
+            from: '/develop/sdks/elixir',
+            to: '/sdks/elixir'
+          },
+          {
+            from: '/develop/sdks/go',
+            to: '/sdks/go'
+          },
+          {
+            from: '/develop/sdks/java',
+            to: '/sdks/java'
+          },
+          {
+            from: '/develop/sdks/kotlin',
+            to: '/sdks/kotlin'
+          },
+          {
+            from: '/develop/sdks/nodejs',
+            to: '/sdks/nodejs'
+          },
+          {
+            from: '/develop/sdks/php',
+            to: '/sdks/php'
+          },
+          {
+            from: '/develop/sdks/python',
+            to: '/sdks/python'
+          },
+          {
+            from: '/develop/sdks/ruby',
+            to: '/sdks/ruby'
+          },
+          {
+            from: '/develop/sdks/rust',
+            to: '/sdks/rust'
+          },
+          {
+            from: '/develop/sdks/swift',
+            to: '/sdks/swift'
+          },
+          {
+            from: '/develop/sdks/ruby',
+            to: '/sdks/ruby'
+          },
+          {
+            from: '/develop/sdks/rust',
+            to: '/sdks/rust'
+          },
+          {
+            from: '/develop/sdks/swift',
+            to: '/sdks/swift'
+          },
         ],
         // This came in with v1.5.0 of the docs where we split out by service.
         // This function redirects anything coming into /develop, /learn, /manage, or /introduction to /cache/<directory>.


### PR DESCRIPTION
A while back we moved the SDK pages up to the top level, from
the `develop` directory. This commit adds redirects so that any
lingering references to the old links won't be broken.
