### PR TITLE
docs: implement ephemeral/cache-only `PutObject`

### DIFF
--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -779,7 +779,7 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
   "timestamp": 1707580800000,
   "operation": "get_object",
   "key": "images/logo.png",
-  "persist": true,
+  "persistence": "durable",
   "store": "my-store",
   "status": "cache_hit",
   "size": 15234,
@@ -795,7 +795,7 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
 | timestamp | Integer | Unix timestamp in milliseconds when the operation occurred. |
 | operation | String | The operation: `get_object`, `put_object`, or `delete_object`. |
 | key | String | The object key that was accessed. |
-| persist | Bool | For `put_object`, whether the object will be written to storage (`true` for `durable` default, `false` if the `mo-persistence: ephemeral` header is specified). Otherwise, this field is excluded from the access log. |
+| persistence | String | For `put_object`, whether the object is `durable` (will be written to S3 storage) or `ephemeral` (cache-only). Otherwise, this field is excluded from the access log. |
 | store | String | The name of the object store. |
 | status | String | The result of the operation (see below). |
 | size | Integer | The size of the object in bytes. Only present for successful operations. |

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -886,7 +886,7 @@ These metrics are emitted with a `Result` dimension, allowing you to filter and 
 | `Ok` | `204` | Object was successfully stored. |
 | `InternalError` | `500` | The request failed due to an internal error. |
 | `AuthorizationError` | `403` | The request was rejected due to insufficient permissions. |
-| `BadRequest` | `400` | The request was rejected due to invalid `mo-tag-*` headers or an invalid `mo-persistence` header. |
+| `BadRequest` | `400` | The request was rejected due to invalid `mo-tag-*` headers. |
 | `LimitExceededError` | `429` | The request was rate limited (operations or throughput limit exceeded). |
 
 #### DeleteObject

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -378,6 +378,7 @@ Stores an object in the specified object store.
 | Authorization    | yes       | String               | The Momento auth token, in string format, is used for authentication/authorization of the request. |
 | mo-meta-*        | no        | String               | Custom metadata headers. Any header prefixed with `mo-meta-` will be stored with the object and returned on GET. The prefix is stripped when storing (e.g., `mo-meta-content-type` is stored as `content-type`). |
 | mo-tag-*         | no        | String               | S3 object tag headers. Any header prefixed with `mo-tag-` will be attached to the S3 object as a tag. The prefix is stripped when storing (e.g., `mo-tag-env` is stored as the tag key `env`). Tags are not returned on GET. |
+| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL. |
 
 :::info[Blocked Metadata Headers]
 
@@ -732,6 +733,16 @@ curl -X PUT -H "Authorization: <token>" \
   -H "mo-tag-team: infra" \
   --data-binary @logo.png \
   "https://api.cache.cell-1-us-east-1-1.prod.a.momentohq.com/objectstore/my-store/images/logo.png"
+```
+
+Store in cache only, inaccessible after 1 minute:
+
+```bash
+curl -X PUT -H "Authorization: <token>" \
+  -H "Content-Type: application/octet-stream" \
+  -H "mo-persistence: ephemeral" \
+  --data-binary @logo.png \
+  "https://api.cache.cell-1-us-east-1-1.prod.a.momentohq.com/objectstore/my-store/images/logo.png?ttl_seconds=60"
 ```
 
 ### Get Object

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -779,7 +779,6 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
   "timestamp": 1707580800000,
   "operation": "get_object",
   "key": "images/logo.png",
-  "persistence_header": "durable",
   "persist": true,
   "store": "my-store",
   "status": "cache_hit",
@@ -796,7 +795,6 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
 | timestamp | Integer | Unix timestamp in milliseconds when the operation occurred. |
 | operation | String | The operation: `get_object`, `put_object`, or `delete_object`. |
 | key | String | The object key that was accessed. |
-| persistence_header | String | For `put_object`, the `mo-persistence` header that you specified. If the header is not specified, the header is not ASCII-parseable, or the operation is not `put_object`, this field is excluded from the access log. |
 | persist | String | For `put_object`, whether the object will be written to storage (`true` for `durable` default, `false` if the `mo-persistence: ephemeral` header is specified). Otherwise, this field is excluded from the access log. |
 | persist | String | The object key that was accessed. |
 | store | String | The name of the object store. |

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -369,7 +369,9 @@ Stores an object in the specified object store.
 
 | Parameter&nbsp;name | Required? | Type    | Description                                                                 |
 |---------------------|-----------|---------|-----------------------------------------------------------------------------|
-| ttl_seconds         | no        | Integer | Optional time-to-live in seconds. If not specified, the object persists indefinitely (unless the `mo-persistence: ephemeral` header is specified). |
+| ttl_seconds         | no        | Integer | Optional time-to-live in seconds. If the `mo-persistence: ephemeral` header is specified, the default and maximum is 10 minutes. Otherwise, the default is that object persists indefinitely. |
+
+[//]: # (TODO Keep an eye on whether this default TTL has been changed in the source code.)
 
 #### Headers
 
@@ -378,7 +380,7 @@ Stores an object in the specified object store.
 | Authorization    | yes       | String               | The Momento auth token, in string format, is used for authentication/authorization of the request. |
 | mo-meta-*        | no        | String               | Custom metadata headers. Any header prefixed with `mo-meta-` will be stored with the object and returned on GET. The prefix is stripped when storing (e.g., `mo-meta-content-type` is stored as `content-type`). |
 | mo-tag-*         | no        | String               | S3 object tag headers. Any header prefixed with `mo-tag-` will be attached to the S3 object as a tag. The prefix is stripped when storing (e.g., `mo-tag-env` is stored as the tag key `env`). Tags are not returned on GET. |
-| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL (which, if not specified, defaults to 10 minutes for ephemeral objects). |
+| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL (or 10 minutes, if TTL is not specified). |
 
 [//]: # (TODO Keep an eye on whether this default TTL has been changed in the source code.)
 

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -795,8 +795,7 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
 | timestamp | Integer | Unix timestamp in milliseconds when the operation occurred. |
 | operation | String | The operation: `get_object`, `put_object`, or `delete_object`. |
 | key | String | The object key that was accessed. |
-| persist | String | For `put_object`, whether the object will be written to storage (`true` for `durable` default, `false` if the `mo-persistence: ephemeral` header is specified). Otherwise, this field is excluded from the access log. |
-| persist | String | The object key that was accessed. |
+| persist | Bool | For `put_object`, whether the object will be written to storage (`true` for `durable` default, `false` if the `mo-persistence: ephemeral` header is specified). Otherwise, this field is excluded from the access log. |
 | store | String | The name of the object store. |
 | status | String | The result of the operation (see below). |
 | size | Integer | The size of the object in bytes. Only present for successful operations. |

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -369,7 +369,7 @@ Stores an object in the specified object store.
 
 | Parameter&nbsp;name | Required? | Type    | Description                                                                 |
 |---------------------|-----------|---------|-----------------------------------------------------------------------------|
-| ttl_seconds         | no        | Integer | Optional time-to-live in seconds. If not specified, the object persists indefinitely. |
+| ttl_seconds         | no        | Integer | Optional time-to-live in seconds. If not specified, the object persists indefinitely (unless the `mo-persistence: ephemeral` header is specified). |
 
 #### Headers
 
@@ -378,7 +378,9 @@ Stores an object in the specified object store.
 | Authorization    | yes       | String               | The Momento auth token, in string format, is used for authentication/authorization of the request. |
 | mo-meta-*        | no        | String               | Custom metadata headers. Any header prefixed with `mo-meta-` will be stored with the object and returned on GET. The prefix is stripped when storing (e.g., `mo-meta-content-type` is stored as `content-type`). |
 | mo-tag-*         | no        | String               | S3 object tag headers. Any header prefixed with `mo-tag-` will be attached to the S3 object as a tag. The prefix is stripped when storing (e.g., `mo-tag-env` is stored as the tag key `env`). Tags are not returned on GET. |
-| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL. |
+| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL (which, if not specified, defaults to 10 minutes for ephemeral objects). |
+
+[//]: # (TODO Keep an eye on whether this default TTL has been changed in the source code.)
 
 :::info[Blocked Metadata Headers]
 

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -380,7 +380,7 @@ Stores an object in the specified object store.
 | Authorization    | yes       | String               | The Momento auth token, in string format, is used for authentication/authorization of the request. |
 | mo-meta-*        | no        | String               | Custom metadata headers. Any header prefixed with `mo-meta-` will be stored with the object and returned on GET. The prefix is stripped when storing (e.g., `mo-meta-content-type` is stored as `content-type`). |
 | mo-tag-*         | no        | String               | S3 object tag headers. Any header prefixed with `mo-tag-` will be attached to the S3 object as a tag. The prefix is stripped when storing (e.g., `mo-tag-env` is stored as the tag key `env`). Tags are not returned on GET. |
-| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL (or 10 minutes, if TTL is not specified). |
+| mo-persistence         | no        | String               | S3 object tag headers. This header determines whether the object is stored in S3. Values: `durable` (default) - stored to cache and S3; `ephemeral` - stored only in cache and cannot be retrieved after TTL (or 10 minutes, whichever is less). |
 
 [//]: # (TODO Keep an eye on whether this default TTL has been changed in the source code.)
 

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -779,6 +779,8 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
   "timestamp": 1707580800000,
   "operation": "get_object",
   "key": "images/logo.png",
+  "persistence_header": "durable",
+  "persist": true,
   "store": "my-store",
   "status": "cache_hit",
   "size": 15234,
@@ -794,6 +796,9 @@ When access logging is enabled, Momento delivers logs to your CloudWatch Log Gro
 | timestamp | Integer | Unix timestamp in milliseconds when the operation occurred. |
 | operation | String | The operation: `get_object`, `put_object`, or `delete_object`. |
 | key | String | The object key that was accessed. |
+| persistence_header | String | For `put_object`, the `mo-persistence` header that you specified. If the header is not specified, the header is not ASCII-parseable, or the operation is not `put_object`, this field is excluded from the access log. |
+| persist | String | For `put_object`, whether the object will be written to storage (`true` for `durable` default, `false` if the `mo-persistence: ephemeral` header is specified). Otherwise, this field is excluded from the access log. |
+| persist | String | The object key that was accessed. |
 | store | String | The name of the object store. |
 | status | String | The result of the operation (see below). |
 | size | Integer | The size of the object in bytes. Only present for successful operations. |

--- a/docs/objectstore/http-api.md
+++ b/docs/objectstore/http-api.md
@@ -886,7 +886,7 @@ These metrics are emitted with a `Result` dimension, allowing you to filter and 
 | `Ok` | `204` | Object was successfully stored. |
 | `InternalError` | `500` | The request failed due to an internal error. |
 | `AuthorizationError` | `403` | The request was rejected due to insufficient permissions. |
-| `BadRequest` | `400` | The request was rejected due to invalid `mo-tag-*` headers. |
+| `BadRequest` | `400` | The request was rejected due to invalid `mo-tag-*` headers or an invalid `mo-persistence` header. |
 | `LimitExceededError` | `429` | The request was rate limited (operations or throughput limit exceeded). |
 
 #### DeleteObject


### PR DESCRIPTION
Adds `mo-persistence` header, where `durable` (default) objects are stored in cache+storage and `ephemeral` objects are stored in only cache