### PR TITLE
chore: add python auth client file to api support matrix generator

### DIFF
--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -67,7 +67,7 @@ const SDKS: Array<SdkInfo> = [
     cacheClientFile: 'src/momento/cache_client_async.py',
     configObjectFile: 'src/momento/config/configuration.py',
     topicClientFile: 'src/momento/topic_client_async.py',
-    authClientFile: undefined,
+    authClientFile: 'src/momento/auth_client_async.py',
     leaderboardClientFile: undefined,
     storageClientFile: undefined,
   },


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1016

Adds `generateDisposableToken` to the python column of the cache language support matrix, and the code snippets from https://github.com/momentohq/client-sdk-python/pull/466 should appear on the auth API reference page once that PR is merged.