### PR TITLE
chore: Set API behavior updates

### DIFF
--- a/docs/cache/develop/api-reference/index.mdx
+++ b/docs/cache/develop/api-reference/index.mdx
@@ -71,7 +71,7 @@ These API methods are used to directly interact with data in a cache.
 
 ### Set
 
-Sets the value in cache with a given Time To Live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
+Sets the value in cache with a given Time To Live (TTL) seconds. If a value for this key is already present, it will be replaced by the new value regardless of the previous value's data type.
 
 | Name       | Type   | Description                                   |
 | ---------- | ------ | --------------------------------------------- |
@@ -84,7 +84,7 @@ Sets the value in cache with a given Time To Live (TTL) seconds. If a value for 
 
 ### SetBatch
 
-Sets multiple key-value pairs in a cache with a given Time To Live (TTL) seconds. If a value for a key is already present it will be replaced by the new value.
+Sets multiple key-value pairs in a cache with a given Time To Live (TTL) seconds. If a value for a key is already present, it will be replaced by the new value regardless of the previous value's data type.
 
 | Name       | Type   | Description                                   |
 | ---------- | ------ | --------------------------------------------- |


### PR DESCRIPTION
Add details about `Set` API behavior when a key already exists.