### PR TITLE
chore: update api support matrix parser source files for rust and ruby sdks

### DIFF
--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -110,8 +110,8 @@ const SDKS: Array<SdkInfo> = [
   },
   {
     sdk: Sdk.RUST,
-    cacheClientFile: 'src/simple_cache_client.rs',
-    configObjectFile: undefined,
+    cacheClientFile: 'src/cache_client.rs',
+    configObjectFile: 'src/cache/config/configuration.rs',
     topicClientFile: 'src/topics/topic_client.rs',
     authClientFile: undefined,
     leaderboardClientFile: undefined,
@@ -119,7 +119,7 @@ const SDKS: Array<SdkInfo> = [
   {
     sdk: Sdk.RUBY,
     cacheClientFile: 'lib/momento/cache_client.rb',
-    configObjectFile: undefined,
+    configObjectFile: 'lib/momento/config/configuration.rb',
     topicClientFile: undefined,
     authClientFile: undefined,
     leaderboardClientFile: undefined,

--- a/plugins/example-code-snippets/src/examples/resolvers/sdk-repo-snippet-resolver.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/sdk-repo-snippet-resolver.ts
@@ -15,6 +15,7 @@ import {ElixirSnippetSourceParser} from './source-parsers/languages/elixir-snipp
 import {SwiftSnippetSourceParser} from './source-parsers/languages/swift-snippet-source-parser';
 import {DartSnippetSourceParser} from './source-parsers/languages/dart-snippet-source-parser';
 import {KotlinSnippetSourceParser} from './source-parsers/languages/kotlin-snippet-source-parser';
+import {RustSnippetSourceParser} from './source-parsers/languages/rust-snippet-source-parser';
 
 export class SdkRepoSnippetResolver implements SnippetResolver {
   private readonly sourceProvider: SdkSourceProvider =
@@ -99,7 +100,7 @@ export class SdkRepoSnippetResolver implements SnippetResolver {
       case ExampleLanguage.DART:
         return new DartSnippetSourceParser(sourceDir);
       case ExampleLanguage.RUST:
-        return undefined;
+        return new RustSnippetSourceParser(sourceDir);
       case ExampleLanguage.RUBY:
         return undefined;
       case ExampleLanguage.CLI:

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/rust-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/rust-snippet-source-parser.ts
@@ -1,0 +1,35 @@
+import {
+  RegexSnippetSourceParser,
+  RegexSnippetTypeOptions,
+} from '../regex-snippet-source-parser';
+import {ExampleSnippetType} from '../../../examples';
+import * as path from 'path';
+
+export class RustSnippetSourceParser extends RegexSnippetSourceParser {
+  constructor(repoSourceDir: string) {
+    const wholeFileExamplesDir = 'example/';
+    const codeSnippetFiles: Array<string> = [
+      'example/src/bin/docs_examples.rs',
+    ];
+    super({
+      wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),
+      snippetTypeParseOptions: new Map<
+        ExampleSnippetType,
+        RegexSnippetTypeOptions
+      >([
+        [
+          ExampleSnippetType.CODE,
+          {
+            snippetSourceFiles: codeSnippetFiles.map(f =>
+              path.join(repoSourceDir, f)
+            ),
+            startRegex: snippetId =>
+              new RegExp(`pub (?:async )?fn example_${snippetId.valueOf()}\\(`),
+            endRegex: () => /^}/,
+            numLeadingSpacesToStrip: 2,
+          },
+        ],
+      ]),
+    });
+  }
+}


### PR DESCRIPTION
Will merge https://github.com/momentohq/client-sdk-rust/pull/253 first to ensure new example code snippets are picked up in the next deployment along with the changes to the API support matrix 

Addresses https://github.com/momentohq/client-sdk-rust/issues/210 