### PR TITLE
chore: add getCompetitionRank to leaderboard api references

### DIFF
--- a/docs/leaderboards/api-reference/index.mdx
+++ b/docs/leaderboards/api-reference/index.mdx
@@ -249,7 +249,7 @@ Momento Leaderboards is a first-class service with purpose-built APIs that suppo
 
         ### Get competition rank
 
-        Look up the competition rank for a given element ID in the leaderboard.
+        Look up the competition rank for given element IDs in the leaderboard.
 
         #### Parameters
         ----------------

--- a/docs/leaderboards/api-reference/index.mdx
+++ b/docs/leaderboards/api-reference/index.mdx
@@ -247,6 +247,40 @@ Momento Leaderboards is a first-class service with purpose-built APIs that suppo
 
     <div class='col col--4' style={{paddingRight: '20px'}}>
 
+        ### Get competition rank
+
+        Look up the competition rank for a given element ID in the leaderboard.
+
+        #### Parameters
+        ----------------
+        - **ids** - *List*: List of integers representing the ids of the elements to fetch.
+
+        #### Optional Parameters
+        ----------------
+        - **order** - *LeaderboardOrder enum*: The order to fetch the elements in. Defaults to ascending, meaning 0 is the lowest-scoring rank.
+
+        #### Returns
+        ----------------
+        One of the following:
+        - [LeaderboardLength.Success](/leaderboards/api-reference/response-objects#success)
+        - [LeaderboardLength.Error](/leaderboards/api-reference/response-objects#error)
+
+    </div>
+
+    <div class='col col--8'>
+
+        <SdkExampleTabs snippetId={'API_LeaderboardGetCompetitionRank'} />
+
+    </div>
+
+</div>
+
+---
+
+<div class='row'>
+
+    <div class='col col--4' style={{paddingRight: '20px'}}>
+
         ### Get leaderboard length
 
         Gets the number of entries in the leaderboard. The leaderboard name is inferred from the `Leaderboard` object.

--- a/docs/leaderboards/api-reference/index.mdx
+++ b/docs/leaderboards/api-reference/index.mdx
@@ -262,8 +262,8 @@ Momento Leaderboards is a first-class service with purpose-built APIs that suppo
         #### Returns
         ----------------
         One of the following:
-        - [LeaderboardLength.Success](/leaderboards/api-reference/response-objects#success)
-        - [LeaderboardLength.Error](/leaderboards/api-reference/response-objects#error)
+        - [LeaderboardFetch.Success](/leaderboards/api-reference/response-objects#success)
+        - [LeaderboardFetch.Error](/leaderboards/api-reference/response-objects#error)
 
     </div>
 

--- a/docs/leaderboards/api-reference/response-objects.md
+++ b/docs/leaderboards/api-reference/response-objects.md
@@ -17,10 +17,10 @@ Errors that occur in calls to the Momento Leaderboards service are surfaced to d
 
 ### Available methods
 
-- `message()`: String - a human readable error message
+- `message()`: String - a human readable error message.
 - `innerException()`: Exception - the original exception.
-- `errorCode()`: MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md)
-- `toString()`: String - alias for message()
+- `errorCode()`: MomentoErrorCode - Momento’s own category of errors such as InvalidArgument or BadRequest. See [Standards And Practices - Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md).
+- `toString()`: String - alias for message().
 
 ---
 


### PR DESCRIPTION
## PR Description:
-  add `getCompetitionRank` to leaderboard api references

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1138

## Localhost Testing Result:


![Screenshot 2025-03-06 at 1 26 20 PM](https://github.com/user-attachments/assets/96652265-4234-4dc1-86e4-086f3e5f45d5)
