### PR TITLE
chore: update topics and leaderboards response object pages

### DIFF
--- a/docs/leaderboards/api-reference/response-objects.md
+++ b/docs/leaderboards/api-reference/response-objects.md
@@ -17,29 +17,27 @@ Errors that occur in calls to the Momento Leaderboards service are surfaced to d
 
 ### Available methods
 
-- message(): String - a human readable error message
-- innerException(): Exception - the original exception.
-- errorCode(): MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
-- toString(): String - alias for message()
+- `message()`: String - a human readable error message
+- `innerException()`: Exception - the original exception.
+- `errorCode()`: MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
+- `toString()`: String - alias for message()
 
 ---
 
 ## Success
 
-Generic response object indicating a successful request with no additional methods attached. Variations of the Success response object include:
+Generic response object indicating a successful request with no additional methods attached. 
+
+Variations of the Success response object include:
 
 ### LeaderboardFetch
 
-Indicates a successful fetch request.
+Indicates a successful fetch request. Available methods include:
 
-#### Available methods
-
-- values(): List - returns a list of records containing the fields `id`, `score`, and `rank`
+- `values()`: List - returns a list of records containing the fields `id`, `score`, and `rank`
 
 ### LeaderboardLength
 
-Indicates a successful length request.
+Indicates a successful length request. Available methods include: 
 
-#### Available methods
-
-- length(): Integer - returns the number of elements in the specified leaderboard
+- `length()`: Integer - returns the number of elements in the specified leaderboard

--- a/docs/topics/develop/api-reference/response-objects.md
+++ b/docs/topics/develop/api-reference/response-objects.md
@@ -7,51 +7,61 @@ description: Learn how to interact with the response object in the Momento API f
 
 # Response objects from Momento APIs in Momento Topics
 
-These are the baseline responses for all commands. Some commands will add more data and functionality.
+Momento response objects extend from a parent class, have child types such as `Success` and `Error,` and are designed to be accessed via pattern matching. (In some languages, this concept is called "sealed classes"; in others, "algebraic data types". It is a flavor of polymorphism.) Your code checks whether the response is a `Success` or an `Error`, and then branches accordingly. Using this approach, you get a type-safe response object that you can use to get more information.
 
-Commands fall *generally* into two categories. Those which respond with: 
-1. **Success or Error** - An example is a Set operation. Either the item was successfully written to the cache or it errored.
-2. **Hit, Miss, or Error** - An example is a Get operation. If the requested item is in the cache, you have a cache Hit. If it is not in the cache, you get a cache Miss. If there is some sort of error, you get an Error.
+---
 
 ## Error
 
-Returned in lieu of an exception.
+Errors that occur in calls to the Momento Leaderboards service are surfaced to developers as part of the return values of the calls rather than thrown exceptions. This helps to ensure your application doesn't crash at runtime, makes errors more visible when you're writing your code, and allows your IDE to be more helpful in ensuring you've handled the errors you care about. For more on our philosophy about this, see our blog post on why [Exceptions are bugs](https://www.gomomento.com/blog/exceptions-are-bugs), and send us any feedback you have!
 
-### Constructor
+### Available methods
 
-- innerException: Exception - the exception which caused the error
+- `message()`: String - a human readable error message
+- `innerException()`: Exception - the original exception.
+- `errorCode()`: MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
+- `toString()`: String - alias for message()
 
-### Methods
-
-- message(): String - a human readable error message
-- innerException(): Exception - the original exception.
-- errorCode(): MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
-- toString(): String - alias for message()
+---
 
 ## Success
 
-The command was successful.
+Generic response object indicating a successful request with no additional methods attached. 
 
-## Hit
+Variations of the Success response object include:
 
-The key or field exists in the cache. Usually extended to return a value.
+### Subscription
 
-## Miss
+Indicates a successful Momento Topics subscription. Depending on the language, you may be provided a callback function or an iterator you can use to poll for new subscription items.
 
-The key or field does not exist in the cache.
+Available methods include:
 
-## Set
+- `unsubscribe()`: void - closes the topics subscription.
 
-For TTL commands, the update was applied successfully.
+### ListWebhooks
 
-## NotSet
+Indicates a successful list webhooks request. Available methods include: 
 
-For TTL commands, the update was not applied and no change was made to the existing TTL.
+- `getWebhooks()`: List - returns a list of existing webhooks. Each [`Webhook` object](./webhooks#webhook-object) contains the fields `destination`, `id`, and `topicName`.
 
-## Stored
+### PutWebhook
 
-For setIf* commands, the key did not exist and the value was set.
+Indicates a successful put webhook request. Available methods include: 
 
-## NotStored
+- `secretString()`: String - returns the signing secret for the webhook.
 
-For setIf* commands, the key existed and no value was set.
+### GetWebhookSecret
+
+Indicates a successful get webhook secret request. Available methods include: 
+
+- `secret()`: String - returns the signing secret for the webhook.
+- `webhookName()`: String - returns the name of the webhook.
+- `cacheName()`: String - returns the name of the cache associated with the webhook.
+
+### RotateWebhookSecret
+
+Indicates a successful rotate webhook secret request. Available methods include: 
+
+- `secret()`: String - returns the signing secret for the webhook.
+- `webhookName()`: String - returns the name of the webhook.
+- `cacheName()`: String - returns the name of the cache associated with the webhook.


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/974

Refreshes the topics response objects page to reflect what's actually available:
- Success/Error only with some accessors on some responses
- no Hit/Miss or Stored/NotStored patterns

Minor formatting changes to leaderboards response objects page for consistency.