### PR TITLE
feat: add a compression page for the Node.js SDK

### DIFF
--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -214,6 +214,7 @@ Momento server-side SDKs allow you to take advantage of Momento's low-latency Ca
   <LinkButton text="Style Guide" link="/sdks/nodejs/style-guide.html"/>
   <LinkButton text="Cache" link="/sdks/nodejs/cache.html"/>
   <LinkButton text="Topics" link="/sdks/nodejs/topics.html"/>
+  <LinkButton text="Compression" link="/sdks/nodejs/compression.html"/>
   <LinkButton text="Examples" link="https://github.com/momentohq/client-sdk-nodejs/tree/main/examples/nodejs" openInNewTab="true" />
   <LinkButton text="Packages" link="https://www.npmjs.com/package/@gomomento/sdk" openInNewTab="true" />
   <LinkButton text="Source Code" link="https://github.com/momentohq/client-sdk-javascript" openInNewTab="true" />

--- a/docs/sdks/nodejs/compression.mdx
+++ b/docs/sdks/nodejs/compression.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 6
+sidebar_label: Compression
+title: Using compression in your Momento Node.js code
+description: "Learn how to compress your data when using the Momento Node.js SDK"
+keywords:
+  - momento
+  - cache
+  - configuration
+  - sdk
+  - production ready
+  - typescript
+  - node.js
+  - nodejs
+  - javascript
+  - compression
+  - zstd
+---
+
+import { SdkExampleCodeBlock } from "@site/src/components/SdkExampleCodeBlock";
+// This import is necessary even though it looks like it's un-used; The inject-example-code-snippet
+// plugin will transform instances of SdkExampleCodeBlock to SdkExampleCodeBlockImpl
+import { SdkExampleCodeBlockImpl } from "@site/src/components/SdkExampleCodeBlockImpl";
+
+# Using compression in the Momento Node.js SDK
+
+The `get`/`set` and `getBatch`/`setBatch` cache methods in the Momento Node.js SDK support [ZSTD](https://facebook.github.io/zstd/) compression. If your data is compressible, enabling compression can significantly decrease the amount of data sent to Momento at the cost of increased CPU usage.
+
+## Enabling compression
+
+To avoid adding extra dependencies, the Momento Node.js SDK does not include compression by default. To add it, you'll need to install the `sdk-nodejs-compression` dependency:
+
+```cli
+npm install @gomomento/sdk-nodejs-compression
+```
+
+Once that is installed, you can enable compression by adding a compression strategy to the cache client configuration:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_ConfigurationWithCompression'} />
+
+If you want to be able to compress data, but don't want the SDK to automatically decompress it, you can also configure that:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_ConfigurationWithCompressionNoAutomatic'} />
+
+## Compressing your data
+
+With the dependency installed and the client configured, you can specify `compress: true` when calling set or setBatch to compress that value:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_SetWithCompression'} />
+
+If automatic decompression is enabled, you won't need to change your get or getBatch calls. You can specify `decompress: true` or `decompress: false` if you want to override the automatic decompression setting:
+
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_GetNoDecompress'} />
+
+Uncompressed data will be unaffected by the compression configuration.
+
+## More Examples
+
+You can find a complete example of a client getting and setting compressed data in the [JavaScript SDK GitHub repository.](https://github.com/momentohq/client-sdk-javascript/blob/main/examples/nodejs/compression)

--- a/docs/sdks/nodejs/index.md
+++ b/docs/sdks/nodejs/index.md
@@ -43,6 +43,7 @@ The source code can be found on GitHub: [momentohq/client-sdk-javascript](https:
 
 - [Getting started with Momento Cache in JavaScript](/sdks/nodejs/cache.mdx)
 - [Getting started with Momento Topics in JavaScript](/sdks/nodejs/topics.mdx)
+- [Using compression with the Node.js SDK](/sdks/nodejs/compression.mdx)
 - [Node.js SDK Configuration and Error Handling](./config-and-error-handling.mdx): Taking your code to production
 - [Node.js SDK Style Guide](./style-guide.mdx): Learn about the two different code styles you can use to interact with Momento
 - [Node.js SDK Observability](./observability.mdx): Logging and Client-side Metrics with the Node.js SDK


### PR DESCRIPTION
Add a page showing how to enable and use compression in the Node.js SDK.

Add links to the compression page in the main Node.js SDK page and the SDK overview page.