### PR TITLE
chore: small fixes on cache and leaderboards api reference pages

### DIFF
--- a/docs/cache/develop/api-reference/index.mdx
+++ b/docs/cache/develop/api-reference/index.mdx
@@ -96,6 +96,8 @@ Sets multiple key-value pairs in a cache with a given Time To Live (TTL) seconds
 | items      | { String/[]Byte :  String/[]Byte } | The mapping of keys to values that should be stored |
 | ttlSeconds | int    | Time to Live for the items in Cache.           |
 
+<SdkExampleTabs snippetId={'API_SetBatch'} />
+
 <details>
 
 <summary>Method response object</summary>
@@ -126,6 +128,8 @@ Get the cache values stored for the given keys.
 | --------- | ------ | --------------------------------------------- |
 | cacheName | String | Name of the cache.                            |
 | keys       | String[] / Bytes[] | The list of keys for which to retrieve values. |
+
+<SdkExampleTabs snippetId={'API_GetBatch'} />
 
 <details>
 

--- a/docs/leaderboards/api-reference/index.mdx
+++ b/docs/leaderboards/api-reference/index.mdx
@@ -310,7 +310,7 @@ One of the following:
 
 <div class='col col--6'>
 
-## Fetch elements by ID
+### Fetch elements by ID
 
 Fetches elements given a list of element IDs. 
 


### PR DESCRIPTION
Noticed inconsistency in heading on the leaderboards api ref page. Noticed missing sdk example tabs for GetBatch and SetBatch on the cache api ref page.

Left this PR in draft until [Go SDK leaderboards code snippets](https://github.com/momentohq/client-sdk-go/pull/407) are merged to make sure the new docs snippets are picked up in the next deployment