### PR TITLE
fix: rust docs examples path (again)

### DIFF
--- a/docs/sdks/rust/cache.mdx
+++ b/docs/sdks/rust/cache.mdx
@@ -62,7 +62,7 @@ export MOMENTO_API_KEY=<your Momento API key here>
 
 This code sets up the main function, the necessary imports, and the CacheClient instantiation that each of the other functions will need to call.
 
-<SdkExampleCodeBlock language={'rust'} file={'./example/src/docs_examples/cheat_sheet_client_instantiation.rs'} />
+<SdkExampleCodeBlock language={'rust'} file={'./example/rust/src/docs_examples/cheat_sheet_client_instantiation.rs'} />
 
 ## Create a new cache in Momento Cache
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/sdks/rust/cache.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/sdks/rust/cache.mdx
@@ -62,7 +62,7 @@ export MOMENTO_API_KEY=<your Momento API key here>
 
 このコードでは、メイン関数、必要なインポート、および他の各関数が呼び出す必要のある CacheClient インスタンス化を設定します。
 
-<SdkExampleCodeBlock language={'rust'} file={'./example/src/docs_examples/cheat_sheet_client_instantiation.rs'} />
+<SdkExampleCodeBlock language={'rust'} file={'./example/rust/src/docs_examples/cheat_sheet_client_instantiation.rs'} />
 
 ## Momento Cacheに新しいキャッシュを作成する
 

--- a/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/rust-snippet-source-parser.ts
+++ b/plugins/example-code-snippets/src/examples/resolvers/source-parsers/languages/rust-snippet-source-parser.ts
@@ -9,7 +9,7 @@ export class RustSnippetSourceParser extends RegexSnippetSourceParser {
   constructor(repoSourceDir: string) {
     const wholeFileExamplesDir = '.';
     const codeSnippetFiles: Array<string> = [
-      'example/src/docs_examples/docs_examples.rs',
+      'example/rust/src/docs_examples/docs_examples.rs',
     ];
     super({
       wholeFileExamplesDir: path.join(repoSourceDir, wholeFileExamplesDir),


### PR DESCRIPTION
We moved the examples directory in the rust SDK repo again; this
commit fixes the path to match the latest directory structure.
