### PR TITLE
fix: move cache pattern docs into a single directory

### DIFF
--- a/docs/cache/pattern/_category_.json
+++ b/docs/cache/pattern/_category_.json
@@ -1,9 +1,0 @@
-{
-  "label": "Patterns",
-  "position": 3,
-  "collapsible": true,
-  "collapsed": true,
-  "link": {
-    "description": "Best practices on how to use Momento Cache in your architecture!"
-  }
-}

--- a/docs/cache/patterns/api-caching.md
+++ b/docs/cache/patterns/api-caching.md
@@ -1,6 +1,7 @@
 ---
-title: Caching API calls to WolframAlpha using Momento Cache
-sidebar_label: Caching the WolframAlpha API calls
+sidebar_position: 2
+title: API Caching Pattern
+sidebar_label: API Caching
 description: Learn how to use Momento Cache to boost performance of applications using the WolframAlpha API
 keywords:
  - cache

--- a/docs/cache/patterns/database-caching.mdx
+++ b/docs/cache/patterns/database-caching.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 1
 title: Database Caching Pattern
 sidebar_label: Database Caching
 description: Learn best practices using Momento cache with your database


### PR DESCRIPTION
Prior to this commit we had two different "pattern" directories
under "cache" ("pattern" and "patterns"), and they were showing
up as two separate menu items in the left nav.

This commit collapses them into a single directory / nav item,
and makes the wording a little more consistent.
