### PR TITLE
chore: add getCompetitionRank to language matrix

### DIFF
--- a/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
+++ b/plugins/example-code-snippets/src/api-support/api-support-matrix-generator.ts
@@ -337,6 +337,7 @@ const LEADERBOARD_API_GROUPS: Array<ApiGroup> = [
       'fetchByScore',
       'fetchByRank',
       'getRank',
+      'getCompetitionRank',
       'length',
       'removeElements',
       'delete',


### PR DESCRIPTION
## PR Description:
- Add `getCompetitionRank` to api-language support matrix. 

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1138


## Result from `localhost:3000` testing:
![Screenshot 2025-03-06 at 12 03 31 PM](https://github.com/user-attachments/assets/055432d0-3fec-4bc3-a391-fa853d50ca86)
