### PR TITLE
chore: fix lingering references to generateAuthToken and refreshAuthToken

### DIFF
--- a/docs/cache/develop/api-reference/auth.md
+++ b/docs/cache/develop/api-reference/auth.md
@@ -30,7 +30,7 @@ Generates a new Momento API key with the specified permissions and expiry.
 
 * Success
   - `apiKey`: string - the new API key
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshapikey-api) to refresh a token before it expires
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh a token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -60,7 +60,7 @@ Refreshes an existing, unexpired Momento API key.  Produces a new API key with t
 
 * Success
   - `apiKey`: string - the new API key
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshapikey-api) to refresh the token before it expires
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh the token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -262,7 +262,7 @@ No. We only support the managed roles listed above for each permission.
 <details>
 <summary>Do these tokens control access to the Momento control plane APIs?</summary>
 
-Access tokens generated with the [GenerateAuthToken](#generateauthtoken-api) API only control access to the Momento data plane APIs. A token for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
+Access tokens generated with the [GenerateApiKey](#generateapikey-api) API only control access to the Momento data plane APIs. A token for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
 
 </details>
 

--- a/docs/leaderboards/api-reference/auth.md
+++ b/docs/leaderboards/api-reference/auth.md
@@ -16,7 +16,7 @@ The auth APIs create and manage API keys and tokens for Momento services. These 
 
 <img src="/img/momento-auth-tokens.png" width="60%"/>
 
-## GenerateAuthToken API
+## GenerateApiKey API
 
 Generates a new Momento auth token with the specified permissions and expiry.
 
@@ -30,7 +30,7 @@ Generates a new Momento auth token with the specified permissions and expiry.
 
 * Success
   - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh a token before it expires
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh a token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -45,9 +45,9 @@ Tokens to access the Momento control plane APIs can only be generated using the 
 
 :::
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-## RefreshAuthToken API
+## RefreshApiKey API
 
 Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
 
@@ -59,8 +59,8 @@ Refreshes an existing, unexpired Momento auth token.  Produces a new auth token 
   <summary>Method response object</summary>
 
 * Success
-  - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh the token before it expires
+  - `apiKey`: string - the new auth token
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh the token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -69,7 +69,7 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ## TokenScope objects
 | Name            | Type                                      | Description                                  |
@@ -262,7 +262,7 @@ No. We only support the managed roles listed above for each permission.
 <details>
 <summary>Do these tokens control access to the Momento control plane APIs?</summary>
 
-Access tokens generated with the [GenerateAuthToken](#generateauthtoken-api) API only control access to the Momento data plane APIs. A token for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
+Access tokens generated with the [GenerateApiKey](#generateapikey-api) API only control access to the Momento data plane APIs. A token for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
 
 </details>
 

--- a/docs/topics/develop/api-reference/auth.md
+++ b/docs/topics/develop/api-reference/auth.md
@@ -16,7 +16,7 @@ The auth APIs create and manage API keys and tokens for Momento services. These 
 
 <img src="/img/momento-auth-tokens.png" width="60%"/>
 
-## GenerateAuthToken API
+## GenerateApiKey API
 
 Generates a new Momento auth token with the specified permissions and expiry.
 
@@ -29,8 +29,8 @@ Generates a new Momento auth token with the specified permissions and expiry.
   <summary>Method response object</summary>
 
 * Success
-  - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh a token before it expires
+  - `apiKey`: string - the new auth token
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh a token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -45,22 +45,22 @@ Tokens to access the Momento control plane APIs can only be generated using the 
 
 :::
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-## RefreshAuthToken API
+## RefreshApiKey API
 
 Refreshes an existing, unexpired Momento auth token.  Produces a new auth token with the same permissions and expiry duration as the original auth token.
 
-| Name            | Type            | Description                                   |
-| --------------- | --------------- | --------------------------------------------- |
-| refreshToken    | String          | The refreshToken for the current auth token, acquired from the original call to `GenerateAuthToken`. |
+| Name            | Type            | Description                                                                                    |
+| --------------- | --------------- |------------------------------------------------------------------------------------------------|
+| refreshToken    | String          | The refreshToken for the current API key, acquired from the original call to `GenerateApiKey`. |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
   - `authToken`: string - the new auth token
-  - `refreshToken`: string - a refresh token that can be used with the [RefreshAuthToken API](#refreshauthtoken-api) to refresh the token before it expires
+  - `refreshToken`: string - a refresh token that can be used with the [RefreshApiKey API](#refreshapikey-api) to refresh the token before it expires
   - `endpoint`: string - the HTTP endpoint the Momento client should use when making requests
   - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
@@ -69,7 +69,7 @@ See [response objects](./response-objects.md) for specific information.
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ## TokenScope objects
 | Name            | Type                                      | Description                                  |
@@ -260,9 +260,9 @@ No. We only support the managed roles listed above for each permission.
 </details>
 
 <details>
-<summary>Do these tokens control access to the Momento control plane APIs?</summary>
+<summary>Do these keys control access to the Momento control plane APIs?</summary>
 
-Access tokens generated with the [GenerateAuthToken](#generateauthtoken-api) API only control access to the Momento data plane APIs. A token for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
+API keys generated with the [GenerateApiKey](#generateauthtoken-api) API only control access to the Momento data plane APIs. A key for access to Momento's control plane APIs must be generated using the [Momento console](https://console.gomomento.com/).
 
 </details>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/auth.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/auth.md
@@ -30,7 +30,7 @@ auth APIは、[Momento auth tokens](./../authentication/index.mdx) として知�
 
 * Success
   - `apiKey`: string - 新しいAPI key
-  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshAuthToken API](#refreshapikey-api)と共に使用できるリフレッシュトークン
+  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshApiKey API](#refreshapikey-api)と共に使用できるリフレッシュトークン
   - `expiresAt`: Timestamp - トークンが失効するタイムスタンプ
 * Error
 
@@ -59,7 +59,7 @@ Momento のコントロールプレーン API にアクセスするためのト�
 
 * Success
   - `apiKey`: string - 新しいAPIキー
-  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshAuthToken API](#refreshapikey-api) と共に使用できるリフレッシュトークン
+  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshApiKey API](#refreshapikey-api) と共に使用できるリフレッシュトークン
   - `expiresAt`: Timestamp - トークンが失効するタイムスタンプ
 * Error
 
@@ -167,7 +167,7 @@ const TopicsPermissions = {
 <details>
 <summary>これらのトークンは、Momento コントロールプレーン API へのアクセスを制御しますか？</summary>
 
-[GenerateAuthToken](#generateauthtoken) API で生成されたアクセストークンは、Momento のデータプレーンAPIへのアクセスだけを制御します。Momento のコントロールプレーンAPIへのアクセスのためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
+[GenerateApiKey](#generateapikey) API で生成されたアクセストークンは、Momento のデータプレーンAPIへのアクセスだけを制御します。Momento のコントロールプレーンAPIへのアクセスのためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
 
 </details>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/index.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/cache/develop/api-reference/index.mdx
@@ -514,7 +514,7 @@ TTLを減少させる場合のみ、keyのTTL秒数を指定された値に減�
 
 これらのAPIは、Momentoの認証トークンやアクセスを管理するために使用されます。
 
-### GenerateAuthToken
+### GenerateApiKey
 
 指定した権限と有効期限を持つ新しいMomento認証トークンを生成します。
 
@@ -528,7 +528,7 @@ TTLを減少させる場合のみ、keyのTTL秒数を指定された値に減�
 
 * Success
 - `authToken`: string - the new auth token
-- `refreshToken`: string - a refresh token that can be used with the `RefreshAuthToken` API to refresh the token before it expires
+- `refreshToken`: string - a refresh token that can be used with the `RefreshApiKey` API to refresh the token before it expires
 - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
 
@@ -536,22 +536,22 @@ TTLを減少させる場合のみ、keyのTTL秒数を指定された値に減�
 
 </details>
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-### RefreshAuthToken
+### RefreshApiKey
 
 既存の有効期限内のMomento認証トークンを更新します。元のトークンと同じ権限と有効期限を持つ 新しいトークンを生成します。
 
 | 名前            | 型            | 説明                                   |
 | --------------- | --------------- | --------------------------------------------- |
-| refreshToken    | String          | 最初の`GenerateAuthToken`の呼び出しから取得した、現在の認証トー クンのrefreshTokenを指定。 |
+| refreshToken    | String          | 最初の`GenerateApiKey`の呼び出しから取得した、現在の認証トー クンのrefreshTokenを指定。 |
 
 <details>
 <summary>メソッドのレスポンスオブジェクト</summary>
 
 * Success
 - `authToken`: string - the new auth token
-- `refreshToken`: string - a refresh token that can be used with the `RefreshAuthToken` API to refresh the token before it expires
+- `refreshToken`: string - a refresh token that can be used with the `RefreshApiKey` API to refresh the token before it expires
 - `expiresAt`: Timestamp - the timestamp at which the token will expire
 * Error
 
@@ -559,7 +559,7 @@ TTLを減少させる場合のみ、keyのTTL秒数を指定された値に減�
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ### コレクションデータ型
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/leaderboards/api-reference/auth.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/leaderboards/api-reference/auth.md
@@ -16,7 +16,7 @@ Auth API は、Momento サービスの API キーとトークンを作成およ�
 
 <img src="/img/momento-auth-tokens.png" width="60%"/>
 
-## GenerateAuthToken API
+## GenerateApiKey API
 
 指定した権限と有効期限を持つ新しい Momento Auth トークンを生成します。
 
@@ -30,7 +30,7 @@ Auth API は、Momento サービスの API キーとトークンを作成およ�
 
 * Success
   - `authToken`: string - 新しいAuthトークン
-  - `refreshToken`: string - [RefreshAuthToken API](#refreshauthtoken-api) を使って、トークンの有効期限が切れる前にリフレッシュするためのトークン
+  - `refreshToken`: string - [RefreshApiKey API](#refreshapikey-api) を使って、トークンの有効期限が切れる前にリフレッシュするためのトークン
   - `endpoint`: string - Momento クライアントがリクエストを行う際に使用する HTTP エンドポイント
   - `expiresAt`: Timestamp - トークンの有効期限が切れるタイムスタンプ
 * Error
@@ -45,22 +45,22 @@ MomentoコントロールプレーンAPIにアクセスするためのトーク�
 
 :::
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-## RefreshAuthToken API
+## RefreshApiKey API
 
 既存の有効期限が切れていない Momento Authトークンをリフレッシュします。 元のトークンと同じ権限と有効期限を持つ新しいトークンを生成します。
 
-| 名前            | タイプ            | 説明                                   |
-| --------------- | --------------- | --------------------------------------------- |
-| refreshToken    | String          | `GenerateAuthToken` をコールした際に取得した、現在のAuthトークンの refreshToken。 |
+| 名前            | タイプ            | 説明                                                       |
+| --------------- | --------------- |----------------------------------------------------------|
+| refreshToken    | String          | `GenerateApiKey` をコールした際に取得した、現在のAuthトークンの refreshToken。 |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
   - `authToken`: string - 新しいAuthトークン
-  - `refreshToken`: string - [RefreshAuthToken API](#refreshauthtoken-api)で使用するリフレッシュトークン。
+  - `refreshToken`: string - [RefreshApiKey API](#refreshapikey-api)で使用するリフレッシュトークン。
   - `endpoint`: string - Momentoクライアントがリクエストを行う際に使用する HTTP エンドポイント。
   - `expiresAt`: Timestamp - トークンの有効期限が切れるタイムスタンプ
 * Error
@@ -69,7 +69,7 @@ MomentoコントロールプレーンAPIにアクセスするためのトーク�
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ## TokenScope objects
 | 名前            | タイプ                                      | 説明                                  |
@@ -271,7 +271,7 @@ const tokenResponse = await authClient.generateDisposableToken(
 <details>
 <summary>これらのトークンは、MomentoのコントロールプレーンAPIへのアクセスを制御しますか？</summary>
 
-[GenerateAuthToken](#generateauthtoken-api)APIで生成されたアクセストークンは、MomentoのデータプレーンAPIへのアクセスのみを制御します。Momento のコントロールプレーン API にアクセスするためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
+[GenerateApiKey](#generateauthtoken-api)APIで生成されたアクセストークンは、MomentoのデータプレーンAPIへのアクセスのみを制御します。Momento のコントロールプレーン API にアクセスするためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
 
 </details>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/api-reference/auth.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/api-reference/auth.md
@@ -16,7 +16,7 @@ auth APIは、[Momento auth tokens](./../authentication/index.mdx) として知�
 
 <img src="/img/momento-auth-tokens.png" width="60%"/>
 
-## GenerateAuthToken API
+## GenerateApiKey API
 
 権限と有効期限を指定することで新しい Momento authトークンを生成します。
 
@@ -30,7 +30,7 @@ auth APIは、[Momento auth tokens](./../authentication/index.mdx) として知�
 
 * Success
   - `authToken`: string - 新しいauthトークン
-  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshAuthToken API](#refreshauthtoken)と共に使用できるリフレッシュトークン
+  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshApiKey API](#refreshapikey)と共に使用できるリフレッシュトークン
   - `expiresAt`: Timestamp - トークンが失効するタイムスタンプ
 * Error
 
@@ -44,22 +44,22 @@ Momento のコントロールプレーン API にアクセスするためのト�
 
 :::
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
-## RefreshAuthToken API
+## RefreshApiKey API
 
 既存の有効な Momento authトークンを更新します。新しいauthトークンは、元のauthトークンと同じ権限と有効期間を持ちます。
 
-| 名前            | 型            | 説明                                   |
-| --------------- | --------------- | --------------------------------------------- |
-| refreshToken    | String          | 現在のauthトークンのリフレッシュトークンで、これは `GenerateAuthToken` の元の呼び出しから取得されます。 |
+| 名前            | 型            | 説明                                                            |
+| --------------- | --------------- |---------------------------------------------------------------|
+| refreshToken    | String          | 現在のauthトークンのリフレッシュトークンで、これは `GenerateApiKey` の元の呼び出しから取得されます。 |
 
 <details>
   <summary>Method response object</summary>
 
 * Success
-  - `authToken`: string - 新しいauthトークン
-  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshAuthToken API](#refreshauthtoken) と共に使用できるリフレッシュトークン
+  - `apiKey`: string - 新しいauthトークン
+  - `refreshToken`: string - 有効期限前にトークンを更新するために、[RefreshApiKey API](#refreshapikey) と共に使用できるリフレッシュトークン
   - `expiresAt`: Timestamp - トークンが失効するタイムスタンプ
 * Error
 
@@ -67,7 +67,7 @@ Momento のコントロールプレーン API にアクセスするためのト�
 
 </details>
 
-<SdkExampleTabs snippetId={'API_RefreshAuthToken'} />
+<SdkExampleTabs snippetId={'API_RefreshApiKey'} />
 
 ## TokenScope objects
 | 名前            | 型                                      | 説明                                  |
@@ -167,7 +167,7 @@ const TopicsPermissions = {
 <details>
 <summary>これらのトークンは、Momento コントロールプレーン API へのアクセスを制御しますか？</summary>
 
-[GenerateAuthToken](#generateauthtoken) API で生成されたアクセストークンは、Momento のデータプレーンAPIへのアクセスだけを制御します。Momento のコントロールプレーンAPIへのアクセスのためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
+[GenerateApikey](#generateapikey) API で生成されたアクセストークンは、Momento のデータプレーンAPIへのアクセスだけを制御します。Momento のコントロールプレーンAPIへのアクセスのためのトークンは、[Momento console](https://console.gomomento.com/) を使用して生成する必要があります。
 
 </details>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/authentication/tokens.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/authentication/tokens.md
@@ -31,7 +31,7 @@ Momento トークンは、*データプレーン*にのみアクセスできま�
 
 以下は、さまざまな権限でトークンを作成する例です：
 
-<SdkExampleTabs snippetId={'API_GenerateAuthToken'} />
+<SdkExampleTabs snippetId={'API_GenerateApiKey'} />
 
 トークン作成の詳細については、[APIリファレンスページ](./../api-reference/auth.md)を参照してください。
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/sdks/web/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/topics/develop/sdks/web/index.md
@@ -57,9 +57,9 @@ API 呼出しは [Momento Node.js SDK と同一](./../nodejs/cheat-sheet.mdx)で
 
 <SdkExampleCodeBlock language={'javascript'} snippetId={'API_InstantiateAuthClient'} />
 
-そうしたら、`generateAuthToken` API を使って、ブラウザに提供するトークンを作成します:
+そうしたら、`generateApiKey` API を使って、ブラウザに提供するトークンを作成します:
 
-<SdkExampleCodeBlock language={'javascript'} snippetId={'API_GenerateAuthToken'} />
+<SdkExampleCodeBlock language={'javascript'} snippetId={'API_GenerateApiKey'} />
 
 他にも、認可のための `TokenScope` や、期限切れのトークンをどうやってリフレッシュするか、などを含めた Momento 認証トークンに関する情報は、[Momento 認証トークンを使う](./../../authentication/index.mdx)をご覧下さい。
 

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -300,8 +300,8 @@ const WEBHOOK_API_GROUPS: Array<ApiGroup> = [
 const AUTH_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Auth',
-    groupDescription: 'A matrix of SDK support for Momento auth token APIs',
-    apis: ['generateAuthToken', 'refreshAuthToken', 'generateDisposableToken'],
+    groupDescription: 'A matrix of SDK support for Momento API Key and auth token APIs',
+    apis: ['generateApiKey', 'refreshApiKey', 'generateDisposableToken'],
   },
 ];
 

--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -300,7 +300,8 @@ const WEBHOOK_API_GROUPS: Array<ApiGroup> = [
 const AUTH_API_GROUPS: Array<ApiGroup> = [
   {
     groupName: 'Auth',
-    groupDescription: 'A matrix of SDK support for Momento API Key and auth token APIs',
+    groupDescription:
+      'A matrix of SDK support for Momento API Key and auth token APIs',
     apis: ['generateApiKey', 'refreshApiKey', 'generateDisposableToken'],
   },
 ];


### PR DESCRIPTION
These were renamed to generateApiKey and refreshApiKey a while back.
