### PR TITLE
valkey-operator docs

### DIFF
--- a/docs/self-hosted/valkey-operator/concepts/architecture.md
+++ b/docs/self-hosted/valkey-operator/concepts/architecture.md
@@ -1,0 +1,105 @@
+---
+title: Architecture
+description: "The Momento Valkey Operator at runtime: one deployment, four control loops, the objects it owns, how clients discover topology, and what it deliberately does not manage."
+sidebar_position: 3
+---
+
+# Architecture
+
+This page describes what actually runs when the Momento Valkey Operator is installed: the operator process itself, its four control loops, the Kubernetes objects it creates for each Valkey cluster, and the boundaries of its responsibility. It is for anyone evaluating or operating the system; no prior page is required, though [Resource model](resource-model.md) explains the resources these loops act on.
+
+## The operator deployment
+
+The operator is a single Deployment (`valkey-operator`, in the `valkey-operator` namespace when installed from the release manifest) running **one replica**. It has **no leader election**: the single replica is the concurrency control. It runs from a distroless container image, is configured at startup through environment variables fed by the `valkey-operator-config` ConfigMap (see [Operator configuration](../reference/operator-configuration.md)), and emits structured JSON logs.
+
+One replica is not the liability it would be for a data plane, because the operator is not on the data path. Valkey clusters serve traffic entirely on their own; the operator only converges them toward their declared specs. If the operator is down, running Valkey clusters keep serving. See [Why this architecture holds up](#why-this-architecture-holds-up) below.
+
+## Four control loops
+
+The operator process runs four independent controllers. Each is described here by its observable behavior.
+
+| Controller | Trigger | Responsibility |
+|---|---|---|
+| Cluster | Event-driven (watches) | Owns the whole Valkey cluster lifecycle |
+| Node | Event-driven (watches) | Create-only executor for `ValkeyNode` specs |
+| ACL | Periodic, 30-second tick | Converges nodes onto the current ACL file |
+| TLS | Periodic, 30-second tick | Causes nodes to reload certificates from disk |
+
+### Cluster controller
+
+The cluster controller watches `ValkeyCluster` resources and everything they own, and also watches `ValkeyConfig` and `ValkeyImage`: an edit to a menu resource re-triggers reconciliation of all Valkey clusters, which is how repointing a config rolls every cluster that uses it. It owns the full lifecycle: bootstrapping a new Valkey cluster, keeping an active one converged (failover handling, scaling, rolling replacement), and rendering the cluster-level objects (the headless Service, the operator-auth Secret, and the ACL ConfigMap). On each pass it takes at most one cluster-mutating action, then re-queues; [Reconciliation](reconciliation.md) explains that model and the priority order in detail.
+
+Reconciliation is per-cluster and independent: each `ValkeyCluster` has its own reconcile queue, at most one reconciliation runs for a given cluster at a time, and reconciliations for different clusters run concurrently within the operator process. A cluster in the middle of a long rebalance does not block reconciliation of any other cluster: the one-action-per-tick pacing applies within a cluster, not across the fleet.
+
+### Node controller
+
+The node controller is a deliberately narrow executor. A `ValkeyNode` spec is immutable, so the controller only ever *creates*: it ensures the node's per-node ConfigMap exists, and creates the node's Pod exactly once, when the node's lifecycle is `Joining`. It never updates a running pod's spec and never recreates a dead one; if a pod dies later, the cluster controller notices and replaces the whole node through the `ValkeyNode` lifecycle. This create-only design is what makes node identity trustworthy: a pod always reflects the exact spec it was created from. The consequences for pod behavior are covered in [Pod management](pod-management.md).
+
+### ACL controller
+
+The ACL controller runs on a fixed 30-second tick. The cluster controller renders the desired ACL file into each cluster's ACL ConfigMap; the ACL controller's only job is convergence: every tick, it instructs each running node to reload its ACL file from the ConfigMap volume mounted into the pod. The reload is atomic per node: if the file were ever invalid, the node keeps its previous ACLs. Failures against individual nodes are logged and retried on the next tick rather than failing the pass.
+
+### TLS controller
+
+The TLS controller also runs on a 30-second tick, and skips Valkey clusters without TLS enabled. For TLS clusters, each tick it points every running node back at its certificate file paths, causing Valkey to re-read the certificate, key, and CA bundle from disk. Combined with the kubelet propagating updated Secret contents into pod volumes, this is the certificate rotation mechanism: update the Secret, and nodes pick up the new material with no restart. See [TLS](../security/tls.md) for the rotation procedures.
+
+:::note
+ACL and TLS changes reach nodes in two stages: the kubelet propagates updated ConfigMap/Secret content into pod volumes (typically up to about a minute), and the next 30-second controller tick triggers the reload. Treat convergence as eventual; do not build workflows that assume a change is live within a fixed number of seconds.
+:::
+
+## What the operator creates and owns
+
+For every `ValkeyCluster`, the operator builds a two-level ownership chain:
+
+```text
+ValkeyCluster my-cluster (namespace: my-app)
+ ├── Service    my-cluster                 headless; ports 6379, 16379
+ ├── Secret     my-cluster-operator-auth   operator + replication credentials
+ ├── ConfigMap  my-cluster-acl             rendered ACL file (users.acl)
+ │
+ ├── ValkeyNode my-cluster-3f8a1
+ │    ├── ConfigMap my-cluster-3f8a1-config   rendered valkey.conf
+ │    └── Pod       my-cluster-3f8a1          one Valkey container
+ ├── ValkeyNode my-cluster-9c04d
+ │    ├── ConfigMap my-cluster-9c04d-config
+ │    └── Pod       my-cluster-9c04d
+ └── ... one ValkeyNode per Valkey node: shards × (1 + replicasPerShard)
+```
+
+Every object carries an owner reference to its parent, so deletion is a clean cascade with no orphans: deleting a `ValkeyCluster` removes its Service, Secret, ConfigMap, and all `ValkeyNode` resources, and each `ValkeyNode` takes its ConfigMap and Pod with it. Node (and therefore pod) names are the cluster name plus a short random suffix, not ordinal indexes; [Pod management](pod-management.md) explains why. The label taxonomy on these objects is documented in [Labels and annotations](../reference/labels-annotations.md).
+
+## The cluster Service and client discovery
+
+The operator creates exactly one Service per Valkey cluster: a **headless** Service named after the cluster (`my-cluster`), exposing port 6379 (client) and 16379 (cluster bus), selecting all of the cluster's pods. The operator creates no LoadBalancer, NodePort, or per-shard Service.
+
+A headless Service is sufficient because discovery is the Valkey cluster protocol's job, not the Service's. Clients use the Service DNS name (`my-cluster.my-app.svc.cluster.local`) only as a **seed address**: it resolves directly to pod IPs. From any node, a cluster-aware client learns the full topology (which node owns which slots) from the cluster protocol itself, and follows redirects from there. This is why you must use a cluster-aware client; a plain client fails on redirected keys.
+
+How nodes announce themselves depends on TLS:
+
+- **Without TLS**, nodes announce their pod IPs, and clients connect to IPs directly.
+- **With TLS**, nodes announce per-pod DNS names (`{pod}.my-cluster.my-app.svc.cluster.local`, published via the headless Service) so that the names clients connect to are covered by the certificate's wildcard SAN. Hostname verification therefore works across failovers and pod replacement.
+
+Connection examples, client configuration, and retry guidance are in [Connecting to a cluster](../team-guide/connecting.md).
+
+## What the operator does not manage
+
+The operator's scope is Valkey clusters, deliberately nothing more. You (or your platform) own:
+
+- **The Kubernetes cluster itself**: Kubernetes node capacity, zones, upgrades, and the scheduler the operator relies on. For how drains and Kubernetes upgrades interact with Valkey pods, see [Kubernetes maintenance](../platform-guide/kubernetes-maintenance.md).
+- **Networking beyond the headless Service**: the operator creates no Ingress, no LoadBalancer, and has no service-mesh integration. Exposure beyond the Kubernetes cluster boundary is your design decision.
+- **Certificates themselves**: the operator validates, mounts, and hot-reloads the TLS Secret you provide, but it does not issue, renew, or monitor certificates. Issuance and renewal belong to your PKI (cert-manager works well); see [TLS](../security/tls.md).
+- **Persistent storage**: the operator provisions no PersistentVolumes, by design; Valkey data is in-memory and durability comes from replication and failover, not disks. Read [Data durability](data-durability.md) before relying on any survivability assumption.
+
+## Why this architecture holds up
+
+The operator keeps **no required state in memory between reconcile passes**. Everything it needs to act is in the Kubernetes API (resource specs, `ValkeyCluster` status, including the `targetSpec` snapshot, owner references) and in what the Valkey nodes themselves report. Each pass re-reads the world, takes at most one action, and re-queues.
+
+That property is what makes the single-replica design safe in practice:
+
+- **Operator restarts and upgrades are non-events for your data plane.** Running Valkey clusters keep serving traffic, replication keeps flowing, and Valkey's own automatic failover still works, because none of that depends on the operator process. When the operator comes back, it re-reads the world and resumes exactly where the state says it should, including mid-bootstrap or mid-rolling-replacement.
+- **While the operator is down, nothing heals and nothing progresses.** Spec changes queue, dead nodes are not replaced, and scaling waits. The failure window is a loss of *convergence*, not a loss of *service*. The operator-down row of [Failure modes](../operations/failure-modes.md) covers exactly what does and does not happen.
+- **Upgrading the operator is an ordinary rollout** of a new image against this stateless loop; the procedure is in [Operator upgrades](../platform-guide/operator-upgrades.md).
+
+:::info
+Because there is no leader election and one replica, do not scale the operator Deployment above one replica. Scaling it to zero is the (blunt) supported way to halt all reconciliation. See [Failure modes](../operations/failure-modes.md).
+:::

--- a/docs/self-hosted/valkey-operator/concepts/data-durability.md
+++ b/docs/self-hosted/valkey-operator/concepts/data-durability.md
@@ -1,0 +1,51 @@
+---
+title: Data durability
+description: The storage model of operator-managed Valkey clusters (in-memory, ephemeral pod storage) and exactly which events lose data.
+sidebar_position: 6
+---
+
+# Data durability
+
+This page states the storage model of operator-managed Valkey clusters plainly and enumerates exactly which failure events lose data. Read it before deciding which workloads belong on a Valkey cluster, and before choosing `replicasPerShard` and placement settings.
+
+## The storage model
+
+Valkey clusters managed by the Momento Valkey Operator are **in-memory**. Pod storage is an ephemeral `emptyDir` volume that holds only cluster metadata; the operator requests no PersistentVolumes or PersistentVolumeClaims. **Nothing survives pod termination.** There is no backup or restore facility today: backup/restore is under investigation on the [roadmap](../roadmap.md).
+
+:::warning
+Enabling Valkey persistence settings (such as append-only files or snapshots) in a `ValkeyConfig` does not change this. Those files are written to the pod's ephemeral volume and are deleted with the pod, so they do not alter any of the loss semantics below.
+:::
+
+Durability in this model comes from three mechanisms working together:
+
+- **Replication**: each shard's data is copied to `replicasPerShard` replicas.
+- **Failover**: when a primary dies, a replica is promoted (by Valkey automatically, or forced by the operator) and serving continues from the copy.
+- **Placement**: zone and host spread keep a shard's primary and replicas off the same machine and zone, so one infrastructure failure rarely takes out all copies at once. See [Zone-aware placement](../operations/zone-aware-placement.md).
+
+Valkey replication is **asynchronous**: a generic property of Valkey, not specific to this operator. A write acknowledged by a primary might not yet have reached its replicas; if the primary dies at that moment, writes within the replication lag are lost even though a replica takes over.
+
+## Loss semantics by event
+
+| Event | Data impact |
+|---|---|
+| Replica pod lost | **No data loss.** The primary keeps serving; the operator creates a replacement replica that syncs from the primary. |
+| Primary lost, in-sync replica exists | **Writes within the replication lag might be lost** (asynchronous replication, see above). The replica is promoted and serving continues from its copy. |
+| Primary lost, **no** replica | **That shard's data is lost.** There is no surviving copy. The operator removes the dead primary from the topology, creates a fresh, empty primary for the shard's slots, and the cluster returns to `Active`: healthy, with a permanent hole in the data. |
+| Zone lost | **Depends on placement.** With `zoneSpread: required` and `replicasPerShard` ≥ 1, each shard's members span zones, so surviving replicas exist (subject to replication lag). With best-effort spread, a shard's members might be co-located in the lost zone. See [Zone-aware placement](../operations/zone-aware-placement.md). |
+| All pods of one shard lost simultaneously | **That shard's data is lost**, regardless of replica count: every copy was destroyed. The operator restores an empty shard. |
+| Full Valkey cluster restart (all pods terminated) | **All data is lost.** The cluster must be repopulated from your systems of record. |
+
+The operator's recovery behavior for each of these events (failover paths, quorum handling, timelines) is cataloged in [Failure modes](../operations/failure-modes.md).
+
+:::info
+With `replicasPerShard: 0`, *every* primary pod loss is a data-loss event for that shard, including routine Kubernetes node drains and evictions.
+:::
+
+## Mitigations
+
+- **Run `replicasPerShard` ≥ 1 in production, always.** Replication is the only mechanism that gives a shard's data a second copy.
+- **Use `zoneSpread: required`.** It makes the per-shard zone spread a hard scheduling constraint, so a shard's copies cannot land in one zone. See [Zone-aware placement](../operations/zone-aware-placement.md).
+- **Set resources in curated configs.** Pods with cpu and memory set get Guaranteed quality of service; a config with no `resources` yields BestEffort pods, the first evicted under Kubernetes node pressure, which for an in-memory store means data loss. Size memory with headroom over `maxmemory`. See [Sizing](../operations/sizing.md).
+- **Design clients for a re-warmable store.** Treat operator-managed Valkey as a cache or recomputable/re-hydratable store: keep the system of record elsewhere, tolerate misses after a loss event, and handle the brief write failures that accompany a failover. The client-side retry and topology-refresh specifics are in [Connecting to your cluster](../team-guide/connecting.md#resilience-during-a-failover).
+
+The operator's data-safety *mechanisms* during planned operations are precise: replacements join and sync before old nodes retire, slot migration moves a shard's slots before the shard is removed, and a rolling replacement performs one clean, sync-gated failover per shard (see [Reconciliation](reconciliation.md)). But no mechanism changes the fundamentals above: the store is in-memory, replication is asynchronous, and a shard with no surviving copy is gone.

--- a/docs/self-hosted/valkey-operator/concepts/index.md
+++ b/docs/self-hosted/valkey-operator/concepts/index.md
@@ -1,0 +1,21 @@
+---
+title: Concepts
+description: "How the Momento Valkey Operator is designed: its resource model, runtime architecture, reconciliation behavior, pod management, and data durability model."
+sidebar_position: 1
+---
+
+# Concepts
+
+This section explains how the Momento Valkey Operator works and why it is designed the way it is. Read it when you want to understand the system. For step-by-step instructions, use the [platform team guide](../platform-guide/index.md) and [product team guide](../team-guide/index.md).
+
+The pages build on each other, but each stands alone:
+
+- **[Resource model](resource-model.md)** — the five custom resources, why the model is split into a cluster-scoped "menu" (images, configs, roles) and namespaced clusters, and how that split gives platform teams governance through nothing more than Kubernetes RBAC. Start here.
+- **[Architecture](architecture.md)** — the runtime picture: a single operator deployment running four independent control loops, the chain of Kubernetes objects it creates and owns, how clients discover cluster topology, and what the operator deliberately does not manage.
+- **[Reconciliation](reconciliation.md)** — the cluster state machine, the `targetSpec` snapshot semantics, and the one-action-per-tick model that makes every change observable and bounded in blast radius. Owns the canonical table of which spec changes trigger a rolling replacement.
+- **[Pod management](pod-management.md)** — why the operator manages bare pods directly instead of using StatefulSets or Deployments, and what an experienced Kubernetes user will notice as a result.
+- **[Data durability](data-durability.md)** — the storage model stated plainly: Valkey data is in-memory, and durability comes from replication, failover, and placement, not from disks. Read this before making availability promises to your users.
+
+:::note
+Concepts pages describe behavior; they do not walk through tasks. Where a task exists, the page links to the relevant guide.
+:::

--- a/docs/self-hosted/valkey-operator/concepts/pod-management.md
+++ b/docs/self-hosted/valkey-operator/concepts/pod-management.md
@@ -1,0 +1,61 @@
+---
+title: Pod management
+description: Why the Momento Valkey Operator manages pods directly instead of through StatefulSets or Deployments, and what that looks like in your Kubernetes cluster.
+sidebar_position: 5
+---
+
+# Pod management
+
+The Momento Valkey Operator creates and manages bare pods directly: there is no StatefulSet or Deployment underneath a Valkey cluster. This page explains why, and walks through the things an experienced Kubernetes user will notice about operator-managed pods, each of which is intentional.
+
+## Why not a StatefulSet
+
+Generic workload controllers reconcile a pod count against a pod template. The unit of correctness for a Valkey cluster is different: it is the cluster topology (which node is a primary, which shard it belongs to, whether its replicas are in sync). Managing that safely requires semantics no generic controller can express:
+
+- **Topology-aware replacement order.** Which pod to replace next, and when, depends on the live topology: shard membership, primary or replica role, replication sync state. Ordinal order or template-hash order is meaningless here.
+- **Replace before retire.** When a node must be replaced, the operator first creates its successor, joins it to the shard, and waits for it to sync; only then does the old node leave. A controller that deletes a pod and recreates it in place cannot provide this overlap.
+- **Exactly one client-visible failover per shard during a roll.** Replacing a primary requires a deliberate, coordinated failover at a moment the operator chooses, after the promoted replica has caught up. See [Reconciliation](reconciliation.md) for the rolling-replacement procedure.
+
+Instead of a workload controller, each Valkey cluster member is modeled as a `ValkeyNode` resource: an operator-internal, read-only-to-you record that owns exactly one pod and one ConfigMap, with an explicit lifecycle (`Joining` → `Active` → `Leaving`). Membership changes are always expressed as lifecycle transitions on these resources, which makes every step of a transition observable with `kubectl`.
+
+## What you will notice
+
+### Random pod names
+
+Pods (and their `ValkeyNode` resources) are named `{cluster}-{random-suffix}`, not `{cluster}-0`, `{cluster}-1`. Identity does not live in the pod name; it lives in the `ValkeyNode` resource and the Valkey cluster topology. A replaced member gets a new name; a changing pod name is normal and expected. To locate pods, use the labels instead: `app.kubernetes.io/instance={cluster}` selects a cluster's pods, and `valkey.gomomento.com/shard-index` identifies the shard.
+
+### restartPolicy: Never
+
+A dead pod is evidence. If the kubelet restarted a crashed Valkey process in place, the operator would have to reverse-engineer what happened from the outside. Instead, a pod that dies stays dead, the operator observes it, and replaces the member through the `ValkeyNode` lifecycle, failing over first if the dead member was a primary. Every state transition in the Valkey cluster is therefore deliberate: taken by the operator or by the Valkey cluster protocol itself, never by the kubelet.
+
+### Liveness-only probes
+
+Pods carry a liveness probe (an authenticated ping, or a TCP check on TLS clusters) and **no readiness probe**. This is deliberate: readiness gates Service endpoints, but clients of a Valkey cluster do not load-balance through Service endpoints; they discover topology through the cluster protocol, which has its own gossip-based view of node health. A readiness gate would remove a node from DNS while the cluster protocol still routes to it (or the reverse), presenting two conflicting health views. The liveness probe exists only to turn a hung server into a dead pod, which, per the previous point, is exactly the signal the operator acts on.
+
+### No PodDisruptionBudgets
+
+The operator creates no PDBs. What stands in for them:
+
+- **Replicas**: with `replicasPerShard` ≥ 1, a shard survives losing a member.
+- **Zone and host spread**: per-shard topology spread constraints keep a shard's members off the same Kubernetes node and zone, so one machine or zone rarely takes out a whole shard.
+- **The operator's own pacing**: one action per tick, one shard in motion at a time.
+
+Nothing, however, blocks a drain from evicting several Valkey pods at once. For Kubernetes node drains and Kubernetes upgrades, pace the work and let the operator recover between steps. See [Kubernetes maintenance](../platform-guide/kubernetes-maintenance.md).
+
+### Built-in arm64 toleration
+
+Every Valkey pod carries a toleration for `kubernetes.io/arch=arm64:NoSchedule`. If your platform taints arm64 Kubernetes node pools expecting only explicitly opted-in workloads, be aware that Valkey pods can schedule onto those pools whenever their placement constraints otherwise allow it. Use `placement.nodeSelector` or `placement.zones` to steer pods where you want them. See [Zone-aware placement](../operations/zone-aware-placement.md).
+
+### Ephemeral storage only
+
+Pods request no PersistentVolumeClaims; the data directory is an `emptyDir` that dies with the pod. This is a property of the storage model, not an accident. See [Data durability](data-durability.md).
+
+## How drains and evictions look to the operator
+
+An eviction (from a Kubernetes node drain, autoscaler scale-down, or resource pressure) deletes the pod, and `restartPolicy: Never` means nothing brings it back in place. From the operator's point of view this is indistinguishable from any other pod death:
+
+1. The member disappears; the operator (and the Valkey cluster's own gossip) notice.
+2. If the dead member was a primary, a replica is promoted: by Valkey's automatic failover when quorum holds, or forced by the operator when it does not.
+3. The dead member is forgotten from the topology, and a replacement node is created, joins the shard, syncs, and activates.
+
+The full event-by-event behavior, including the no-replica cases, is cataloged in [Failure modes](../operations/failure-modes.md).

--- a/docs/self-hosted/valkey-operator/concepts/reconciliation.md
+++ b/docs/self-hosted/valkey-operator/concepts/reconciliation.md
@@ -1,0 +1,122 @@
+---
+title: Reconciliation
+description: "How the Momento Valkey Operator changes things: cluster states, one action per tick, the repair priority order, and which spec changes replace pods."
+sidebar_position: 4
+---
+
+# Reconciliation
+
+This page explains how the Momento Valkey Operator turns a `ValkeyCluster` spec into a running Valkey cluster and keeps it that way: the states you can observe, how the operator paces changes, and (most importantly for day-2 operations) [what happens when you edit a live cluster's spec](#what-happens-when-you-change-the-spec). Read it before planning upgrades, scaling, or maintenance.
+
+## The cluster state machine
+
+A `ValkeyCluster` reports one of three observable states in `status.state`:
+
+| State | Meaning |
+|---|---|
+| `Creating` | The initial state. The operator is bootstrapping the Valkey cluster: creating nodes, forming the topology, assigning slots, attaching replicas. |
+| `Active` | Steady state. All ongoing change (scaling, rebalancing, rolling replacement, failure recovery) happens while the cluster reports `Active`. |
+| `Invalid` | The referenced TLS Secret failed validation. Reconciliation of the cluster is paused until the Secret validates. |
+
+:::note
+The schema also defines an `Updating` value. It is reserved and not currently reported: rolling upgrades and other changes run entirely under `Active`. See [Cluster status](../reference/cluster-status.md) for the full status schema.
+:::
+
+`Invalid` has exactly one trigger: TLS Secret validation failure. On every reconciliation pass of a TLS-enabled cluster, the operator validates the referenced Secret: it must exist, contain the expected keys, hold a well-formed certificate, and cover the required DNS names. Any failure sets `status.state: Invalid` with the specific reason in `status.message`. Recovery is automatic: once the Secret validates again (you create the missing Secret, fix its contents, or point `tls.secretRef` at a valid one), the operator resets the cluster and it returns to `Active` within a few reconciliation passes. You never need to recreate the `ValkeyCluster` resource. See [TLS](../security/tls.md) for the validation rules.
+
+## targetSpec, spec snapshots and deferred edits
+
+When the operator begins a transition (entering `Creating`), it snapshots the spec into `status.targetSpec` and drives the bootstrap **topology** (shard count and replicas per shard) toward that snapshot, not toward the live spec. Topology edits you make while the transition is in flight are deferred, not lost: once the transition completes and `targetSpec` is cleared, the next reconciliation pass picks up the current spec and acts on it. Non-topology fields (`configRef` resolution, `placement`, `tls.secretRef`, `acl`) are read live on every pass even during bootstrap, but each node's own spec is fixed when that node is created, so live edits shape only nodes not yet created.
+
+This has one consequence worth internalizing: a spec mistake made at creation generally cannot be corrected by editing the spec while the cluster is still `Creating`: deferred topology edits don't apply until bootstrap ends, and live-read fields don't repair nodes already created under the old values. Fixes *outside* the spec do take effect immediately (for example, creating a `ValkeyImage` or `ValkeyConfig` that a reference points to) because references are resolved live on every pass. Spec-level mistakes require deleting and recreating the cluster. See the wedged-bootstrap entry in [Troubleshooting](../operations/troubleshooting.md).
+
+## One action per tick
+
+The operator is stateless between reconciliation passes ("ticks"). Every tick, for each cluster, it:
+
+1. Rediscovers actual state from scratch: the cluster's `ValkeyNode` resources, their pods, and the live Valkey topology as the nodes themselves report it.
+2. Compares that against the desired spec.
+3. Takes **at most one corrective action** (create one node, move one batch of slots, fail over one shard), then requeues and starts over.
+
+Ticks are event-driven (edits to a `ValkeyCluster`, or to a `ValkeyConfig` or `ValkeyImage` it references, trigger reconciliation immediately) and otherwise re-run on short intervals: seconds while work is in flight. A tick that fails (for example, because a `configRef`, `imageRef`, or `roleRef` cannot be resolved) takes no partial action and is retried.
+
+This design is deliberate:
+
+- **Predictability.** Each state change is a single, small, well-defined step. No compound action is ever half-applied.
+- **Bounded blast radius.** A wrong decision (or a badly timed failure) affects one node or one slot batch, not the whole Valkey cluster.
+- **Observable progress.** You can watch a transition happen step by step through `ValkeyNode` resources, pod events, and the cluster's own topology commands.
+- **Safe operator restarts.** Because no plan is held in memory, restarting or upgrading the operator mid-transition loses nothing. The next tick rediscovers reality and continues.
+
+:::note
+There is one documented exception: when the operator removes a dead member from the topology, it issues the forget command to every live node in the same tick. The cluster protocol does not gossip forgets, and a partially-forgotten node would be re-learned from peers that still remember it.
+:::
+
+## What the operator fixes first
+
+When multiple things need attention, the first applicable action in a fixed priority order wins the tick. In plain language, the order is:
+
+1. **Stability.** Restore a healthy primary to every shard: wait for Valkey's automatic failover when a replica and quorum exist, force a takeover when quorum is lost, or, when a failed primary has no replica, remove it and create a fresh, empty primary (a data-loss event; see [Data durability](data-durability.md)). Then forget departed members that are still in the topology, and restore each shard's replica count.
+2. **Topology.** Complete the departure of any node marked as leaving, retire shards that have been drained of slots (scale-in), rebalance slots toward an even distribution, and add new shards (scale-out).
+3. **Updates.** Roll outdated nodes to the current spec, one shard at a time (see below).
+4. **Cleanup.** Remove excess replicas and terminate nodes that no longer belong to any shard.
+
+Stability always preempts everything else: a Valkey cluster with an unhealthy primary is repaired before any scaling, rebalancing, or upgrade work continues. This is also how the operator avoids wedging when a failure lands mid-workflow: the failure is repaired first, then the interrupted work resumes from rediscovered state.
+
+## What happens when you change the spec
+
+:::info
+This is the canonical change-impact table. Every field you can edit on a live `ValkeyCluster` falls into one of three categories: it triggers a **rolling pod replacement**, it applies **in place** to running pods, or it affects **only future pods**.
+:::
+
+| Spec change | Impact |
+|---|---|
+| Image: the resolved `ValkeyImage` changes (a `ValkeyConfig`'s `imageRef` is repointed, or the `ValkeyImage`'s repository/tag is edited) | **Rolling pod replacement.** Editing a menu resource rolls *every* cluster that references it. See [Valkey upgrades](../platform-guide/valkey-upgrades.md). |
+| `resources` (cpu, memory) anywhere in the resolved config | **Rolling pod replacement.** |
+| Any `valkey` setting anywhere in the config inheritance chain | **Rolling pod replacement.** |
+| Switching the cluster's `configRef` to a different `ValkeyConfig` | **Rolling pod replacement** (if the resolved result differs). |
+| `placement.zones` (compared as a set; reordering is not a change) | **Rolling pod replacement.** |
+| `placement.nodeSelector` | **Rolling pod replacement.** |
+| `podAnnotations` | **In place.** Added or changed annotations are patched onto live pods; *removals* take effect only when a pod is next replaced. |
+| ACL changes (`spec.acl` bindings, config-level bindings, edits to a referenced `ValkeyRole`) | **In place.** The rendered ACL file is updated and reloaded on every node: no pod restarts. Changes reach nodes in two stages: kubelet volume propagation (typically up to about a minute) plus the ACL controller's 30-second pass. See [ACLs](../security/acls.md). |
+| `tls.secretRef` rotation (new certificate material) | **In place.** Nodes re-read certificates from disk: no pod restarts. Same two-stage propagation as ACLs. See [TLS](../security/tls.md). |
+| `placement.zoneSpread` | **Future pods only.** It is a scheduling preference baked into pods at creation; existing pods are not replaced or moved. |
+
+Two related notes:
+
+- `shards` and `replicasPerShard` are topology changes, not pod-template changes: the operator adds or removes nodes and rebalances slots rather than replacing existing pods. See [Scaling](../team-guide/scaling.md).
+- TLS *presence* is immutable: you cannot enable or disable TLS on an existing cluster (admission rejects the edit). Only `tls.secretRef` may change.
+
+### How a rolling replacement proceeds
+
+When any node's spec is outdated, the operator rolls the Valkey cluster **strictly one shard at a time**, in a deterministic shard order. Within the shard, it replaces before it retires:
+
+1. Create a new node with the up-to-date spec and join it to the shard as a replica.
+2. Once the shard is over its replica target, retire an outdated replica.
+3. If the primary is outdated, issue **exactly one** coordinated failover onto an up-to-date replica. The failover command performs a clean handoff: the replica is promoted only after it has caught up with the primary.
+4. Retire the demoted, outdated former primary as an excess replica.
+
+The result: clients see at most one failover per shard per roll, the shard never drops below its replica target because new capacity joins before old capacity leaves, and only one shard is in motion at any moment. The cluster reports `Active` throughout.
+
+## The bootstrap sequence
+
+A new `ValkeyCluster` moves from `Creating` to `Active` through a fixed sequence, one step per tick:
+
+1. **Snapshot.** The spec is captured into `status.targetSpec` (see above).
+2. **Create nodes.** One `ValkeyNode` per tick, spread evenly across shard indices, until `shards × (1 + replicasPerShard)` exist. Each node brings up its own configuration and pod.
+3. **Wait for pods.** Bootstrap does not proceed until every pod is running with an IP address. An unschedulable pod (for example, unsatisfiable placement) makes bootstrap wait: it logs the scheduler's reason and holds, rather than proceeding with a partial topology. See [Troubleshooting](../operations/troubleshooting.md) for stuck-`Creating` diagnosis.
+4. **Cluster meet.** Nodes are introduced to the topology one per tick through a seed node, and any stale member from a previous incarnation is forgotten.
+5. **Assign slots.** Slot assignment is gated on consensus: every node must agree on how many slots are currently assigned before the operator hands out more. It then assigns contiguous slot ranges to one designated primary per tick.
+6. **Attach replicas.** One replica per tick is attached to the primary of its shard.
+7. **Verify and activate.** Nodes flip from `Joining` to `Active` lifecycle, and the cluster is marked `Active` only when every node reports a healthy cluster view, **all 16384 slots are assigned**, the shard count matches the target, and every slot-holding primary has its full replica count. `targetSpec` is cleared and any deferred edits are picked up.
+
+Full slot coverage is the operator's universal invariant: bootstrap, scaling, upgrades, and failure recovery all converge on all 16384 slots assigned.
+
+## Deletion
+
+Deleting a `ValkeyCluster` tears down everything it created, with nothing left behind. Finalizers (`valkey.gomomento.com/cleanup` on the cluster, `valkey.gomomento.com/node-cleanup` on each node) gate the deletion, and every dependent object (`ValkeyNode` resources, pods, per-node ConfigMaps, the ACL ConfigMap, the auth Secret, and the headless Service) carries an owner reference to the cluster, so Kubernetes garbage collection cascades the removal. Teardown is scoped to the cluster's namespace.
+
+Deletion does not interact with the Valkey protocol: there is no flush or drain. Pods terminate with their resources, and because storage is ephemeral, the data is gone. See [Data durability](data-durability.md).
+
+:::warning
+Finalizers require a running operator to clear. If the operator is down (or was uninstalled before its clusters were deleted), a deleted `ValkeyCluster` sits in `Terminating` indefinitely. See the stuck-`Terminating` entry in [Troubleshooting](../operations/troubleshooting.md).
+:::

--- a/docs/self-hosted/valkey-operator/concepts/resource-model.md
+++ b/docs/self-hosted/valkey-operator/concepts/resource-model.md
@@ -1,0 +1,165 @@
+---
+title: Resource model
+description: The five custom resources of the Momento Valkey Operator, why the model splits a cluster-scoped menu from namespaced clusters, and how references resolve between them.
+sidebar_position: 2
+---
+
+# Resource model
+
+This page explains the five custom resources the Momento Valkey Operator installs, why the model is split the way it is, and how the split turns ordinary Kubernetes RBAC into a governance mechanism. It is for both personas: platform teams own most of these resources; product teams interact with exactly one.
+
+## Five resources, one API group
+
+All five resources live in the API group `valkey.gomomento.com/v1alpha1`. Four are user-facing; one is operator-internal.
+
+| Kind | Scope | Purpose |
+|---|---|---|
+| `ValkeyImage` | Cluster | Allowlist entry for a permitted Valkey container image |
+| `ValkeyConfig` | Cluster | A curated configuration "menu item" (image, resources, Valkey settings, platform ACLs), with inheritance via `baseRef` |
+| `ValkeyRole` | Cluster | Reusable ACL permission template (command and category rules) |
+| `ValkeyCluster` | Namespaced | A product team's request for a Valkey cluster: config choice plus topology |
+| `ValkeyNode` | Namespaced | Operator-internal record of a single Valkey cluster member; read-only for users |
+
+Full field-by-field schemas live in the API reference: [`ValkeyImage`](../reference/api/valkeyimage.md), [`ValkeyConfig`](../reference/api/valkeyconfig.md), [`ValkeyRole`](../reference/api/valkeyrole.md), [`ValkeyCluster`](../reference/api/valkeycluster.md), [`ValkeyNode`](../reference/api/valkeynode.md).
+
+## Why the model is split this way
+
+A single "cluster" resource with an image field would work mechanically, but it would leave the platform team with no control point: any team could run any image with any configuration. The operator's model separates *what is allowed* (cluster-scoped, platform-owned) from *what is requested* (namespaced, team-owned).
+
+### ValkeyImage, the allowlist
+
+A `ValkeyImage` names a container image (`repository` + `tag`) and the Valkey version it provides. It is not a convenience alias; it is an allowlist. Every Valkey cluster's configuration must ultimately resolve to a `ValkeyImage` by name, and the operator resolves that reference on every reconcile. If no `ValkeyImage` with that name exists, resolution fails and the Valkey cluster cannot run. Removing an image from the allowlist therefore blocks new use of it; adding one is the only way to permit it.
+
+Because the reference is by name and resolved live, upgrades are also governed here: repointing a config at a new `ValkeyImage` rolls every Valkey cluster that references it. See [Managing Valkey upgrades](../platform-guide/valkey-upgrades.md).
+
+### ValkeyConfig, the curated menu
+
+A `ValkeyConfig` bundles everything about *how* a Valkey node runs: which allowlisted image (`imageRef`), CPU and memory, Valkey settings, and platform-level ACL bindings. Platform teams publish a small menu of these (for example `standard` and `large`) and product teams pick from it by name. Product teams never set an image, resource size, or engine setting directly; they can only choose a menu item.
+
+Configs compose through `baseRef`: a config can inherit from another config and override selectively. Fields set on the child win; the `valkey` settings map merges per key (a child key overrides that key, unrelated base keys survive); ACL bindings are the exception: a config that sets `acl` replaces its base's bindings entirely rather than merging. Chains resolve up to 10 levels deep. This lets a platform team maintain one base config and publish size variants that differ only in resources:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0
+spec:
+  repository: valkey/valkey
+  tag: 9.0.0
+  version: 9.0.0
+---
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: 2Gi
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: allkeys-lru
+---
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: large
+spec:
+  baseRef: standard        # inherits image and settings from `standard`
+  resources:
+    cpu: "4"
+    memory: 16Gi
+  valkey:
+    maxmemory: "12gb"      # overrides this one key; other keys inherited
+```
+
+The operator force-injects a small set of cluster-critical settings (cluster mode, ports, file paths, replication identity) into every node regardless of what a config specifies. See [Forced settings](../reference/forced-settings.md). Authoring guidance, including the merge rules and memory headroom, is in [Curating images and configs](../platform-guide/curating-images-and-configs.md).
+
+### ValkeyRole, reusable permission templates
+
+A `ValkeyRole` captures a reusable set of Valkey ACL command and category permissions, for example, a `cache-readwrite` role or a `metrics-readonly` role. Roles deliberately contain *only* command permissions. Everything identity- and data-scoped (usernames, password hashes, key patterns, channel patterns) is specified at the binding site: in a `ValkeyConfig` (platform-level bindings applied to every cluster using that config) or in a `ValkeyCluster` (per-cluster bindings). One role can therefore serve many teams, each binding it to their own users and key spaces. The full model is described in [ACLs](../security/acls.md).
+
+### ValkeyCluster, the product team's single touchpoint
+
+A `ValkeyCluster` is the one resource a product team creates. It names a config from the menu and states topology and per-cluster choices:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+```
+
+Everything else (pods, ConfigMaps, Secrets, the Service, slot assignment, failover, rolling replacement) is derived from this spec by the operator. Product teams observe progress through the resource's status (`state`, `message`, node list); see [Cluster status](../reference/cluster-status.md) and [Provisioning a cluster](../team-guide/provisioning.md). A namespace can hold any number of `ValkeyCluster` resources.
+
+### ValkeyNode, operator-internal
+
+For each Valkey cluster member, the operator creates a `ValkeyNode` resource recording that node's fully resolved state: the exact image, resources, rendered settings, and placement. Its spec is immutable by design: when anything about a node needs to change, the operator creates a replacement node and retires the old one rather than mutating it in place. This is the mechanism behind rolling replacement (see [Reconciliation](reconciliation.md) and [Pod management](pod-management.md)).
+
+You can see `ValkeyNode` resources with `kubectl get valkeynodes`, and reading them is useful for observing lifecycle transitions (`Joining`, `Active`, `Leaving`). Do not create or edit them; they exist for the operator, not for users.
+
+## Scoping as the governance mechanism
+
+The split between cluster-scoped and namespaced resources is not incidental; it is the entire governance model.
+
+- `ValkeyImage`, `ValkeyConfig`, and `ValkeyRole` are **cluster-scoped**. Only the platform team holds write access to them; product teams get read-only access (a ClusterRoleBinding, since namespaced RoleBindings cannot grant access to cluster-scoped resources).
+- `ValkeyCluster` is **namespaced**. Product teams get full CRUD on it within their own namespaces via an ordinary RoleBinding, and nothing outside them.
+
+The result: a product team can provision as many Valkey clusters as they want, but only from images, configurations, and roles the platform team has published. No admission webhooks and no external policy engine are involved: enforcement is pure Kubernetes RBAC on resource scope, plus validation rules compiled into the CRD schemas themselves. A team without write access to the menu cannot put an unapproved image or setting into service, because there is no field on `ValkeyCluster` where one could go.
+
+Complete onboarding manifests for this split are in [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md); what the operator's own service account can do is documented in [Operator RBAC](../security/rbac.md).
+
+## How references resolve
+
+References are plain names, resolved live by the operator on every reconcile: there is no admission-time existence check. A dangling reference (for example, a `configRef` naming a config that does not exist, or a config chain that never reaches a valid `imageRef`) blocks reconciliation of the affected Valkey cluster until the referenced resource appears:
+
+```text
+ValkeyCluster my-cluster (namespace: my-app)
+    │
+    │ spec.configRef
+    ▼
+ValkeyConfig large ── spec.baseRef ──▶ ValkeyConfig standard
+    │                                       │
+    │        spec.imageRef (first one found in the chain)
+    └───────────────────┬───────────────────┘
+                        ▼
+              ValkeyImage valkey-9-0        ◀── allowlist: if this
+                                                resource does not exist,
+                                                the cluster cannot run
+
+ACL bindings (ValkeyConfig.spec.acl and ValkeyCluster.spec.acl)
+    │
+    │ permissions[].roleRef
+    ▼
+ValkeyRole cache-readwrite                  ◀── command permissions;
+                                                users, passwords, and key
+                                                patterns stay at the binding
+```
+
+Because resolution is live, fixing a broken reference requires no change to the `ValkeyCluster` itself: creating the missing `ValkeyImage` or `ValkeyConfig` unblocks every cluster waiting on it on its next reconcile.
+
+## Who touches what
+
+| Resource | Platform team | Product team | The operator |
+|---|---|---|---|
+| `ValkeyImage` | create, update, delete | read (browse the allowlist) | reads to resolve images |
+| `ValkeyConfig` | create, update, delete | read (browse the menu) | reads to resolve cluster configuration |
+| `ValkeyRole` | create, update, delete | read | reads to render ACL files |
+| `ValkeyCluster` | typically none (governs via the menu) | create, update, delete in own namespace | reads spec; writes status |
+| `ValkeyNode` | read (troubleshooting) | read (observe lifecycle) | creates, updates lifecycle, deletes |
+
+:::info
+`ValkeyNode` is read-only for everyone except the operator. Manually editing or deleting one interferes with reconciliation in ways the operator does not expect.
+:::
+
+## Where to go next
+
+- [Architecture](architecture.md) — the control loops that act on these resources and the Kubernetes objects they create.
+- [Curating images and configs](../platform-guide/curating-images-and-configs.md) — building the menu (platform team).
+- [Provisioning a cluster](../team-guide/provisioning.md) — consuming the menu (product team).

--- a/docs/self-hosted/valkey-operator/getting-started/glossary.md
+++ b/docs/self-hosted/valkey-operator/getting-started/glossary.md
@@ -1,0 +1,47 @@
+---
+title: Glossary
+description: Definitions of the Valkey terms and operator vocabulary used throughout these docs, including the three meanings of the word "cluster".
+sidebar_position: 5
+---
+
+# Glossary
+
+This page defines the Valkey terms and the operator's own vocabulary that the rest of these docs use. It serves two readers: Kubernetes engineers who haven't run Valkey before, and Valkey engineers meeting this operator's resource model for the first time. Kubernetes fundamentals (pods, custom resources, controllers, RBAC) are assumed throughout these docs and aren't defined here.
+
+## Three meanings of "cluster"
+
+The word "cluster" names three different things in any conversation about this operator. These docs always distinguish them:
+
+- **Valkey cluster.** The sharded Valkey deployment itself: a set of Valkey nodes that split the keyspace and replicate within shards. This is the thing that serves your traffic.
+- **Kubernetes cluster.** The Kubernetes environment everything runs in. Always written fully qualified in these docs, never bare "cluster".
+- **`ValkeyCluster`.** The namespaced custom resource a product team creates to declare a Valkey cluster. Code-formatted, exact casing. See the [`ValkeyCluster` API reference](../reference/api/valkeycluster.md).
+
+## Valkey terms
+
+- **node.** One member of a Valkey cluster: a single Valkey process. The operator runs each node as one pod and tracks it with a [`ValkeyNode`](../reference/api/valkeynode.md) resource. A machine in the Kubernetes cluster is always "Kubernetes node".
+- **shard.** A primary and its replicas, together owning a range of hash slots. A `ValkeyCluster`'s `shards` field sets how many shards exist; see [Scaling a cluster](../team-guide/scaling.md).
+- **hash slot.** One of the 16384 buckets the keyspace is divided into. Every key hashes to exactly one slot, and every slot is owned by exactly one shard. Scaling and rebalancing move slots between shards; the operator treats "all 16384 slots assigned" as the invariant a healthy cluster converges on. See [Reconciliation](../concepts/reconciliation.md).
+- **primary and replica.** The two roles within a shard. The primary serves writes for the shard's slots; replicas replicate it and stand by for promotion. These docs never use the terms master or slave.
+- **failover.** Promotion of a replica to primary after the primary is lost. Depending on the failure, this is Valkey's own election or an operator-forced takeover; [Failure modes](../operations/failure-modes.md) covers every case.
+- **cluster bus.** The node-to-node channel on port `16379` that carries topology gossip and failure detection, separate from the client port `6379`. Application clients never use it. See [Connecting to your cluster](../team-guide/connecting.md).
+- **cluster-aware client.** A client library that speaks the Valkey cluster protocol: it maintains a map of slot ownership, follows redirects, and refreshes its view when topology changes. Connecting with anything less breaks; [Connecting to your cluster](../team-guide/connecting.md) explains why.
+- **`MOVED` redirect.** The response a node returns when a client asks it for a key whose slot lives on a different shard, naming the node that owns it. Cluster-aware clients follow these automatically.
+- **ACL.** Valkey's access control lists: named users with permissions over commands and key patterns. The operator manages ACLs declaratively; see [ACLs](../security/acls.md).
+
+## Operator terms
+
+- **the operator.** The Momento Valkey Operator: the controllers that turn the custom resources below into running Valkey clusters and keep them converged. [Architecture](../concepts/architecture.md) describes its runtime shape.
+- **the menu.** The cluster-scoped resources the platform team curates and product teams consume by reference: [`ValkeyImage`](../reference/api/valkeyimage.md) (allowlisted engine images), [`ValkeyConfig`](../reference/api/valkeyconfig.md) (named configuration profiles), and [`ValkeyRole`](../reference/api/valkeyrole.md) (reusable ACL permission sets). Cluster scoping is what makes the menu a governance mechanism; see [Resource model](../concepts/resource-model.md).
+- **platform team and product team.** The two personas the operator is built around. The platform team installs the operator and owns the menu; product teams create `ValkeyCluster` resources in their own namespaces. The split is enforced by Kubernetes RBAC, not by a policy engine; see [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md).
+- **reconciliation tick.** One pass of a control loop comparing desired state against observed state. The cluster loop takes at most one cluster-changing action per tick, which is why changes roll out as a sequence of small observable steps. See [Reconciliation](../concepts/reconciliation.md).
+- **`targetSpec`.** The snapshot of a cluster's spec that the operator is currently driving toward. Spec edits made while a transition is in progress are deferred until the current target is reached. See [Cluster status](../reference/cluster-status.md).
+- **cluster states.** The `state` printer column of a `ValkeyCluster`: `Creating`, `Active`, or `Invalid` in practice, with `Updating` reserved in the schema but not reported. [Cluster status](../reference/cluster-status.md) defines each.
+- **node lifecycle.** The join/leave progression of a `ValkeyNode`: `Joining` (being added to the Valkey cluster), `Active` (full member), `Leaving` (being drained and retired). Watching lifecycles is the practical way to observe a bootstrap or a rolling replacement; see the [`ValkeyNode` API reference](../reference/api/valkeynode.md).
+- **forced settings.** Valkey configuration directives the operator injects into every node's rendered config, overriding any user-supplied value, because the cluster doesn't function without them. The exact list is in [Forced Valkey settings](../reference/forced-settings.md).
+- **zone spread.** The per-shard topology spread constraint that spreads a shard's nodes across availability zones, strictly or best-effort depending on the configured mode. Configured through `placement`; see [Zone-aware placement](../operations/zone-aware-placement.md).
+
+## Where to go next
+
+- **New to Valkey?** Read [Data durability](../concepts/data-durability.md) first: it states the in-memory storage model and its consequences plainly. Then [Connecting to your cluster](../team-guide/connecting.md) for how clients are expected to behave.
+- **New to the operator's model?** [Resource model](../concepts/resource-model.md) explains the five resources and the governance split; [Reconciliation](../concepts/reconciliation.md) explains how changes actually happen.
+- **Ready to try it?** The [quickstart](quickstart.md) has you running a sharded cluster in roughly 20 minutes.

--- a/docs/self-hosted/valkey-operator/getting-started/index.md
+++ b/docs/self-hosted/valkey-operator/getting-started/index.md
@@ -1,0 +1,28 @@
+---
+title: Getting started
+description: "Install the Momento Valkey Operator and run your first Valkey cluster: prerequisites, installation, and a hands-on quickstart."
+sidebar_position: 1
+---
+
+# Getting started
+
+This section takes you from an empty Kubernetes cluster to a running, sharded Valkey cluster managed by the Momento Valkey Operator. It is written for both personas: the platform team evaluating or installing the operator, and product teams who want to see a cluster working end to end.
+
+Work through the first three pages in order:
+
+- **[Prerequisites](prerequisites.md)** — version floors, required access, optional dependencies, and what the operator deliberately does not need. Includes a Pod Security Standards note you should read before choosing namespaces.
+- **[Installation](installation.md)** — install the CRDs and the operator from the v0.6.0 release artifacts, understand what lands in your Kubernetes cluster, and verify the rollout.
+- **[Quickstart](quickstart.md)** — the hands-on tutorial: register an image, define a config, provision a three-shard Valkey cluster, connect to it, scale it to four shards, and tear it down.
+- **[Glossary](glossary.md)** — the Valkey terms and operator vocabulary these docs use, including the three meanings of the word "cluster". Keep it open in a tab if either Valkey or this operator is new to you.
+
+Expect the prerequisites and installation pages to take a few minutes each; the quickstart is roughly 15 to 20 minutes at the keyboard, depending mostly on how fast your Kubernetes cluster pulls images and schedules pods.
+
+:::note
+The quickstart has you play both personas: registering menu resources as the platform team, then provisioning a cluster as a product team. In production these roles are separated by RBAC; see [Resource model](../concepts/resource-model.md).
+:::
+
+## Where to go next
+
+- **Platform engineers**: after installing, curate your image and config menu in [Curating images and configs](../platform-guide/curating-images-and-configs.md) and onboard teams with [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md).
+- **Product-team developers**: once the platform team has published a menu, start at [Provisioning a cluster](../team-guide/provisioning.md) and [Connecting to a cluster](../team-guide/connecting.md).
+- **Still evaluating?** Read [Why this operator](../why-this-operator.md) and the [Concepts](../concepts/index.md) section, especially [Data durability](../concepts/data-durability.md), which states the in-memory storage model plainly.

--- a/docs/self-hosted/valkey-operator/getting-started/installation.md
+++ b/docs/self-hosted/valkey-operator/getting-started/installation.md
@@ -1,0 +1,64 @@
+---
+title: Installation
+description: Install the Momento Valkey Operator from the v0.6.0 release artifacts, understand what it creates, and verify the rollout.
+sidebar_position: 3
+---
+
+# Installation
+
+This page installs the Momento Valkey Operator from the v0.6.0 GitHub release artifacts and verifies the rollout. It assumes the `cluster-admin` access described in [Prerequisites](prerequisites.md).
+
+## 1. Apply the CRDs
+
+```bash
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/crds.json
+```
+
+This registers all five custom resource definitions: `ValkeyImage`, `ValkeyConfig`, `ValkeyRole`, `ValkeyCluster`, and `ValkeyNode`.
+
+## 2. Deploy the operator
+
+```bash
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/operator.yaml
+```
+
+The operator image is pulled from Docker Hub at `gomomento/valkey-operator`.
+
+## What this installs
+
+`operator.yaml` creates:
+
+| Object | Name | Notes |
+|---|---|---|
+| Namespace | `valkey-operator` | Holds every object below. |
+| ServiceAccount | `valkey-operator` | Identity the operator Deployment runs as. |
+| ClusterRole + ClusterRoleBinding | `valkey-operator` | Grants the operator the permissions it needs across all namespaces. See [RBAC](../security/rbac.md). |
+| ConfigMap | `valkey-operator-config` | Optional process settings, only `defaultZoneSpread`. See [Operator configuration](../reference/operator-configuration.md). |
+| Deployment | `valkey-operator` | Runs the operator container. |
+
+The Deployment runs a **single replica with no leader election**; one replica is the entire concurrency control, by design. If that pod restarts or is briefly unavailable during an upgrade, reconciliation pauses, but no running Valkey cluster is affected. Valkey clusters serve traffic independently of the operator process. See [Architecture](../concepts/architecture.md) for why the stateless, single-replica design holds up in practice.
+
+The operator container is a distroless image (no shell or package manager) running a single process. The manifest sets **no resource requests or limits and no probes** on the Deployment. If your platform requires them (for capacity planning, quota, or scheduling policy), add them to the Deployment after installing. The operator's footprint is that of a single lightweight control loop, and the docs make no specific sizing claim for it. For what to monitor on the operator itself, see [Monitoring](../platform-guide/monitoring.md).
+
+## Verify the rollout
+
+```bash
+kubectl -n valkey-operator rollout status deployment/valkey-operator
+```
+
+This returns once the operator pod is `Running` and ready.
+
+Confirm the CRDs registered:
+
+```bash
+kubectl get crd | grep valkey.gomomento.com
+```
+
+You should see five entries: `valkeyimages`, `valkeyconfigs`, `valkeyroles`, `valkeyclusters`, and `valkeynodes`, all under `valkey.gomomento.com`.
+
+## Next steps
+
+- Continue to the [Quickstart](quickstart.md) to provision your first Valkey cluster.
+- Review [Operator configuration](../reference/operator-configuration.md) if you need to change `defaultZoneSpread` before teams start creating clusters.
+- Bookmark [Operator upgrades](../platform-guide/operator-upgrades.md) for when the next release ships.
+- Bookmark [Uninstall](../operations/uninstall.md) for the reverse procedure and the order it must run in.

--- a/docs/self-hosted/valkey-operator/getting-started/prerequisites.md
+++ b/docs/self-hosted/valkey-operator/getting-started/prerequisites.md
@@ -1,0 +1,41 @@
+---
+title: Prerequisites
+description: Version floors, access requirements, optional dependencies, and Pod Security Standard compatibility to check before installing the Momento Valkey Operator.
+sidebar_position: 2
+---
+
+# Prerequisites
+
+This page lists what your Kubernetes cluster and access level need to provide before you install the Momento Valkey Operator. It is a reference. For the install steps themselves, go to [Installation](installation.md).
+
+## Version floors
+
+| Requirement | Minimum |
+|---|---|
+| Kubernetes | 1.27+ |
+| Valkey (in any `ValkeyImage` you register) | 9+ |
+| Architecture | amd64 or arm64 |
+
+[Compatibility](../support/compatibility.md) is the canonical source for version and architecture support, including why these floors apply and what is tested versus merely supported. Treat the table above as a summary, not the authority.
+
+## Access required to install
+
+Installing the operator creates cluster-scoped objects: the CRDs themselves, a ClusterRole, and a ClusterRoleBinding, in addition to a namespace, ServiceAccount, ConfigMap, and Deployment. You need `cluster-admin` (or an equivalent role with create/update on `customresourcedefinitions`, `clusterroles`, and `clusterrolebindings`) to run the install. Provisioning a `ValkeyCluster` afterward needs no cluster-scoped access; see [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md) for the narrower grant product teams need.
+
+## Optional dependencies
+
+| Dependency | Needed for | Required? |
+|---|---|---|
+| cert-manager | Issuing and rotating the TLS Secret a `ValkeyCluster` references via `spec.tls.secretRef` | No. The operator consumes a `kubernetes.io/tls` Secret in the shape it expects, however that Secret is produced. cert-manager is the recommended way to produce and rotate it; see [TLS](../security/tls.md). |
+
+## What the operator does not need
+
+- **PersistentVolumes or PersistentVolumeClaims.** Valkey clusters managed by the operator are in-memory; the operator provisions none. Do not reserve storage classes or PV capacity for this workload. See [Data durability](../concepts/data-durability.md) for the full storage model and loss semantics.
+- **A service mesh.** The operator has no service-mesh integration and does not require one. If your platform runs one, it composes independently of anything the operator manages.
+- **Admission webhooks.** All validation the operator relies on is expressed as CRD schema rules (CEL and OpenAPI), not a webhook. Nothing to install or keep available for the operator's own correctness.
+
+## Pod Security Standards
+
+Neither the operator's own pods nor the Valkey pods it creates set a `securityContext`. No field on `ValkeyCluster`, `ValkeyConfig`, or the operator installation adds one. The operator's own image is distroless with no `USER` directive and runs as root. Valkey pods run whichever image you register. Because the operator launches `valkey-server` directly rather than through the image's entrypoint script, any privilege drop that script would normally perform is bypassed.
+
+As shipped, the operator and the clusters it manages are **incompatible with the `restricted` Pod Security Standard**. A namespace with `restricted` enforcement rejects both the operator's pods and any Valkey pods at admission. Install the operator, and provision Valkey clusters, into namespaces enforcing `privileged` or `baseline` at most. If pods are being rejected at creation, see [Troubleshooting](../operations/troubleshooting.md).

--- a/docs/self-hosted/valkey-operator/getting-started/quickstart.md
+++ b/docs/self-hosted/valkey-operator/getting-started/quickstart.md
@@ -1,0 +1,166 @@
+---
+title: Quickstart
+description: A hands-on tutorial that provisions, connects to, scales, and tears down a Valkey cluster using the Momento Valkey Operator.
+sidebar_position: 4
+---
+
+# Quickstart
+
+This tutorial takes you from an installed Momento Valkey Operator to a running, connected, scaled Valkey cluster. It assumes you have completed [Installation](installation.md) and have `cluster-admin` access to the Kubernetes cluster, and it takes roughly 15 to 20 minutes.
+
+:::note
+This tutorial has you play both personas. Steps 1 and 2 (registering an image and a config) are platform-team work: curating what teams are allowed to run. Step 3 onward is product-team work: provisioning and using a cluster from that menu. In production these are separated by RBAC; see [Resource model](../concepts/resource-model.md) and [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md).
+:::
+
+## 1. Register a Valkey image
+
+`ValkeyImage` is the allowlist of container images clusters are permitted to run. Register Valkey 9.0.0:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0
+spec:
+  repository: valkey/valkey
+  tag: "9.0.0"
+  version: "9.0.0"
+EOF
+```
+
+```bash
+kubectl get valkeyimage valkey-9-0
+```
+
+## 2. Create a config
+
+`ValkeyConfig` bundles an image reference, resource sizing, and Valkey settings into a named profile that clusters reference by name. Create a profile called `standard`:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: 2Gi
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: "allkeys-lru"
+EOF
+```
+
+```bash
+kubectl get valkeyconfig standard
+```
+
+## 3. Provision a cluster
+
+Create the namespace your application lives in, then a `ValkeyCluster` inside it, referencing the `standard` config:
+
+```bash
+kubectl create namespace my-app
+```
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+EOF
+```
+
+## 4. Watch it come up
+
+```bash
+kubectl -n my-app get valkeycluster -w
+```
+
+The `STATE` column starts at `Creating`. Bootstrapping a three-shard, one-replica-per-shard cluster means bringing up six Valkey nodes (`shards × (1 + replicasPerShard)`), meeting them into a cluster, and assigning hash slots. Once that finishes, `STATE` flips to `Active`. Press Ctrl+C to stop watching. (`Creating` and `Active` are two of several states a `ValkeyCluster` can report; see [Cluster status](../reference/cluster-status.md) for the full set and what each means.)
+
+While it converges (or once it's `Active`), look at what the operator built. Each Valkey cluster member is represented by a `ValkeyNode`, and each `ValkeyNode` owns exactly one pod:
+
+```bash
+kubectl -n my-app get valkeynodes
+kubectl -n my-app get pods -l app.kubernetes.io/instance=my-cluster
+```
+
+You should see six `ValkeyNode` resources, each with a random-suffixed name like `my-cluster-1a4f2`, and a matching pod for each (not ordinal names like `my-cluster-0`), because the operator manages pods directly rather than through a StatefulSet.
+
+## 5. Connect and run some commands
+
+The operator creates one headless Service per cluster, named after the cluster, reachable at `{cluster}.{namespace}.svc.cluster.local`. Run `valkey-cli` from a throwaway pod inside the Kubernetes cluster, in cluster mode (`-c`, so the client follows slot redirects across nodes):
+
+```bash
+kubectl -n my-app run valkey-cli --rm -it --restart=Never \
+  --image valkey/valkey:9.0 \
+  -- valkey-cli -c -h my-cluster.my-app.svc.cluster.local
+```
+
+At the prompt:
+
+```text
+my-cluster.my-app.svc.cluster.local:6379> PING
+PONG
+my-cluster.my-app.svc.cluster.local:6379> SET hello world
+OK
+my-cluster.my-app.svc.cluster.local:6379> GET hello
+"world"
+```
+
+Exit with `exit` or Ctrl+D; the `--rm` flag deletes the pod on exit.
+
+## 6. Scale out a shard
+
+Increase `shards` from 3 to 4:
+
+```bash
+kubectl -n my-app patch valkeycluster my-cluster \
+  --type merge -p '{"spec": {"shards": 4}}'
+```
+
+Watch it again:
+
+```bash
+kubectl -n my-app get valkeycluster -w
+```
+
+`STATE` stays `Active` throughout (scaling is a live operation, not a separate state), and the `SHARDS` column shows the updated desired count immediately, since it reflects the spec. The real progress signal is the node list: the operator brings up the added shard's nodes and migrates a share of the existing hash slots onto them so all four shards end up balanced. Meanwhile, existing shards keep serving. Watch the nodes converge:
+
+```bash
+kubectl -n my-app get valkeynodes -w
+```
+
+Once four shards' worth of nodes are `Active`, confirm the updated node count:
+
+```bash
+kubectl -n my-app get valkeynodes
+```
+
+You should now see eight `ValkeyNode` resources (four shards × two nodes each).
+
+## 7. Clean up
+
+Delete the cluster:
+
+```bash
+kubectl -n my-app delete valkeycluster my-cluster
+```
+
+This cascades: the Service, the auth Secret, the ACL ConfigMap, and every `ValkeyNode` (and its pod and ConfigMap) go with it. The namespace `my-app`, the `standard` `ValkeyConfig`, and the `valkey-9-0` `ValkeyImage` are **not** deleted: they're independent, cluster-scoped (or, for the namespace, unrelated) resources, and stay available for the next cluster you provision.
+
+## Where to go next
+
+- **Platform engineers**: build out a real menu in [Curating images and configs](../platform-guide/curating-images-and-configs.md), then onboard teams with [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md).
+- **Product-team developers**: read [Provisioning a cluster](../team-guide/provisioning.md) for the decisions you make at creation time (TLS, placement, ACLs), and [Connecting to a cluster](../team-guide/connecting.md) for client configuration beyond `valkey-cli`.
+- **Both personas**: this cluster ran with no ACL bindings, so its `default` user was wide open to anything that could reach it on the network (fine for a quickstart, not for production). Read [ACLs](../security/acls.md) and [TLS](../security/tls.md) before going further.

--- a/docs/self-hosted/valkey-operator/index.md
+++ b/docs/self-hosted/valkey-operator/index.md
@@ -1,0 +1,78 @@
+---
+title: Momento Valkey Operator
+description: What the Momento Valkey Operator does, who it is for, and where to go next in these docs.
+sidebar_position: 1
+---
+
+# Momento Valkey Operator
+
+The Momento Valkey Operator runs sharded Valkey clusters on Kubernetes. This page explains what it does, how it splits responsibility between two personas, and where to go next depending on what you're trying to do.
+
+:::note
+These docs describe operator release v0.6.0.
+:::
+
+## What the operator does
+
+The operator turns a small set of custom resources into running Valkey clusters and keeps them that way. Given a `ValkeyCluster`, it bootstraps the cluster from nothing: creating nodes, forming the topology, assigning hash slots, attaching replicas. It then keeps the cluster converged on the desired spec: scaling shards and replicas, carrying out rolling upgrades, handling primary failover, and enforcing zone-aware placement. It also manages TLS certificate delivery and ACL user provisioning, converging both continuously rather than only at creation time.
+
+Everything the operator does is driven by custom resources, not imperative commands. You declare what you want: a cluster's topology, a config's settings, an image allowlist entry. The operator's control loops then drive the running state toward it, one small step at a time. See [Reconciliation](concepts/reconciliation.md) for how that works.
+
+## Two personas, one governance model
+
+The operator is built around a split between two personas, enforced through Kubernetes RBAC rather than through any custom policy engine. The **platform team** curates a cluster-scoped menu: which Valkey images are allowed to run (`ValkeyImage`), which configuration profiles exist (`ValkeyConfig`), and which reusable ACL permission sets are available (`ValkeyRole`). Because these resources are cluster-scoped, the platform team can grant every namespace read-only visibility into the menu while keeping write access to themselves.
+
+The **product team** provisions Valkey clusters by creating `ValkeyCluster` resources in their own namespace, choosing a config from the menu and stating topology. `ValkeyCluster` is namespace-scoped, so a product team can create any number of clusters in a namespace they control, but every cluster they create is built only from images, configs, and roles the platform team has already approved. This is the whole governance model: no admission webhooks, no external policy service; only which resources live at which scope, and who has write access to each.
+
+The five resource kinds split cleanly along that boundary. A product team writes only `ValkeyCluster`; everything it references lives in the platform team's cluster-scoped menu, and the operator manages `ValkeyNode` resources on the team's behalf:
+
+```mermaid
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart RL
+  subgraph platform["Platform Team"]
+    config[ValkeyConfig]
+    image[ValkeyImage]
+    role[ValkeyRole]
+    config --> image
+    config --> role
+  end
+
+  subgraph product["Product Team"]
+    cluster[ValkeyCluster]
+  end
+
+  subgraph operator["Operator"]
+    node[ValkeyNode]
+  end
+
+  cluster --> config
+  node -.-> cluster
+```
+
+The arrows are references by name: a cluster's `configRef` selects a `ValkeyConfig` from the menu, and each `ValkeyNode` points at the `ValkeyCluster` that owns it (the operator creates one per cluster member; deleting the cluster cascades to its nodes). Within the menu, a config's `imageRef` and ACL-binding `roleRef` entries compose the other two kinds, and a `ValkeyCluster`'s own ACL bindings can also reference published roles; those edges are left out of the diagram for readability. See [Resource model](concepts/resource-model.md) and [ACLs](security/acls.md).
+
+## Coming from a managed cache offering
+
+If you're evaluating the operator after working with a managed cache offering, the concepts map fairly directly:
+
+| Managed cache offering concept | Operator equivalent |
+| ------------------------------ | ------------------- |
+| Engine version                 | `ValkeyImage`       |
+| Instance type / node size      | `ValkeyConfig`      |
+| Replication group / cluster    | `ValkeyCluster`     |
+
+The mapping isn't exact. In particular, `ValkeyConfig` also carries platform-level ACL bindings and raw Valkey settings, and the operator's governance model is Kubernetes RBAC on these resources rather than an IAM policy layer. But it's a reasonable starting mental model. See [Resource model](concepts/resource-model.md) for the real shape.
+
+## Part of the Platform Engineering Toolkit
+
+The operator is one component of Momento's Platform Engineering Toolkit for Valkey. Two other components exist alongside it and are not documented here: **Valkey Router**, a gateway that sits in front of a Valkey cluster to handle client-facing scaling concerns, and **Valkey Enterprise Image**, a hardened container image for Valkey nodes. Nothing in these docs assumes either component is present: the operator runs any allowlisted Valkey image over its own headless Service.
+
+## Find your way around
+
+- **Evaluating the operator?** Read [Why this operator](why-this-operator.md), then [Architecture](concepts/architecture.md), [Failure modes](operations/failure-modes.md), and [Data durability](concepts/data-durability.md); the rest of the [concepts section](concepts/index.md) fills in the model, and the [quickstart](getting-started/quickstart.md) gets you hands-on in about 20 minutes.
+- **Platform team setting up the operator?** Start at [Getting started](getting-started/index.md), then move to the [platform team guide](platform-guide/index.md).
+- **Product team provisioning a cluster?** Go straight to the [product team guide](team-guide/index.md).
+- **Running a security review?** Start at [Security](security/index.md).
+- **Something's wrong?** Go to [Troubleshooting](operations/troubleshooting.md); the rest of the [operations section](operations/index.md) covers failure modes, placement, sizing, and teardown.
+- **Quick question?** The [FAQ](support/faq.md) gives short answers with pointers, and the [glossary](getting-started/glossary.md) defines the Valkey and operator terms these docs use.
+- **Looking something up?** Field-level detail lives in the [reference section](reference/index.md); version floors and support channels in [support](support/index.md); direction in the [roadmap](roadmap.md).

--- a/docs/self-hosted/valkey-operator/operations/benchmarking.md
+++ b/docs/self-hosted/valkey-operator/operations/benchmarking.md
@@ -1,0 +1,114 @@
+---
+title: Benchmarking
+description: Validate throughput and latency against an operator-provisioned Valkey cluster using standard Valkey benchmarking tools.
+sidebar_position: 5
+---
+
+# Benchmarking
+
+This page shows how to run reproducible performance validation against a Valkey cluster provisioned by the Momento Valkey Operator, using standard Valkey tooling from inside your Kubernetes cluster. It does not make performance claims on the operator's behalf. Throughput and latency depend on your node shape, config, network, and workload, and you should measure your own cluster rather than trust a number from elsewhere.
+
+## Run valkey-benchmark as a Kubernetes Job
+
+`valkey-benchmark` ships in the standard Valkey image and speaks the cluster protocol with `--cluster`, so it follows slot redirects the same way a cluster-aware client does. Run it as a Job in the cluster's namespace, pointed at the headless Service:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: valkey-bench
+  namespace: my-app
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: valkey-benchmark
+          image: valkey/valkey:9.0
+          command:
+            - valkey-benchmark
+            - -h
+            - my-cluster.my-app.svc.cluster.local
+            - -p
+            - "6379"
+            - --cluster
+            - -c
+            - "50"
+            - -n
+            - "1000000"
+            - -t
+            - set,get
+  backoffLimit: 0
+```
+
+Adjust `-c` (client connections) and `-n` (requests) to the load you want to generate, and `-t` to the command mix you care about. `kubectl logs job/valkey-bench -n my-app` shows the results; delete the Job (`kubectl delete job valkey-bench -n my-app`) before rerunning.
+
+### TLS clusters
+
+Against a TLS-only cluster, add `--tls` and point `--cacert` at the cluster's CA certificate, mounted from the same Secret the cluster itself validates against:
+
+```yaml
+      containers:
+        - name: valkey-benchmark
+          image: valkey/valkey:9.0
+          command:
+            - valkey-benchmark
+            - -h
+            - my-cluster.my-app.svc.cluster.local
+            - -p
+            - "6379"
+            - --cluster
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - -c
+            - "50"
+            - -n
+            - "1000000"
+          volumeMounts:
+            - name: tls-certs
+              mountPath: /etc/valkey/tls
+              readOnly: true
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: my-cluster-tls
+```
+
+### ACL-protected clusters
+
+If the cluster has ACL bindings, authenticate as a dedicated benchmark user rather than reusing an application credential. Bind a `bench` user scoped to a throwaway key pattern so benchmark traffic is trivially distinguishable from and isolated from production keys. See [ACLs](../security/acls.md) for creating the binding. Pass its credentials with `--user` and `--pass`:
+
+```yaml
+            - valkey-benchmark
+            - -h
+            - my-cluster.my-app.svc.cluster.local
+            - -p
+            - "6379"
+            - --cluster
+            - --user
+            - bench
+            - --pass
+            - <bench-user-password>
+            - -c
+            - "50"
+            - -n
+            - "1000000"
+```
+
+`--tls`/`--cacert` and `--user`/`--pass` combine for a cluster that runs both.
+
+## memtier_benchmark as an alternative
+
+`memtier_benchmark` is a general-purpose load generator for the Valkey wire protocol, with richer workload shaping (key-space distributions, pipelining, mixed read/write ratios) than `valkey-benchmark` offers. It is not part of the Valkey image, so run it from its own container image. The connection, TLS, and ACL flags are conceptually the same as above, with different spellings on `memtier_benchmark`'s command line. Either tool works against an operator-provisioned cluster the same way: the operator has no benchmarking-specific behavior to accommodate.
+
+## What to measure
+
+- **Throughput at a target p99 latency**, not throughput alone. Raise concurrency until p99 crosses your acceptable threshold, and report the throughput at that point: an unbounded-latency throughput number is rarely the number that matters for a production SLA.
+- **Per-shard scaling.** Run the same benchmark before and after changing `shards` on the cluster (see [Scaling](../team-guide/scaling.md)). Because slots and their keys distribute evenly across shards and each shard is served independently, headline throughput is expected to grow close to linearly with shard count for a workload that spreads across the key space. This is a property of Valkey cluster mode generally, not a number the operator guarantees. A workload concentrated on a few hot keys will not show this, regardless of shard count.
+
+## Pitfalls
+
+- **Benchmark pod placement and zone locality.** A benchmark pod scheduled in a different zone from the shard it's hitting adds cross-zone network latency to every result, which shows up as worse p99 than clients will actually see in a same-zone deployment. Either accept that as representative of your real client placement, or pin the benchmark Job with `nodeSelector`/affinity to land alongside the cluster.
+- **Don't benchmark through a single connection.** A cluster's aggregate throughput comes from parallel client connections spread across shards; `-c 1` measures one connection's round-trip latency, not the cluster's capacity. Use enough connections (`-c`) to actually exercise every shard concurrently.
+- **Warm up before measuring.** The first requests against a freshly bootstrapped or freshly scaled cluster pay one-time costs (connection establishment across every shard, cluster-topology discovery, cold caches at any layer below Valkey). Run a short unmeasured warm-up pass, or discard the first portion of a long run, before recording numbers you intend to compare.

--- a/docs/self-hosted/valkey-operator/operations/failure-modes.md
+++ b/docs/self-hosted/valkey-operator/operations/failure-modes.md
@@ -1,0 +1,143 @@
+---
+title: Failure modes
+description: How Valkey clusters managed by the operator behave when pods, Kubernetes nodes, zones, or the operator itself fail.
+sidebar_position: 2
+---
+
+# Failure modes
+
+This page explains how a Valkey cluster managed by the Momento Valkey Operator behaves when things fail: what the operator does automatically, how quickly detection happens, what data is at risk, and where manual action is required. It covers operator-specific behavior only: general Kubernetes failure handling is out of scope. For step-by-step remediation of specific symptoms, see [Troubleshooting](troubleshooting.md); for the underlying storage model, see [Data durability](../concepts/data-durability.md).
+
+The short version, per event:
+
+| Event | Automatic response | Data at risk |
+|---|---|---|
+| Replica pod dies | Operator replaces the replica | None |
+| Primary pod dies, quorum held, replica exists | Valkey auto-failover, then operator restores replica count | Writes in replication lag |
+| Primary pod dies, quorum lost, replica exists | Operator forces a takeover on a surviving replica | Writes in replication lag |
+| Primary pod dies, no replicas | Operator forgets the dead node and creates a fresh empty primary | That shard's entire dataset |
+| Kubernetes node lost or drained | Per-pod combination of the above | Depends on which pods were affected |
+| Zone lost | Per-pod combination of the above; blast radius depends on placement | Depends on `zoneSpread` |
+| Operator down | Clusters keep serving; healing and changes pause | None from the outage itself |
+| Fault during a scaling or upgrade operation | Reconciler absorbs the fault and converges to the target | Same as the underlying pod failure |
+
+Two operator design decisions shape everything below. First, Valkey pods run with `restartPolicy: Never`: a dead pod is never restarted in place; the operator replaces it with a new node through its join lifecycle (see [Pod management](../concepts/pod-management.md)). Second, the operator forces `cluster-node-timeout` to 5000 ms on every node. Valkey's own failure detection (the input to both auto-failover and the operator's recovery logic) is bounded by a 5-second window plus gossip propagation.
+
+## Replica pod dies
+
+**What happens automatically.** The dead pod's cluster node becomes an orphan. The operator forgets it from the remaining nodes, removes its internal `ValkeyNode` resource, and creates a replacement replica for the same shard. The replacement joins the cluster, replicates from the shard's primary, and is only marked active after its initial sync completes. Shard identity is preserved: the replacement lands in the shard that lost the replica.
+
+**Timeline.** Detection is event-driven (the operator watches its pods); the replacement proceeds over successive reconciliation ticks, and the new replica's usefulness is gated on the initial sync from the primary, which scales with the shard's dataset size.
+
+**Data at risk.** None. The primary holds the authoritative copy throughout. See [Data durability](../concepts/data-durability.md).
+
+**Client impact.** Writes are unaffected. Clients that were reading from the dead replica see connection errors until their topology refresh; cluster-aware clients handle this automatically.
+
+**Manual action.** None.
+
+## Primary pod dies (quorum held, replica exists)
+
+**What happens automatically.** When a majority of primaries is still healthy, the operator deliberately does not intervene in the failover itself: it waits for Valkey's automatic failover to promote one of the shard's replicas. Because the operator forces `cluster-node-timeout` to 5000 ms, failure detection is bounded by that 5-second window; the replica election follows. Once the new primary is serving, the operator cleans up. It forgets the dead node from all live nodes, deletes its resources, and creates a fresh replica so the shard returns to its configured `replicasPerShard`. This recovery path is verified against real Kubernetes clusters for both pod deletion and in-place process death.
+
+**Timeline.** Failure detection is bounded by the forced 5-second `cluster-node-timeout`; promotion follows Valkey's standard election. Restoring the replica count happens afterwards and is gated on the new replica's initial sync.
+
+**Data at risk.** Writes acknowledged by the old primary but not yet replicated to the promoted replica are lost: the replication-lag window. See [Data durability](../concepts/data-durability.md).
+
+**Client impact.** Writes to the affected shard fail during detection and election. Cluster-aware clients pick up the new primary via topology refresh; other shards are unaffected.
+
+**Manual action.** None.
+
+## Primary pod dies (quorum lost)
+
+**What happens automatically.** When too few primaries survive to form a majority (for example, one primary of a two-shard cluster dies), Valkey's automatic failover cannot win an election. The operator detects this and issues a takeover on a healthy surviving replica of the affected shard, promoting it without an election. It then performs the same cleanup and replica restoration as above. This path is also verified against real clusters.
+
+**Timeline.** Same detection bound (the forced 5-second `cluster-node-timeout`); the takeover is issued by the operator on a subsequent reconciliation tick rather than waiting on an election that cannot complete.
+
+**Data at risk.** Same as the quorum-held case: writes in the replication-lag window. A forced takeover bypasses Valkey's election safety checks. It is the intended recovery path for small clusters where a majority cannot form, and the operator only issues it when normal failover is impossible.
+
+**Manual action.** None.
+
+## Primary pod dies (no replicas)
+
+**What happens automatically.** With `replicasPerShard: 0`, no surviving copy of the shard's data exists. The operator does not halt. It forgets the dead node from all live nodes, at which point that shard's data is unrecoverable. It then creates a fresh primary, assigns it the orphaned slot range, and returns the cluster to `Active` with full hash-slot coverage. The new shard starts empty.
+
+**Timeline.** Detection as above; the replacement primary is created and assigned slots over the following ticks. The cluster reports `Active` once slot coverage is restored.
+
+**Data at risk.** The entire dataset of the affected shard. This is the explicit trade-off of running without replicas. See [Data durability](../concepts/data-durability.md) for mitigations, starting with `replicasPerShard: 1`.
+
+**Client impact.** Requests for keys in the affected slot range fail until the replacement primary is serving, then succeed against an empty keyspace. Applications must be able to repopulate (for example, treat the cluster as a cache backed by a source of truth).
+
+**Manual action.** None for recovery; the cluster heals itself topologically. Repopulating the lost data is the application's responsibility.
+
+## Kubernetes node lost or drained
+
+**What happens automatically.** Losing a Kubernetes node kills every Valkey pod on it, and each is handled by the per-pod logic above. Dead replicas are replaced; dead primaries fail over (or are taken over, or replaced empty) per their shard's replica and quorum situation. Because pods use `restartPolicy: Never`, a drain's eviction has the same effect as a crash: the operator replaces the pod rather than Kubernetes restarting it. Replacement pods schedule onto remaining Kubernetes nodes subject to the cluster's placement constraints.
+
+**Timeline.** As per the individual events. The operator prioritizes stability: it restores unhealthy primaries before doing anything else, and works through replacements over successive ticks.
+
+**Data at risk.** Depends on which pods were co-located. If a shard's primary and all its replicas were on the same Kubernetes node, that shard's data is lost (the no-replicas case above). Per-shard host spread constraints make this co-location unlikely but are best-effort; zone spread gives stronger guarantees ([Zone-aware placement](zone-aware-placement.md)).
+
+**Manual action.** For planned maintenance, drain one Kubernetes node at a time and wait for the cluster to return to full health before proceeding. See [Kubernetes maintenance](../platform-guide/kubernetes-maintenance.md).
+
+## Zone lost
+
+**What happens automatically.** A zone outage is the Kubernetes-node case at larger scale: every affected pod is handled individually. What differs is the blast radius, and that is determined by your placement configuration:
+
+- With `zoneSpread: required` and `replicasPerShard` of at least 1, each shard's nodes are hard-spread across zones, so no shard loses both its primary and its replica to a single zone. Every shard fails over or replaces a replica; no shard loses data beyond the replication-lag window.
+- With `zoneSpread: bestEffort` (the shipped default), spread is a scheduler preference. A shard whose nodes were co-located in the lost zone loses its data and is recreated empty.
+
+Replacement pods schedule into the surviving zones, subject to `placement.zones` and spread constraints. See [Zone-aware placement](zone-aware-placement.md) for the mechanics, including what happens when surviving capacity is insufficient.
+
+**Timeline.** Failover detection per shard is bounded by the forced 5-second `cluster-node-timeout`; replacing the lost pods proceeds shard by shard and depends on available capacity in the surviving zones.
+
+**Data at risk.** With required spread and replicas: the replication-lag window per affected shard. Without: potentially entire shards.
+
+**Manual action.** None for recovery, provided surviving zones have capacity. Placement is enforced at scheduling time only: when the zone returns, the operator does not proactively rebalance existing pods back into it. Spread is restored as pods are naturally replaced.
+
+## The operator itself is down
+
+**What happens automatically.** Nothing breaks. The data plane is independent of the operator: Valkey pods serve clients, replication continues, and Valkey's own automatic failover still promotes replicas when quorum allows, because it is native cluster behavior, not operator behavior.
+
+What pauses is everything the operator does: dead pods are not replaced, quorum-lost shards are not taken over, replica counts are not restored, and spec changes (scaling, upgrades, placement) are not acted on. Reconciliation is stateless: the operator keeps no in-memory workflow state. When it returns, it inspects the actual cluster state and converges toward the current spec, including changes applied while it was down. Nothing is lost by editing a `ValkeyCluster` during operator downtime; the changes queue.
+
+**Timeline.** Recovery of pending work begins as soon as the operator deployment is back and proceeds one action per tick.
+
+**Data at risk.** None from the operator outage itself, but the fleet is running without self-healing, so a coincident pod failure that would normally be repaired automatically stays broken until the operator returns.
+
+**Manual action.** Restore the operator deployment. The operator ships as a single replica with no health endpoint, so alert on deployment availability. See [Monitoring](../platform-guide/monitoring.md).
+
+## Faults during scaling or upgrades
+
+**What happens automatically.** A pod failure that lands in the middle of a scale-out, scale-in, or rolling upgrade does not wedge the reconciler. Because the operator recomputes the difference between actual and desired state on every tick, rather than executing a stored plan, it absorbs the fault (failing over or replacing the dead node, exactly as above). It then continues converging to the target spec. This is verified behavior: clusters killed mid-scale-up, mid-scale-down, and mid-upgrade all converge to the target shape with full hash-slot coverage.
+
+**Timeline.** The operator prioritizes stability over progress: primary recovery gates the rest of the pipeline, so an in-flight operation pauses while a shard is unhealthy and resumes afterwards.
+
+**Data at risk.** Whatever the underlying pod failure implies (see the per-event sections above); the in-flight operation itself does not add exposure classes beyond those.
+
+**Manual action.** None. If a cluster appears stuck, see [Troubleshooting](troubleshooting.md) before intervening.
+
+## Watching a failover happen
+
+The abstract sequences above look like this in practice. Take `my-cluster` with three shards and one replica per shard (six nodes), and suppose shard 1's primary dies while quorum holds:
+
+1. **Steady state.** `kubectl get valkeynodes -n my-app` shows six nodes, all `Active` lifecycle; `kubectl get valkeycluster` shows `STATE: Active`.
+2. **The pod dies.** `kubectl get pods -n my-app` shows the pod gone (if deleted) or failed (if the process died; `restartPolicy: Never` means it stays that way). Writes to shard 1's slots start failing. The `ValkeyCluster` still shows `Active`: cluster state does not track individual pod health, which is why [Monitoring](../platform-guide/monitoring.md) has you watch pods and logs, not only the state column.
+3. **Detection, then promotion.** After the 5-second `cluster-node-timeout` window, the surviving nodes mark the primary failed, and shard 1's replica wins the election that follows. Writes to shard 1 succeed again; cluster-aware clients converge on the new primary via topology refresh. The operator's log shows `primary unhealthy but replicas exist, waiting for auto-failover` while it deliberately stands back.
+4. **Cleanup and replacement.** On following ticks the operator forgets the dead node from every live node, deletes its `ValkeyNode`, and creates a replacement replica for shard 1. `kubectl get valkeynodes` now shows five `Active` plus one `Joining` node with a fresh random-suffix name.
+5. **Sync completes.** The replacement finishes its initial sync from the new primary (time scales with the shard's dataset), the log shows `completed join`, and its lifecycle flips to `Active`. The cluster is back to six `Active` nodes with `replicasPerShard: 1` restored.
+
+The quorum-lost variant differs only at step 3: with too few primaries for an election, nothing is promoted until the operator observes the condition on a following tick and forces the takeover itself (log line: `no quorum — issued TAKEOVER on replica`). Steps 4 and 5 proceed identically.
+
+## Halting reconciliation deliberately
+
+No per-cluster pause mechanism exists. If you need the operator to stop acting on your clusters entirely (for example, during an incident investigation where you want no automated topology changes), the only lever is blunt. Scale the operator deployment to zero.
+
+```bash
+kubectl -n valkey-operator scale deployment/valkey-operator --replicas=0
+```
+
+All Valkey clusters keep serving traffic (see the previous section). Restore with `--replicas=1`; the operator picks up where the actual state and the specs disagree.
+
+:::warning
+While the operator is scaled down, no cluster is self-healing: dead pods are not replaced, failed primaries without quorum are not recovered, and replica counts are not restored. Do not leave the operator scaled to zero longer than necessary, and never as a steady state.
+:::

--- a/docs/self-hosted/valkey-operator/operations/index.md
+++ b/docs/self-hosted/valkey-operator/operations/index.md
@@ -1,0 +1,20 @@
+---
+title: Operations
+description: "Day-2 operations for Valkey clusters managed by the Momento Valkey Operator: failure behavior, placement, sizing, benchmarking, troubleshooting, and uninstall."
+sidebar_position: 1
+---
+
+# Operations
+
+This section is the day-2 reference for running Valkey clusters on the Momento Valkey Operator in production: what happens when things fail, how to place and size clusters, how to validate performance, and how to diagnose problems. It assumes a cluster is already provisioned; for first-time setup, see [Getting started](../getting-started/index.md) and the [platform](../platform-guide/index.md) and [product](../team-guide/index.md) team guides.
+
+- **[Failure modes](failure-modes.md)** — the flagship page. How a Valkey cluster behaves, automatically, when a replica dies, a primary dies with or without quorum or replicas, a Kubernetes node or zone is lost, or the operator itself goes down. Read this before you need it.
+- **[Zone-aware placement](zone-aware-placement.md)** — how `placement.zones`, `nodeSelector`, and `zoneSpread` control where pods land, what changing placement does to a live cluster, and how placement interacts with a cluster autoscaler.
+- **[Sizing](sizing.md)** — setting `resources` in a `ValkeyConfig` so pods get Guaranteed quality of service, leaving `maxmemory` headroom, and choosing when to scale up versus out.
+- **[Benchmarking](benchmarking.md)** — validating throughput and latency against an operator-provisioned cluster with standard Valkey tooling, in-cluster, including TLS and ACL variants.
+- **[Troubleshooting](troubleshooting.md)** — symptom-first diagnosis: stuck `Creating`, `Invalid` clusters, pods stuck `Pending`, ACL authentication failures, stalled rolling upgrades, stuck `Terminating`, and what to collect before contacting support.
+- **[Uninstall](uninstall.md)** — the order to remove clusters, the operator, and CRDs, and how to verify nothing is left behind.
+
+:::note
+[Failure modes](failure-modes.md) and [Data durability](../concepts/data-durability.md) cover related ground from different angles: failure modes describes the operator's automatic response to each event, while data durability states the storage model and exactly which events lose data. Read them together before setting availability expectations for a cluster.
+:::

--- a/docs/self-hosted/valkey-operator/operations/sizing.md
+++ b/docs/self-hosted/valkey-operator/operations/sizing.md
@@ -1,0 +1,62 @@
+---
+title: Sizing
+description: Set resources in a ValkeyConfig for Guaranteed quality of service, leave maxmemory headroom, and choose the right node shape.
+sidebar_position: 4
+---
+
+# Sizing
+
+This page covers sizing decisions for a `ValkeyConfig`, managed by the Momento Valkey Operator: how `resources` determines pod quality of service, how much headroom to leave between the memory limit and Valkey's own `maxmemory`, and when to size up versus scale out. It is written primarily for platform teams curating the config menu, and for product teams choosing among curated configs. For the resource fields themselves, see [ValkeyConfig](../reference/api/valkeyconfig.md).
+
+## Resources set both requests and limits
+
+`resources.cpu` and `resources.memory` on a `ValkeyConfig` are applied to each Valkey pod as **both** the request and the limit. A config with both set produces pods in the Kubernetes **Guaranteed** quality-of-service class, the class least likely to be evicted or throttled under node pressure.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: 2Gi
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: "allkeys-lru"
+```
+
+:::warning
+A `ValkeyConfig` that omits `resources` entirely produces **BestEffort** pods: no requests, no limits. BestEffort pods are the first the kubelet evicts under node memory pressure. For an in-memory data store, an eviction is a data-loss event: the pod's data disappears with it, and if it was an unreplicated primary, so does the shard's data (see [Data durability](../concepts/data-durability.md)). Always set `resources` on configs you publish for production use.
+:::
+
+## Leave maxmemory headroom under the memory limit
+
+Valkey's `maxmemory` setting bounds the data Valkey itself will hold, but the process uses additional memory beyond that for things `maxmemory` does not account for: replication output buffers, the memory overhead of fork-based operations (background saves, AOF rewrites), and allocator fragmentation. If `maxmemory` is set close to the pod's memory limit, that overhead pushes the container over the limit and the kubelet OOM-kills it: the same data-loss outcome as an eviction, self-inflicted by an undersized headroom.
+
+As a starting point, size `maxmemory` to roughly **70% to 80% of the pod's memory limit** and adjust from there based on observed overhead for your workload (write-heavy and replication-heavy workloads need more headroom than read-mostly ones). The `standard` config above follows this ratio: `maxmemory: 1500mb` against a `2Gi` limit is about 73%.
+
+This is general Valkey operational guidance, not a mechanism enforced by the operator: the operator does not validate `maxmemory` against `resources.memory` or reject an unsafe ratio.
+
+## Node shape
+
+Valkey is memory-bound far more than it is CPU-bound for typical cache-shaped workloads. When choosing the underlying Kubernetes node pool for a Valkey cluster:
+
+- Prefer memory-optimized instance types over general-purpose ones: a higher memory-to-vCPU ratio gets more usable Valkey capacity per node.
+- Avoid overcommitting the node pool. Because production configs should carry Guaranteed-class `resources` (see above), the scheduler already accounts for every Valkey pod's full memory footprint against node capacity. But leave enough slack in the pool for operator-driven replacements (a rolling upgrade or a failover briefly needs capacity for both the old and new pod), rather than sizing the pool to exactly the steady-state pod count.
+
+This is general Kubernetes and Valkey capacity-planning guidance; nothing here is operator-specific behavior.
+
+## Scale out, not up
+
+When a curated config's memory ceiling stops being enough for the workload, the operator-native lever is horizontal: increase `shards` on the `ValkeyCluster` and let the operator rebalance slots across the larger shard count, rather than repeatedly raising one config's `resources.memory`. Scaling shards distributes both the dataset and the request load, and it composes with placement: more shards means more opportunities for zone and host spread to matter. See [Scaling](../team-guide/scaling.md) for the mechanics and client impact of a shard-count change.
+
+## Autoscalers do not apply
+
+Do not point Kubernetes autoscalers at operator-managed resources; neither has anything to act on:
+
+- **Horizontal Pod Autoscaler.** No operator resource exposes a `scale` subresource, and the Valkey pods are bare pods with no Deployment or StatefulSet behind them, so HPA has no valid target. Horizontal scaling is `spec.shards` and `spec.replicasPerShard`, changed by you (or your own tooling) editing the `ValkeyCluster`.
+- **Vertical Pod Autoscaler.** Pod resources come from the resolved `ValkeyConfig`, and the operator compares declared specs, not live pods. A VPA-mutated pod is invisible to the operator and reverts to config-declared resources on the next replacement; a VPA that evicts pods to resize them triggers the operator's failure recovery instead, which rebuilds the pod from the declared config. Either way the VPA value does not stick. Resize by publishing a config variant and repointing `configRef`, which rolls the cluster deliberately.
+
+The cluster autoscaler (which scales Kubernetes nodes, not pods) is compatible; see [Kubernetes maintenance](../platform-guide/kubernetes-maintenance.md) for how it interacts with the operator.

--- a/docs/self-hosted/valkey-operator/operations/troubleshooting.md
+++ b/docs/self-hosted/valkey-operator/operations/troubleshooting.md
@@ -1,0 +1,181 @@
+---
+title: Troubleshooting
+description: Symptom-first diagnosis and remediation for common Momento Valkey Operator problems, from stuck states to authentication failures.
+sidebar_position: 6
+---
+
+# Troubleshooting
+
+This page diagnoses and resolves the problems you are most likely to hit operating the Momento Valkey Operator: stuck cluster states, pods that won't schedule, TLS and ACL failures, and an unhealthy operator. It is written for the on-call engineer who needs to go from symptom to fix. For the theory behind failure recovery, see [Failure modes](failure-modes.md); for the full state machine, see [Cluster status](../reference/cluster-status.md).
+
+## Read the situation first
+
+Before working a specific symptom below, gather the same four signals every time:
+
+```bash
+# Cluster state and a one-line reason (when Invalid)
+kubectl get valkeycluster -n my-app
+
+# Full status: targetSpec (if bootstrapping) and status.message
+kubectl describe valkeycluster my-cluster -n my-app
+
+# Per-node lifecycle: Joining / Active / Leaving
+kubectl get valkeynodes -n my-app
+
+# Operator logs: structured JSON, filtered by RUST_LOG
+kubectl -n valkey-operator logs deployment/valkey-operator
+```
+
+`kubectl get valkeycluster` shows the `STATE` column: `Creating`, `Active`, or `Invalid` in practice (the schema also defines `Updating`, but the current release never reports it; a cluster mid-change shows `Active`); `kubectl describe` or `kubectl get valkeycluster -o yaml` surfaces `status.message`, which is populated on `Invalid` with the exact validation failure. The operator emits one JSON log line per reconcile action, filtered by the `RUST_LOG` environment variable on its Deployment (`info` by default); [Logging](../platform-guide/logging.md) explains the format and how to filter by cluster. See [Cluster status](../reference/cluster-status.md) for what each state and column means.
+
+Know where explanations surface: **TLS validation failures are the only errors written to `status.message`**, and the operator emits no Kubernetes Events at all. Every other diagnosis below (missing references, ACL problems, connection failures) is explained only in the operator logs, so expect `kubectl describe` to look uninformative even when the logs name the exact problem.
+
+## Cluster stuck in Creating
+
+A cluster that has been `Creating` for longer than a few reconcile ticks usually has one of three causes. (A fourth is an unpullable image: the operator trusts a `ValkeyImage`'s `repository:tag` verbatim, so a typo there shows up as pods in `ImagePullBackOff`.)
+
+| Cause | How to confirm | Fix |
+|---|---|---|
+| Referenced `ValkeyImage` or `ValkeyConfig` is missing, or the `baseRef` inheritance chain is broken | `kubectl get valkeyconfig <name>` / `kubectl get valkeyimage <name>` returns not found; operator logs (never `status.message`) show the resolution error verbatim: `ValkeyConfig "<name>" not found`, `ValkeyImage "<name>" not found`, `no image_ref in config chain ending at "<name>"`, or `config inheritance depth exceeds 10 (cycle?)` | Create the missing resource. References are resolved fresh on every reconcile; you do not need to recreate the `ValkeyCluster` once the missing `ValkeyImage` or `ValkeyConfig` exists. |
+| Pods are unschedulable: resource requests too large for available capacity, or placement constraints unsatisfiable | `kubectl get pods -n my-app` shows pods `Pending`; `kubectl describe pod <pod> -n my-app` events show scheduling failures | Resize node capacity, reduce the config's `resources`, or relax `placement` (zones, `nodeSelector`, `zoneSpread: required`). See [Zone-aware placement](zone-aware-placement.md) and [Sizing](sizing.md). |
+| Pods are rejected by Pod Security admission: the namespace enforces the `restricted` Pod Security Standard, and Valkey pods carry no `securityContext` (no `runAsNonRoot` declaration) | `kubectl get pods -n my-app` shows no pods created, or events / `kubectl describe namespace my-app` show a `violates PodSecurity` admission rejection; check the namespace's `pod-security.kubernetes.io/enforce` label | Relabel or exempt the namespace to `privileged` or `baseline` enforcement. See [Prerequisites](../getting-started/prerequisites.md) for the compatibility statement. |
+
+## A wedged bootstrap can't be fixed by editing
+
+:::info
+During bootstrap, the operator works the cluster's **topology** from a snapshot (`status.targetSpec`) taken the moment the cluster enters `Creating`. Edits to `shards` or `replicasPerShard` while still `Creating` are deferred until bootstrap finishes, so a wrong topology value cannot be corrected by editing. Other spec fields (`configRef`, `placement`, `tls.secretRef`, `acl`) are read live on every reconcile, but they only shape **nodes that have not been created yet**. Node specs are immutable once created, so editing `placement` mid-bootstrap does not fix a node already stuck `Pending` under the old placement. Mid-bootstrap edits can also leave a cluster with nodes built from two different configurations.
+:::
+
+External fixes still work while `Creating`: creating a missing `ValkeyImage` or `ValkeyConfig` unblocks bootstrap immediately, because references resolve live on every reconcile; no recreate needed (see the table above). But a mistake in the spec itself (a wrong topology value, or an unsatisfiable `placement` already stamped onto stuck nodes) requires **deleting and recreating** the `ValkeyCluster`; that is the reliable path. See [`targetSpec` snapshot semantics](../reference/cluster-status.md#targetspec-snapshot-semantics).
+
+## Cluster shows Invalid
+
+`Invalid` has exactly one trigger: the TLS Secret referenced by `spec.tls.secretRef` failed validation. The operator checks it on every reconcile and writes the specific failure to `status.message`. The messages, verbatim (with `<secret>` standing for the Secret name):
+
+| `status.message` | What it means |
+|---|---|
+| `TLS Secret "<secret>" not found in namespace "<namespace>"` | `spec.tls.secretRef` names a Secret that doesn't exist in the cluster's namespace |
+| `TLS Secret "<secret>" has no data` | The Secret exists but is empty |
+| `TLS Secret "<secret>" missing required key "<key>"` | A required key (`tls.crt`, `tls.key`, or `ca.crt`) is absent from the Secret |
+| `TLS Secret "<secret>": tls.crt is not valid PEM` | The certificate data is malformed |
+| `TLS Secret "<secret>": tls.crt is not a valid X.509 certificate` | The PEM block doesn't parse as a certificate |
+| `TLS cert in Secret "<secret>" missing SAN "<name>"` | The certificate's SAN list is missing `{cluster}.{namespace}.svc.cluster.local` or the wildcard `*.{cluster}.{namespace}.svc.cluster.local`; the message names the one it expected |
+
+Fix the Secret in place: patch it with corrected data, or point `spec.tls.secretRef` at a valid one. Recovery is automatic: once validation passes, the operator resets the state to `Creating`, and a previously-formed cluster passes through bootstrap as a no-op back to `Active`. No `ValkeyCluster` edit or recreation is needed. See [TLS](../security/tls.md).
+
+## TLS clients fail while the cluster shows Active
+
+If clients get TLS handshake or certificate errors but `kubectl get valkeycluster` reports `Active`, the certificate has expired. Certificate expiry is a **warn-only** check: the operator logs it but never sets `Invalid`, so the cluster keeps reporting healthy while connections fail.
+
+**Check:**
+
+```bash
+kubectl get secret <tls-secret-name> -n my-app -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -enddate
+```
+
+**Fix:** rotate the leaf certificate by updating `tls.crt` (and `tls.key`) in the Secret. See [TLS](../security/tls.md) for the rotation procedure and for setting up expiry monitoring; the operator does not alert on this for you.
+
+## Pods stuck Pending
+
+Pods that stay `Pending` on an otherwise-`Active` cluster (during scale-out, a rolling change, or a placement change) indicate the scheduler cannot satisfy a constraint:
+
+- **`zoneSpread: required`** with insufficient capacity in one or more target zones.
+- **`placement.nodeSelector`** matching no nodes.
+
+```bash
+kubectl get pods -n my-app
+kubectl describe pod <pending-pod> -n my-app   # scheduler events name the unsatisfied constraint
+```
+
+Existing pods keep serving: a stuck `Pending` replacement does not take down the shard it's replacing. The operator does not retry with different constraints; it waits. Once matching capacity appears (a node joins, an autoscaler adds capacity, `nodeSelector` labels are added to nodes), scheduling and the rollout resume on their own. If you run a cluster autoscaler, confirm it is configured to act on this workload's pending pods. See [Zone-aware placement](zone-aware-placement.md).
+
+**During a genuine zone outage**, waiting for capacity in the dead zone can mean waiting out the outage. If `spec.placement.zones` pins the cluster to a zone that is down, you can remove the affected zone from the list to let replacement pods schedule into the surviving zones: this is a placement change, so it triggers the standard rolling replacement, and you can restore the zone list after the outage the same way. See [Zone-aware placement](zone-aware-placement.md#zone-outage-behavior).
+
+## ACL user cannot authenticate
+
+Work through these in order:
+
+| Check | Detail |
+|---|---|
+| Password hash format | `passwordHashes` entries must be the SHA-256 hash of the password, exactly 64 lowercase hex characters, with no `#` prefix; the operator adds it. |
+| Propagation timing | ACL changes reach nodes in two stages: kubelet propagates the updated ConfigMap into the pod volume (typically up to about a minute), then the separate ACL controller's 30-second tick issues `ACL LOAD` on each pod. Wait for both stages before concluding a binding "didn't take." |
+| Default user disabled | The moment **any** ACL binding exists anywhere in the cluster's config chain or `spec.acl`, the `default` user is disabled. If your client authenticates as `default` with no credentials, it breaks as soon as the first binding lands; see [ACLs](../security/acls.md). |
+| Invalid `roleRef` | A binding's `permissions[].roleRef` naming a `ValkeyRole` that doesn't exist blocks reconciliation for the **entire cluster**, not just that binding. This surfaces **only in operator logs** (never in `status.message`), verbatim: `ValkeyRole "<role>" not found (referenced by user "<username>")`. Duplicate usernames across merged bindings log `duplicate username "<username>" in merged ACL bindings`. |
+
+Fix the hash, wait out the two propagation stages, bind `default` explicitly if you need unauthenticated access, or create the missing `ValkeyRole`.
+
+## Rolling change (upgrade or placement change) stalled
+
+A rolling change (image upgrade, `configRef` change, resource change, or `placement.zones`/`nodeSelector` change) proceeds one shard at a time by design: this bounds blast radius but means a stall on one shard blocks the rest of the fleet-wide rollout from that cluster's perspective.
+
+1. Check for a `Pending` replacement pod: the [Pods stuck Pending](#pods-stuck-pending) section above is the most common cause.
+2. Identify which shard is in progress: `kubectl get valkeynodes -n my-app`; a node in `Joining` or `Leaving` lifecycle marks the shard currently being replaced. Nodes on shards not yet reached stay `Active` and unchanged.
+3. Resolve the blocking condition on that shard (usually a scheduling constraint); the rollout resumes automatically once the shard completes and moves to the next.
+
+## Cluster stuck Terminating
+
+A `ValkeyCluster` (or `ValkeyNode`) stuck in `Terminating` is waiting on its finalizer: `valkey.gomomento.com/cleanup` on the cluster, `valkey.gomomento.com/node-cleanup` on nodes. Finalizer removal requires the operator to be running and watching the resource.
+
+**Most common cause:** the operator was uninstalled (or scaled to zero) before the cluster was deleted. **Fix:** restore the operator, and deletion completes on its own. See [Uninstall](uninstall.md) for the correct teardown order.
+
+If the operator was fully uninstalled, reinstall it from the release artifacts (the Deployment no longer exists, so scaling it does nothing):
+
+```bash
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/operator.yaml
+kubectl -n valkey-operator rollout status deployment/valkey-operator
+```
+
+If it was only scaled to zero, the Deployment still exists; scale it back up:
+
+```bash
+kubectl -n valkey-operator get deployment valkey-operator
+kubectl -n valkey-operator scale deployment/valkey-operator --replicas=1
+```
+
+:::warning
+Manually removing the finalizer (`kubectl patch valkeycluster my-cluster -n my-app --type merge -p '{"metadata":{"finalizers":[]}}'`) is a last resort. It unblocks the Kubernetes delete immediately, but the cluster's pods, Services, ConfigMaps, and Secrets are **not** cleaned up by cascade-delete alone in every case and may be orphaned. Only do this if the operator genuinely cannot be restored, and follow it by manually deleting any leftover resources labeled for that cluster; see [Labels and annotations](../reference/labels-annotations.md).
+:::
+
+## Operator not running or CrashLoopBackOff
+
+The operator validates its own configuration at startup and exits immediately (deliberately) if it's invalid, rather than running with a guessed default. The most common cause is an invalid value in the `valkey-operator-config` ConfigMap.
+
+```bash
+kubectl -n valkey-operator get pods
+kubectl -n valkey-operator logs deployment/valkey-operator
+```
+
+A startup failure logs the specific invalid value before exiting. Fix the ConfigMap and restart:
+
+```bash
+kubectl -n valkey-operator patch configmap valkey-operator-config \
+  --type merge -p '{"data":{"defaultZoneSpread":"bestEffort"}}'
+kubectl -n valkey-operator rollout restart deployment/valkey-operator
+kubectl -n valkey-operator rollout status deployment/valkey-operator
+```
+
+Existing Valkey clusters keep serving traffic while the operator is down; nothing is lost, but no reconciliation happens until it's healthy again. See [Operator configuration](../reference/operator-configuration.md) and [Failure modes](failure-modes.md).
+
+## Collecting diagnostics for support
+
+Before contacting support, capture the following. All of it is plain `kubectl`:
+
+```bash
+# Operator logs (structured JSON)
+kubectl -n valkey-operator logs deployment/valkey-operator > operator-logs.txt
+
+# Full cluster spec, status, and events
+kubectl get valkeycluster -n my-app -o yaml > valkeycluster.yaml
+
+# Node-level state
+kubectl get valkeynodes -n my-app -o yaml > valkeynodes.yaml
+
+# Pod status and scheduling events
+kubectl get pods -n my-app -o wide > pods.txt
+kubectl get events -n my-app > events.txt
+
+# Operator process configuration
+kubectl get configmap valkey-operator-config -n valkey-operator -o yaml > operator-config.yaml
+```
+
+See [Getting support](../support/getting-support.md) for how to open a case and what to attach.

--- a/docs/self-hosted/valkey-operator/operations/uninstall.md
+++ b/docs/self-hosted/valkey-operator/operations/uninstall.md
@@ -1,0 +1,72 @@
+---
+title: Uninstall
+description: The ordered teardown procedure for removing the Momento Valkey Operator and its CRDs, and how to verify nothing is left behind.
+sidebar_position: 7
+---
+
+# Uninstall
+
+This page removes the Momento Valkey Operator from a Kubernetes cluster: Valkey clusters, then the operator, then the CRDs, in that order. The order matters: reversing it leaves resources stuck. It is written for platform teams decommissioning the operator entirely; to remove one Valkey cluster and keep the operator, delete only that `ValkeyCluster`.
+
+## Match your installed version before you start
+
+The commands below reference release manifest URLs pinned to a version. Use the URLs for the version you actually installed, not necessarily the latest release. An operator manifest from a different version than your CRDs can leave the CRD schema and the running operator's expectations out of sync during teardown.
+
+Check the deployed image tag:
+
+```bash
+kubectl -n valkey-operator get deployment valkey-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+The tag in the output (for example, `gomomento/valkey-operator:v0.6.0`) tells you which release's `crds.json` and `operator.yaml` to reference throughout this page.
+
+## 1. Delete all ValkeyClusters first
+
+```bash
+kubectl delete valkeycluster --all -A
+```
+
+Deleting a `ValkeyCluster` triggers the operator's cleanup finalizer, which relies on Kubernetes cascade-delete of everything owned by the cluster: its `ValkeyNode` resources, their Pods and ConfigMaps, the headless Service, the operator auth Secret, and the ACL ConfigMap. That finalizer only clears with the operator running and reconciling. Wait for the clusters to actually disappear before moving on:
+
+```bash
+kubectl get valkeycluster -A
+```
+
+Confirm the list is empty (or contains only clusters you intend to keep on a different operator installation) before proceeding. If a cluster stays `Terminating`, do not continue to the next step: the operator must still be running to finish the cleanup. See the [stuck-`Terminating` entry in Troubleshooting](troubleshooting.md#cluster-stuck-terminating) if it doesn't clear.
+
+## 2. Delete the operator
+
+```bash
+kubectl delete -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/operator.yaml
+```
+
+Use the manifest URL matching the version you installed. This removes the operator's Deployment, ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMap, and namespace.
+
+## 3. Delete the CRDs
+
+```bash
+kubectl delete -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/crds.json
+```
+
+:::warning
+Deleting a CustomResourceDefinition cascades deletion of every custom resource of that kind, cluster-wide. If any `ValkeyCluster` (on this or another operator installation sharing the same CRDs) still exists at this point, deleting the CRDs deletes it too, bypassing the finalizer-driven cleanup from step 1. Confirm step 1 is complete across every namespace you care about before running this.
+:::
+
+This removes all five CRDs: `ValkeyImage`, `ValkeyConfig`, `ValkeyRole`, `ValkeyCluster`, and `ValkeyNode`.
+
+## Verify cleanup
+
+Confirm nothing tagged for the operator or its clusters remains:
+
+```bash
+kubectl get crd | grep valkey.gomomento.com   # expect no output
+kubectl get namespace valkey-operator          # expect NotFound
+kubectl get pods -A -l app.kubernetes.io/name=valkey   # expect no output
+```
+
+The pod label `app.kubernetes.io/name=valkey` is guaranteed on every Valkey pod the operator ever created, so an empty result here is strong evidence step 1 completed everywhere. Services, ConfigMaps, and Secrets belonging to a cluster follow naming patterns rather than a shared label (`{cluster}`, `{cluster}-operator-auth`, `{cluster}-acl`, `{node}-config`). See [Labels and annotations](../reference/labels-annotations.md) for the full taxonomy if you need to search a namespace by hand for anything a partially-completed finalizer left orphaned.
+
+## Wrong order
+
+If you deleted the operator or the CRDs before deleting your `ValkeyCluster` resources, see [Cluster stuck Terminating](troubleshooting.md#cluster-stuck-terminating): the fix is to restore the operator so cleanup can complete, not to force-delete resources by hand.

--- a/docs/self-hosted/valkey-operator/operations/zone-aware-placement.md
+++ b/docs/self-hosted/valkey-operator/operations/zone-aware-placement.md
@@ -1,0 +1,103 @@
+---
+title: Zone-aware placement
+description: Configure zones, node selectors, and zone spread for a Valkey cluster, and what changing placement does on a live cluster.
+sidebar_position: 3
+---
+
+# Zone-aware placement
+
+This page covers `spec.placement` on a `ValkeyCluster`, managed by the Momento Valkey Operator: restricting pods to specific availability zones, pinning them to a node pool, and controlling how strictly shard members are spread across zones. It is for platform and product teams sizing a cluster's failure-domain footprint. For what a zone outage actually does to data, see [Failure modes](failure-modes.md) and [Data durability](../concepts/data-durability.md).
+
+## The placement fields
+
+```yaml
+spec:
+  placement:
+    zones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    zoneSpread: required
+    nodeSelector:
+      node-pool: valkey
+```
+
+### zones
+
+An optional list of availability zone names. When set, every pod gets a **hard** node affinity restricting it to `topology.kubernetes.io/zone` values in the list; a pod that cannot land in one of these zones does not schedule at all. `zones` also activates the per-shard zone spread constraint described below. Full one-per-zone spread on a shard requires at least as many zones as that shard has nodes (primary plus `replicasPerShard` replicas). Fewer zones than shard members still balances nodes across the zones you listed, but not exclusively one per zone.
+
+Leaving `zones` empty imposes no zone restriction; pods can land in any zone your Kubernetes cluster schedules to.
+
+### nodeSelector
+
+An optional map passed through verbatim to every pod's `nodeSelector`. Use it to pin a cluster to a labeled node pool, for example, a pool of memory-optimized instances reserved for Valkey (see [Sizing](sizing.md)). Kubernetes ANDs `nodeSelector` with the `zones` node affinity: a pod must satisfy both, so a selector that names a pool with no presence in the listed zones leaves pods unschedulable.
+
+### zoneSpread
+
+Controls how strictly a shard's members are spread across zones. Two values:
+
+| Value | Effect |
+|---|---|
+| `bestEffort` | Zone spread is a scheduling preference. Pods still land even when spreading is impossible. |
+| `required` | Zone spread is enforced. A pod that would violate it stays `Pending` rather than schedule. |
+
+Under the hood, every Valkey pod always carries a per-shard **host** spread constraint (maxSkew 1, best-effort) regardless of `zoneSpread`. Two members of the same shard are steered off the same Kubernetes node whenever possible. `zoneSpread` governs the equivalent constraint at the zone level:
+
+- **`bestEffort`**: one per-shard topology spread constraint on `topology.kubernetes.io/zone`, maxSkew 1, best-effort (`ScheduleAnyway`).
+- **`required`**: the same per-shard constraint, but enforced (`DoNotSchedule`), **plus** a second, cluster-wide zone spread constraint that balances the whole cluster's pods across zones, not just one shard at a time. That second constraint is always best-effort, and has to be: Kubernetes allows only one hard (`DoNotSchedule`) constraint per topology key, and the per-shard constraint already holds that slot. So in `required` mode, each shard's spread is a hard guarantee, and balance across the whole cluster is a strong, but not absolute, preference layered on top.
+
+If you don't set `zoneSpread` at all, the cluster inherits the operator-wide default configured by your platform team. See [Operator configuration](../reference/operator-configuration.md). As shipped, that default is `bestEffort`.
+
+## Zone outage behavior
+
+Which shards keep serving through a zone loss is entirely a function of `zoneSpread` and `replicasPerShard`:
+
+- With `zoneSpread: required` and `replicasPerShard` of at least 1, no shard has both its primary and all its replicas in one zone; every shard has a surviving member elsewhere and fails over or takes over per [Failure modes](failure-modes.md#zone-lost).
+- With `zoneSpread: bestEffort` (the shipped default), spread is only a preference. A shard whose members happened to land together in the lost zone loses its data.
+
+The operator does not proactively rebalance pods back into a recovered zone: replacement pods schedule into whichever zones satisfy `placement` and have capacity at the time, and spread is restored gradually as pods are naturally replaced.
+
+During an extended zone outage, a cluster whose `zones` list includes the dead zone can end up with replacement pods stuck `Pending`: the scheduler has nowhere allowed to put them. Rather than waiting out the outage, you can remove the affected zone from `spec.placement.zones`: that is a placement change, so it triggers the standard rolling replacement into the surviving zones, and you can restore the original zone list the same way once the zone recovers. See [Changing placement on a live cluster](#changing-placement-on-a-live-cluster).
+
+## Autoscaler interaction
+
+`zoneSpread: required` can leave pods `Pending` when the required zone capacity doesn't exist yet, for example, before a cluster autoscaler has provisioned nodes in an under-represented zone. This is a safe stall, not a failure. Bootstrap and reconciliation wait for the pod to become schedulable rather than proceeding with a partial or unbalanced topology, and they take no other corrective action while waiting. A `Pending` pod is visible with `kubectl get pods`; the `ValkeyCluster` itself does not surface a distinct status for this condition. Once the autoscaler adds capacity in a satisfying zone, the pod schedules and reconciliation continues without intervention.
+
+## Changing placement on a live cluster
+
+`zones` and `nodeSelector` are pod-template inputs: changing either one on a running cluster triggers a rolling replacement of every pod, one shard at a time, onto the new placement, the same mechanism used for image and config changes. See the canonical change-impact table in [Reconciliation](../concepts/reconciliation.md#what-happens-when-you-change-the-spec).
+
+`zoneSpread` is different: it's a scheduling preference baked into a pod only when that pod is created. Changing it on a live cluster does not replace any existing pods: it takes effect only for pods created afterward (new shards, replacement replicas, or a later rolling replacement triggered by something else).
+
+## Worked example with three zones, required spread, and a dedicated node pool
+
+A cluster pinned to a `valkey` node pool, spread with a hard guarantee across three zones:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  placement:
+    zones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    zoneSpread: required
+    nodeSelector:
+      node-pool: valkey
+```
+
+With `replicasPerShard: 1`, each shard has two members (primary + one replica) against three listed zones: full one-per-zone spread is achievable, and `required` makes it a hard guarantee.
+
+## Notes and anti-patterns
+
+- **`replicasPerShard: 0` makes placement irrelevant to durability.** Zone spread only protects data that has a second copy; with no replicas, losing the primary's pod for any reason (including a zone that was never actually lost, only a single evicted pod) loses the shard's data. See [Data durability](../concepts/data-durability.md).
+- **Fewer zones than nodes per shard undercuts `zones`.** If a shard has more members (primary + replicas) than `zones` lists, the per-shard spread constraint still balances members across the zones you provided, but it cannot guarantee one member per zone; two members can end up in the same zone. List at least as many zones as `1 + replicasPerShard`.
+- **`nodeSelector` narrower than `zones` produces unschedulable pods**, not a relaxed constraint: Kubernetes requires both to be satisfied simultaneously. Confirm your node pool actually has capacity in every zone you list before combining the two.
+- **A tainted node pool cannot host Valkey pods.** There is no way to give the pods tolerations: the only toleration they carry is a built-in one for `kubernetes.io/arch=arm64:NoSchedule` (see [Compatibility](../support/compatibility.md)). If your platform dedicates node pools by tainting them, Valkey pods stay `Pending` there forever. Dedicate a pool to Valkey with labels plus `nodeSelector` (as in the worked example above), and keep other workloads off it through their own scheduling constraints rather than a taint.

--- a/docs/self-hosted/valkey-operator/platform-guide/curating-images-and-configs.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/curating-images-and-configs.md
@@ -1,0 +1,102 @@
+---
+title: Curating images and configs
+description: "How to build the platform menu: register allowlisted images, author base and variant configs with baseRef inheritance, and size resources safely."
+sidebar_position: 2
+---
+
+# Curating images and configs
+
+This guide walks through building the menu product teams choose from with the Momento Valkey Operator. It covers registering allowlisted Valkey images with `ValkeyImage`, and authoring a `ValkeyConfig` catalog, including base-and-variant configs via `baseRef`. It is for platform teams; product teams only read what you publish here.
+
+## Register an allowlisted image
+
+A `ValkeyImage` is not a convenience alias; it is the allowlist. If no `ValkeyImage` exists for a given image, no `ValkeyConfig` can reference it, and no cluster can run it.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0
+spec:
+  repository: valkey/valkey
+  tag: "9.0.0"
+  version: "9.0.0"
+```
+
+Apply one `ValkeyImage` per version you are willing to run.
+
+### What the operator validates, and what it trusts
+
+The allowlist check is existence, nothing more: at every reconcile the operator resolves the config chain's `imageRef` to a `ValkeyImage` by name, joins `repository` and `tag` into an image string, and puts that string verbatim into pod specs. It never contacts a registry, parses the tag, or inspects the image, and it never reads `version`: that field is informational, surfaced as a printer column for humans, and nothing checks that the image actually contains the Valkey version it declares. Curation is therefore entirely your responsibility. Register exact, pinned tags of images you have verified meet the [Valkey version floor](../support/compatibility.md); avoid mutable tags such as `latest`, which make "what is running" unanswerable and can silently violate the floor on the next pod replacement.
+
+The operator also sets no `imagePullPolicy` and no `imagePullSecrets` on the pods, so kubelet defaults apply. If your images live in a private registry, supply pull credentials through the tenant namespace's default ServiceAccount or your nodes' registry configuration.
+
+:::warning
+Do not remove a `ValkeyImage` while any config still references it, directly or through a `baseRef` chain. Config resolution runs at the start of every reconciliation, so a missing image does not just block new configs: it halts **all** reconciliation for every cluster on a config that still points at it: no scaling, no ACL or TLS updates, no self-healing, until the image is restored. Running pods keep serving, but the clusters are unmanaged in the meantime. Remove an image only after no config in the menu references it.
+:::
+
+## Author a base config
+
+A `ValkeyConfig` bundles an image reference, resource sizing, Valkey settings, and platform-level ACL bindings into a named menu item:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: "2Gi"
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: "allkeys-lru"
+```
+
+Product teams reference this by name in `ValkeyCluster.spec.configRef`; they cannot set an image, a resource size, or a Valkey setting directly. See [Resource model](../concepts/resource-model.md) for why the split exists.
+
+## Build variants with baseRef
+
+Use `baseRef` to derive size or purpose variants from a common base without repeating settings:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: large
+spec:
+  baseRef: standard
+  resources:
+    cpu: "4"
+    memory: "16Gi"
+  valkey:
+    maxmemory: "12gb"
+```
+
+Resolution follows a fixed set of rules, walked from the selected config toward its root:
+
+- **Whole-field overrides.** `imageRef`, `resources.cpu`, and `resources.memory` are replaced outright by whichever config in the chain sets them first, walking child to parent. `large` above sets both `cpu` and `memory`; a variant that only set `memory` would keep the base's `cpu`.
+- **`imageRef` can come entirely from the base.** A derived config does not need to set `imageRef` at all: `large` inherits `valkey-9-0` from `standard`. It must be set somewhere in the chain, or resolution fails and every cluster using the config stops progressing.
+- **The `valkey` map merges per key.** `large` overrides `maxmemory` but keeps `maxmemory-policy: allkeys-lru` from `standard`, because it never sets that key. This is the one field that merges rather than replaces: unset keys survive from the parent.
+- **`acl` replaces, it does not merge.** The first config in the chain that sets `acl` supplies the complete binding list for every config below it. A variant that sets its own `acl` block replaces the base's bindings entirely, not adds to them; a variant that omits `acl` inherits the base's bindings unchanged. See [ACLs](../security/acls.md) for how these compose with cluster-level bindings.
+- **Chains resolve up to 10 configs deep.** A longer chain (including an accidental cycle) fails resolution.
+
+Config resolution runs on every reconcile, not once at admission: editing a base config or the image it points to re-resolves every config and cluster downstream of it. See [Managing Valkey upgrades](valkey-upgrades.md) for what that means when the change is an image bump.
+
+## Resources vs. maxmemory headroom
+
+`resources.cpu` and `resources.memory` set both the request and the limit on the Valkey container. Leave headroom between `resources.memory` and the `valkey.maxmemory` setting: Valkey needs memory beyond the keyspace for connection buffers, replication backlogs, and fork-based persistence operations. A pod that hits its memory limit is killed outright rather than gracefully degraded. See [Sizing](../operations/sizing.md) for concrete headroom guidance and the risk of omitting `resources` entirely.
+
+## What curated configs cannot override
+
+A fixed set of Valkey settings (cluster mode, the client port, file paths, replication identity, and more) is injected by the operator after your config resolves. It always wins over anything in the `valkey` map. Design your menu around this: don't spend menu space trying to set `cluster-enabled` or `port`. Don't assume the operator rejects settings it doesn't force: anything else in the `valkey` map passes through unchecked. See [Forced settings](../reference/forced-settings.md) for the exact list.
+
+## Menu design patterns
+
+Two patterns cover most fleets:
+
+- **T-shirt sizes.** Publish a base config with shared settings, then thin variants that only override `resources`: `standard` and `large` above are the minimal version of this. Add more sizes as needed; each is a few lines of `baseRef` and a resource override.
+- **Dev vs. prod menus.** Maintain separate config trees per environment class rather than one config shared across dev and prod namespaces: a dev tree with smaller resources and a permissive `maxmemory-policy`, and a prod tree with production sizing and ACLs bound at the config level. Since `ValkeyConfig` is cluster-scoped, both trees live side by side. A namespace's RBAC does not restrict which configs it can read, only whether it can act on that read (see [Multi-tenancy and RBAC](multi-tenancy-and-rbac.md)). Naming conventions, for example `dev-standard` and `prod-standard`, are what keep the menu legible, not access control.
+
+Keep the menu small. Every config you publish is something product teams can select immediately and something you commit to keeping current. See [Managing Valkey upgrades](valkey-upgrades.md) for what changing a widely-referenced config triggers.

--- a/docs/self-hosted/valkey-operator/platform-guide/index.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/index.md
@@ -1,0 +1,34 @@
+---
+title: For platform teams
+description: What platform teams own when running the Momento Valkey Operator (installation, the config menu, tenancy, upgrades, and monitoring), with links to each guide.
+sidebar_position: 1
+---
+
+# For platform teams
+
+This section is for the team that installs and governs the Momento Valkey Operator. You run the operator itself, curate what product teams are allowed to provision, and own the operational surface (upgrades, maintenance, and monitoring) across every Valkey cluster in the fleet.
+
+## Your job in this model
+
+The operator splits ownership along the same line as its resource model: cluster-scoped resources are yours, namespaced `ValkeyCluster` resources belong to product teams (see [Resource model](../concepts/resource-model.md)). Concretely, you are responsible for:
+
+- **Installing and upgrading the operator:** apply the release manifests, verify rollout, and keep the operator current.
+- **Curating the menu:** publish the `ValkeyImage` allowlist and the `ValkeyConfig` catalog product teams choose from, so nothing runs that you have not approved.
+- **Onboarding tenants:** grant each product team namespaced write access to `ValkeyCluster` and read-only access to the menu, using ordinary Kubernetes RBAC.
+- **Owning fleet-wide upgrades:** Valkey engine upgrades happen by repointing configs at new images, which rolls every cluster that references them; you control the pace by how you stage that change.
+- **Keeping the Kubernetes cluster healthy under the operator:** node drains, cluster-autoscaler behavior, and the absence of PodDisruptionBudgets all need operator-aware handling.
+- **Monitoring the fleet:** the operator's own health, per-cluster state, and (if you need it) Valkey-level metrics via your own exporter.
+
+## Guides in this section
+
+- [Curating images and configs](curating-images-and-configs.md) — build the image allowlist and the config menu, including `baseRef` inheritance rules, resource sizing, and menu design patterns.
+- [Multi-tenancy and RBAC](multi-tenancy-and-rbac.md) — copy-pasteable manifests to onboard a product team: a namespace, cluster CRUD, and read-only menu access.
+- [Managing Valkey upgrades](valkey-upgrades.md) — how registering a new image and repointing a config rolls the fleet, what a roll looks like per shard, and the staged-rollout pattern for controlling blast radius.
+- [Upgrading the operator](operator-upgrades.md) — apply new release artifacts, what happens to running clusters while the operator restarts, and how to roll back.
+- [Kubernetes maintenance](kubernetes-maintenance.md) — how node drains and the cluster-autoscaler interact with the operator, and what stands in since there are no PodDisruptionBudgets.
+- [Monitoring](monitoring.md) — operator logs, cluster state, label taxonomy for dashboards, what to alert on, and how to get Valkey-level metrics today.
+- [Logging](logging.md) — the log contract: JSON structure and fields, `RUST_LOG` control, what gets logged, Valkey node logs, and what your platform must provide.
+
+The operator's one fleet-wide process setting (the default `zoneSpread` mode applied to clusters that don't set their own) lives in the `valkey-operator-config` ConfigMap; see [Operator configuration](../reference/operator-configuration.md).
+
+For the underlying mechanics these guides build on, see [Reconciliation](../concepts/reconciliation.md) and [Architecture](../concepts/architecture.md). For the security posture of the operator itself, start at [Security model](../security/index.md). For how the teams you onboard connect their applications, point them at [Connecting to your cluster](../team-guide/connecting.md).

--- a/docs/self-hosted/valkey-operator/platform-guide/kubernetes-maintenance.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/kubernetes-maintenance.md
@@ -1,0 +1,71 @@
+---
+title: Kubernetes maintenance
+description: How node drains and the cluster-autoscaler interact with the operator, and what stands in for the PodDisruptionBudgets it does not create.
+sidebar_position: 6
+---
+
+# Kubernetes maintenance
+
+This guide covers routine Kubernetes-side maintenance (node drains, Kubernetes upgrades, and cluster-autoscaler scale-down) from the operator's point of view. It assumes you are already familiar with draining nodes and running the cluster-autoscaler. It covers only what is different because a Valkey cluster managed by the operator is running on the node you are draining.
+
+## How a drain looks to the operator
+
+A node drain evicts every pod on the node, Valkey pods included. From there, the operator's normal recovery path takes over, because eviction and a pod crash look identical to it:
+
+1. The evicted pod terminates. Valkey pods run with `restartPolicy: Never`, so Kubernetes does not restart it in place; it stays gone.
+2. The operator detects the missing pod on its next reconciliation pass.
+3. If the pod was a shard primary, Valkey's own automatic failover promotes a replica when quorum holds; the operator forces a takeover on a surviving replica when it does not. If the pod was a replica, there is no failover to make.
+4. The operator creates a replacement node for the affected shard through the same `Joining` lifecycle every new node goes through. It joins the cluster, attaches as a replica, and completes its initial sync before becoming Active.
+
+This is the same sequence documented event-by-event in [Failure modes](../operations/failure-modes.md); a drain is a voluntary trigger for it.
+
+## Recommended drain practice
+
+Drain Kubernetes nodes one at a time, and wait for every affected `ValkeyCluster` to report `Active` again before draining the next:
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+kubectl get valkeynodes -A -w   # wait for every node's LIFECYCLE to return to Active
+```
+
+A cluster's `STATE` column stays `Active` while it heals: recovery is not a separate reported state. Gate on the `ValkeyNode` lifecycle (no nodes stuck `Joining` or `Leaving`) and on pods being `Running` rather than on cluster state. See [Cluster status](../reference/cluster-status.md).
+
+A single Kubernetes node can host pods from multiple shards and multiple clusters. Draining several nodes at once multiplies how many shards are simultaneously down a member, which raises the odds of pushing some shard past quorum before its replacement has caught up. Pacing drains to one node at a time, gated on cluster health, keeps that risk to a single node's worth of exposure.
+
+A full Kubernetes upgrade (rotating every node pool through drain, replace, rejoin) is this same procedure applied repeatedly. Upgrade one Kubernetes node (or small pool slice) at a time, gated on the same node-lifecycle check between steps. The operator has no special upgrade mode to enable.
+
+### Draining the Kubernetes node the operator runs on
+
+The operator itself is a single-replica Deployment, so draining its Kubernetes node evicts the one operator pod and reconciliation pauses until the Deployment reschedules it elsewhere. Running Valkey clusters keep serving during the gap (the operator is not on the data path), but no healing, scaling, or configuration changes happen until the pod is back. Drain the operator's node first (or last), on its own, rather than together with nodes hosting Valkey pods. If a Valkey pod dies while the operator is rescheduling, its replacement is delayed until the operator returns. See [Failure modes](../operations/failure-modes.md) for the operator-down behavior in full.
+
+## No PodDisruptionBudgets
+
+The operator creates no `PodDisruptionBudget` for the pods it manages, so `kubectl drain` and the cluster-autoscaler have no PDB to consult before evicting a Valkey pod. Three things stand in for it:
+
+- **`placement.zoneSpread: required`** on the cluster spreads each shard's nodes across zones as a hard scheduling constraint, so the loss of a single zone's worth of nodes cannot take out a whole shard. See [Zone-aware placement](../operations/zone-aware-placement.md).
+- **`replicasPerShard` of at least one** ensures a lost primary has a promotable replica rather than triggering a data-loss recreation. See [Data durability](../concepts/data-durability.md).
+- **Pacing your own drains and node-pool rotations** (the practice above), since nothing else limits how many shard members can go down at once.
+
+None of these substitute for a PDB's admission-time protection during an eviction storm; they reduce the odds of correlated failure and bound the damage when it happens, rather than blocking the eviction outright.
+
+## Cluster-autoscaler interaction
+
+The operator sets no scale-down protection on Valkey pods itself. It does not annotate them to resist eviction, and if the autoscaler does evict one, the operator relies on the same drain-handling path described above.
+
+If you want the cluster-autoscaler to leave Valkey pods alone during scale-down, add the annotation it recognizes through `spec.podAnnotations`:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  podAnnotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+```
+
+This works because the operator applies `podAnnotations` verbatim to every pod it creates, and the cluster-autoscaler independently honors that annotation as part of its own eviction logic. This is standard Kubernetes/cluster-autoscaler behavior, not something the operator implements or detects. Setting it prevents the autoscaler from evicting the pod to consolidate nodes. It has no effect on the operator's own drain handling above, and it does not exempt the pod from a manual `kubectl drain`.

--- a/docs/self-hosted/valkey-operator/platform-guide/logging.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/logging.md
@@ -1,0 +1,75 @@
+---
+title: Logging
+description: "The operator's log contract: JSON structure, level control, what gets logged, Valkey node logs, and what is deliberately left to your platform."
+sidebar_position: 8
+---
+
+# Logging
+
+This page is the log contract for the Momento Valkey Operator and the Valkey pods it manages: where logs go, what each line contains, and how to control verbosity. It is written for platform teams wiring log pipelines and alerts. Logs are the operator's only observability surface (it exposes no metrics or health endpoint), so [Monitoring](monitoring.md) builds directly on this page.
+
+## The contract
+
+The operator writes structured JSON, one object per line, to container stdout. Nothing is written to files or volumes, and the operator ships no collection or retention: log storage is your platform's concern, handled by whatever node-level collector or pipeline your Kubernetes cluster already runs. `kubectl logs` works as it does for any container:
+
+```bash
+kubectl -n valkey-operator logs deployment/valkey-operator
+```
+
+Each line carries these top-level keys:
+
+| Key | Contents |
+|---|---|
+| `timestamp` | Event time, RFC 3339 UTC |
+| `level` | `ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE` |
+| `fields` | The event itself: `message` plus the event's structured fields (see below) |
+| `target` | The emitting module path, such as `operator::controller::acl` |
+| `span`, `spans` | Present when the event fires inside a reconcile: the object reference of the resource being reconciled, including its namespace |
+
+Events identify their subject through structured fields, not message text: most reconcile-path events carry a `cluster_name` field, and per-pod events add `pod` or `node`. Filter on `fields.cluster_name` rather than grepping message strings:
+
+```bash
+kubectl -n valkey-operator logs deployment/valkey-operator \
+  | jq 'select(.fields.cluster_name == "my-cluster")'
+```
+
+The namespace is **not** an event field. It appears only in the `span`/`spans` object reference, so if two namespaces host same-named clusters, disambiguate with the span data rather than `cluster_name` alone.
+
+## Level control
+
+Verbosity is set by the `RUST_LOG` environment variable on the operator Deployment. Both the release manifest and the Helm chart set it to `info`. The value feeds the filter directly, so standard directive syntax works, including per-module levels such as `info,operator=debug`. The variable is read once at startup: to change it, edit the Deployment's env and let the rollout restart the operator.
+
+:::warning
+Never remove `RUST_LOG`. With the variable unset, the operator logs nothing at any level, including errors: a misconfigured operator can exit without a single log line. Lower the level to `warn` if `info` is too verbose; do not unset it.
+:::
+
+## What gets logged
+
+At `info`, expect a steady heartbeat plus one line per action taken:
+
+- **Per-tick heartbeats.** Each cluster produces `ACL reconcile tick` and `TLS reconcile tick` lines every 30 seconds, and an `active tick` line (with shard and node counts) from the cluster's main loop. This steady rhythm is a health signal in itself: [Monitoring](monitoring.md) recommends alerting when it stops.
+- **Actions.** One line per resource created or step taken: `creating Pod for node`, `creating headless Service`, `cluster meet issued`, `failover to up-to-date replica for rolling upgrade`, `cluster formed, transitioning to Active`.
+- **Diagnostics you will search for.** Scheduling problems log `bootstrap blocked: pod cannot be scheduled` with the scheduler's own reason. Failover handling logs `primary unhealthy but replicas exist, waiting for auto-failover` and, when quorum is lost, `no quorum — issued TAKEOVER on replica`. TLS validation failures log `TLS Secret validation failed, setting cluster Invalid` with the same reason text that lands in `status.message`.
+- **Retryable errors at `WARN`.** Best-effort paths log and retry rather than fail, for example `ACL LOAD failed, will retry next tick` and `reconcile error, requeuing`. A persistent stream of the same `WARN` line is a problem worth investigating; a single occurrence usually is not. [Troubleshooting](../operations/troubleshooting.md) maps the common ones to causes.
+- **`ERROR` is rare**: invalid operator configuration at startup and internal invariant violations.
+
+Two absences to plan around:
+
+- **No startup banner.** The operator logs no version or "starting up" line; the first output is whatever reconcile activity occurs. Verify a rollout with `kubectl rollout status`, not by waiting for a boot message.
+- **No Kubernetes Events.** The operator never emits Events, so `kubectl describe valkeycluster` shows none from the operator and event-based tooling sees nothing. Everything is in the log stream (and, for TLS validation failures, in `status.message`).
+
+The operator never writes passwords into log messages; missing-credential conditions log key names only.
+
+Two kinds of non-JSON output exist, both limited to startup: if the operator cannot construct its Kubernetes client it exits with a plain-text panic message on stderr, and an invalid `RUST_LOG` directive prints a plain-text `ignoring ...` warning on stderr before logging initializes.
+
+## Valkey node logs
+
+Valkey pods are single-container with no sidecars. The operator sets neither `logfile` nor `loglevel`, so `valkey-server` writes its native plain-text log to container stdout at Valkey's default level. Collect it with the same node-level pipeline as any workload:
+
+```bash
+kubectl -n my-app logs my-cluster-8c04d
+```
+
+You can raise or lower node verbosity by setting `loglevel` in a `ValkeyConfig`'s `valkey` map. Do not set `logfile`: it would redirect node logs into the container's ephemeral filesystem, invisible to `kubectl logs` and lost with the pod.
+
+Because Valkey pods run with `restartPolicy: Never` and are replaced rather than restarted, a failed pod's logs survive only as long as your cluster retains logs for terminated pods. If you rely on post-incident log review, make sure your collector captures Valkey namespaces continuously; by the time you investigate, the pod that mattered may already be replaced. `kubectl logs --previous` does not apply here (there is no restarted container, only new pods with new names).

--- a/docs/self-hosted/valkey-operator/platform-guide/monitoring.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/monitoring.md
@@ -1,0 +1,76 @@
+---
+title: Monitoring
+description: Operator logs, cluster state, the label taxonomy for dashboards, what to alert on, and how to get Valkey-level metrics today.
+sidebar_position: 7
+---
+
+# Monitoring
+
+This guide covers observing the Momento Valkey Operator and the clusters it manages: the operator's own logs, the per-cluster state signal, and the label taxonomy for building dashboards and alerts. Since the operator exposes no Valkey metrics itself, this guide also covers how to get them today.
+
+## Operator logs
+
+The operator emits structured JSON logs to stdout. Log verbosity is controlled by the `RUST_LOG` environment variable on the operator Deployment (`info` by default):
+
+```bash
+kubectl -n valkey-operator logs deployment/valkey-operator
+```
+
+Because the logs are JSON, pipe them into whatever log pipeline you already run (a sidecar, a node-level collector, or `kubectl logs -f | jq`) rather than parsing them ad hoc. [Logging](logging.md) is the full contract: the JSON structure, the fields that identify clusters and pods, what gets logged at each level, and Valkey node logs. See [Operator configuration](../reference/operator-configuration.md) for how `RUST_LOG` is wired to the Deployment.
+
+## Cluster state
+
+Each `ValkeyCluster`'s `status.state` and `status.message` are the primary health signal:
+
+```bash
+kubectl get valkeyclusters -A -w
+```
+
+`state` is one of `Creating`, `Active`, or `Invalid` (`Updating` is reserved and not reported; a cluster mid-upgrade still shows `Active`). `message` is populated with a specific reason when `state` is `Invalid`. See [Cluster status](../reference/cluster-status.md) for the full schema.
+
+## Watching ValkeyNode lifecycle
+
+`ValkeyNode` resources are the operator's internal record of each cluster member, and reading them is useful for watching a transition (a scale-out, an upgrade, a failure recovery) happen step by step:
+
+```bash
+kubectl get valkeynodes -n <namespace> -w
+```
+
+Nodes appear with `Joining` lifecycle, flip to `Active` once they finish joining the cluster, and briefly show `Leaving` on their way out. See [Reconciliation](../concepts/reconciliation.md) for what drives each transition.
+
+## Building dashboards on labels
+
+Every Valkey pod carries a stable set of labels (`app.kubernetes.io/name=valkey`, `app.kubernetes.io/instance={cluster}`, and a shard index) that are safe to build dashboards, NetworkPolicies, and alert rules on. See [Labels and annotations](../reference/labels-annotations.md) for the complete taxonomy and which labels are stable versus transient.
+
+## What to alert on
+
+Three signals cover most of what you need at the fleet level:
+
+- **`state` not `Active` for longer than your normal roll or bootstrap takes.** A cluster stuck in `Creating` or `Invalid` past the time a routine change normally needs is worth paging on. See [Troubleshooting](../operations/troubleshooting.md) for the common causes.
+- **Pod churn on a cluster.** Repeated replacement of members in the same shard, outside of a change you initiated, points at an underlying failure (a bad node, a resource limit being hit, an unschedulable placement) rather than routine self-healing.
+- **The operator Deployment itself not available.** See below.
+
+## Monitoring the operator itself
+
+The operator exposes no liveness or readiness probe, no health endpoint, and no metrics port: there is nothing to scrape or poll on the operator process directly. Monitor it the same way you monitor any critical, unprobed Deployment:
+
+- **Alert on Deployment availability:** `kubectl -n valkey-operator get deployment valkey-operator` reporting fewer available replicas than desired (normally one) means the operator is down. Because it runs a single replica with no leader election, "down" means no reconciliation is happening anywhere in the fleet. See [Failure modes](../operations/failure-modes.md) for what that does and does not affect.
+- **Alert on log flow stopping.** A running pod that has stopped emitting logs (no reconciliation activity across any cluster) is a secondary signal that the process is wedged even though the Deployment reports Ready.
+
+## Valkey-level metrics
+
+The operator does not expose Valkey metrics anywhere: Valkey pods are single-container with no metrics endpoint, and the operator adds none. To collect Valkey-level metrics today, deploy your own standalone exporter as a separate Deployment, pointed at the cluster's headless Service:
+
+```text
+{cluster}.{namespace}.svc.cluster.local:6379
+```
+
+Authenticate the exporter with a dedicated ACL user scoped to read-only monitoring commands, rather than reusing an application credential. See [ACLs](../security/acls.md) for how to bind one. The exporter Deployment, its own annotations, and its scrape configuration are entirely yours to manage. `spec.podAnnotations` on the `ValkeyCluster` is for your own customer-owned tooling that needs annotations on the Valkey pods themselves (service-mesh injection and similar), not a mechanism for exposing metrics from those pods.
+
+:::note
+Built-in metrics export is on the roadmap but not available today. See [Roadmap](../roadmap.md).
+:::
+
+## Certificate expiry
+
+The operator does not monitor or alert on TLS certificate expiry: an expired certificate leaves the cluster reporting `Active` while client connections fail. Monitoring certificate expiry is your responsibility. See [TLS](../security/tls.md) for the validation the operator does perform and how expiry is handled if you use cert-manager.

--- a/docs/self-hosted/valkey-operator/platform-guide/multi-tenancy-and-rbac.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/multi-tenancy-and-rbac.md
@@ -1,0 +1,110 @@
+---
+title: Multi-tenancy and RBAC
+description: Complete manifests to onboard a product team onto the Momento Valkey Operator using plain Kubernetes RBAC, no admission webhooks required.
+sidebar_position: 3
+---
+
+# Multi-tenancy and RBAC
+
+This guide onboards a product team onto the Momento Valkey Operator using nothing but standard Kubernetes RBAC objects. No admission webhook or external policy engine is involved: the governance model is the resource split itself (cluster-scoped menu, namespaced clusters) enforced by ordinary `Role`/`ClusterRole` grants. The manifests below onboard one team, `checkout-team`, onto its own namespace.
+
+## 1. The team's namespace
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: checkout-team
+```
+
+Every `ValkeyCluster` the team creates lives in this namespace. A namespace can hold any number of `ValkeyCluster` resources: there is no one-cluster-per-namespace restriction.
+
+## 2. Cluster CRUD, namespaced
+
+Grant full control over `ValkeyCluster` and read access to the operator-internal `ValkeyNode`, scoped to the team's namespace with an ordinary `Role` and `RoleBinding`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: checkout-team-clusters
+  namespace: checkout-team
+rules:
+  - apiGroups: ["valkey.gomomento.com"]
+    resources: ["valkeyclusters"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["valkey.gomomento.com"]
+    resources: ["valkeynodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: checkout-team-clusters
+  namespace: checkout-team
+subjects:
+  - kind: Group
+    name: checkout-team-engineers
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: checkout-team-clusters
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Substitute the `Group` subject for whatever your cluster uses to identify the team: a `User`, or a `ServiceAccount` with its own `namespace` field. Because this is a `Role`/`RoleBinding` pair, not a `ClusterRole`/`ClusterRoleBinding`, the grant is confined to the `checkout-team` namespace: the team cannot touch `ValkeyCluster` or `ValkeyNode` resources anywhere else.
+
+## 3. Read-only menu access, cluster-wide
+
+`ValkeyImage`, `ValkeyConfig`, and `ValkeyRole` are cluster-scoped resources, so no `RoleBinding` can grant access to them: a `RoleBinding` only ever grants within its own namespace. Read access requires a `ClusterRole` bound with a `ClusterRoleBinding`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: valkey-menu-reader
+rules:
+  - apiGroups: ["valkey.gomomento.com"]
+    resources: ["valkeyimages", "valkeyconfigs", "valkeyroles"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: checkout-team-menu-reader
+subjects:
+  - kind: Group
+    name: checkout-team-engineers
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: valkey-menu-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+`valkey-menu-reader` is a single shared `ClusterRole`. Define it once and bind it to every team with a separate `ClusterRoleBinding` per team (as above), or list multiple teams' subjects on one `ClusterRoleBinding` if that fits your RBAC conventions better. Either way, the grant is read-only: `get`/`list`/`watch`, never `create`/`update`/`delete`.
+
+## Why this is governance without admission webhooks
+
+The two bindings above are the entire tenancy model:
+
+- The **namespaced** `Role` gives the team full self-service control over their own `ValkeyCluster` resources (create, scale, reconfigure, delete) with no platform-team involvement per cluster.
+- The **cluster-scoped read** grant lets the team see the full menu (which images and configs exist) but grants no path to create or modify one.
+
+Because `ValkeyCluster.spec` can only reference menu resources by name (there is no field for an inline image, an inline resource size, or an inline Valkey setting), a team with exactly these two grants cannot put anything into service that the platform team has not published to the menu. No admission webhook has to intercept and validate the spec; the schema and the RBAC split do that work between them. See [Resource model](../concepts/resource-model.md) for the full reasoning behind the split.
+
+## What tenants can and cannot do
+
+With the grants above, `checkout-team` can:
+
+- Create, scale, reconfigure, and delete any number of `ValkeyCluster` resources in the `checkout-team` namespace.
+- Read the full catalog of `ValkeyImage`, `ValkeyConfig`, and `ValkeyRole` resources to see what is available.
+- Read `ValkeyNode` resources in their namespace to observe cluster member lifecycle.
+
+They cannot:
+
+- Create, edit, or delete a `ValkeyImage`, `ValkeyConfig`, or `ValkeyRole`: the menu is platform-team-owned.
+- See or affect `ValkeyCluster` or `ValkeyNode` resources in any other team's namespace: the `RoleBinding` in step 2 is namespace-scoped by construction.
+- Reach pods, Services, ConfigMaps, or Secrets directly: nothing in these manifests grants core-resource access. Only the operator's own service account has that; see [RBAC](../security/rbac.md) for what it grants and why.
+
+Repeat steps 1 to 3 (with a new namespace and subject) for each additional team; the shared `valkey-menu-reader` `ClusterRole` from step 3 does not need to be recreated.

--- a/docs/self-hosted/valkey-operator/platform-guide/operator-upgrades.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/operator-upgrades.md
@@ -1,0 +1,46 @@
+---
+title: Upgrading the operator
+description: Apply new release artifacts, what happens to running clusters while the operator restarts, and how to roll back.
+sidebar_position: 5
+---
+
+# Upgrading the operator
+
+This guide covers upgrading the Momento Valkey Operator itself (the controller Deployment and its CRDs) as opposed to upgrading the Valkey engine version running inside your clusters (see [Managing Valkey upgrades](valkey-upgrades.md)).
+
+## Apply the new release
+
+Apply the new release's CRDs and operator manifest, then confirm the rollout completes:
+
+```bash
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/crds.json
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/v0.6.0/operator.yaml
+kubectl -n valkey-operator rollout status deployment/valkey-operator
+```
+
+This is the same procedure as a fresh install (see [Installation](../getting-started/installation.md)): applying CRDs is always safe to repeat, and `kubectl apply` on the Deployment manifest updates it in place.
+
+## While the operator restarts
+
+The operator is a single-replica Deployment with no leader election (see below), so an upgrade briefly stops reconciliation while the old pod terminates and the new one starts. Nothing breaks during that window:
+
+- **Running clusters keep serving.** The data plane (Valkey pods, replication, client connections, and Valkey's own automatic failover) is entirely independent of the operator. See [Reconciliation](../concepts/reconciliation.md) and [Failure modes](../operations/failure-modes.md) for why: the operator holds no in-memory state between reconciliation passes, so it has nothing to lose by disappearing.
+- **Pending changes queue, they do not fail.** Any spec edit, scale, or upgrade in flight when the operator goes down waits. When the new operator pod starts, it rediscovers actual state from scratch and resumes converging every cluster toward its current spec, including edits made while it was down.
+
+No special ordering requirement exists between CRDs and the Deployment beyond applying both; the operator does not need to be down to apply a new CRD schema.
+
+## Rolling back
+
+Rolling back is the same operation with the previous release's artifacts:
+
+```bash
+kubectl apply -f https://github.com/momentohq/valkey-operator/releases/download/<previous-version>/operator.yaml
+```
+
+:::warning
+Reapplying an older `operator.yaml` does not revert the CRD schema: `kubectl apply`-ing CRDs only ever adds or changes fields, it never removes them, so the newer CRD schema stays installed even after you roll the operator Deployment back. If any `ValkeyCluster`, `ValkeyConfig`, or other resource was created or edited using a spec field the new release introduced, the older operator binary was not built to understand that field. Confirm what changed between the two CRD versions before rolling back a Deployment that has already seen newer resources, and treat rollback as a last resort rather than a routine operation.
+:::
+
+## Single-replica deployment
+
+The operator runs as a Deployment with exactly one replica and no leader election: a second replica would not add high availability, since the operator's design already tolerates being down (see above). Kubernetes's default rolling-update behavior for a one-replica Deployment briefly has zero available replicas during the swap (or, depending on your `maxUnavailable`/`maxSurge` settings, briefly two). Either way, reconciliation pauses for that window and resumes once the new pod is Ready. Monitor the upgrade the same way you monitor operator health day to day. See [Monitoring](monitoring.md).

--- a/docs/self-hosted/valkey-operator/platform-guide/valkey-upgrades.md
+++ b/docs/self-hosted/valkey-operator/platform-guide/valkey-upgrades.md
@@ -1,0 +1,79 @@
+---
+title: Managing Valkey upgrades
+description: How registering a new image and repointing a config rolls the fleet, what a rolling upgrade looks like per shard, and how to stage a fleet-wide rollout.
+sidebar_position: 4
+---
+
+# Managing Valkey upgrades
+
+This guide covers upgrading (and downgrading) the Valkey engine version across a fleet managed by the Momento Valkey Operator. It covers how a version change propagates from a `ValkeyConfig` to every cluster that uses it, what a rolling upgrade looks like at the shard level, and how to control the blast radius of a fleet-wide change.
+
+## Trigger a fleet upgrade
+
+No per-cluster upgrade action exists. An upgrade is a menu change: register the new image, then repoint the config's `imageRef` at it.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0-1
+spec:
+  repository: valkey/valkey
+  tag: "9.0.1"
+  version: "9.0.1"
+```
+
+```bash
+kubectl patch valkeyconfig standard \
+  --type merge -p '{"spec": {"imageRef": "valkey-9-0-1"}}'
+```
+
+:::info
+Every `ValkeyCluster` that resolves to `standard` (directly, or through a `baseRef` chain) starts rolling immediately, and **all of them roll concurrently**. No fleet-level sequencing exists: the operator does not stagger clusters, wait for one to finish before starting the next, or offer a canary step at the config level. Each cluster paces its own roll one shard at a time, but every cluster referencing the config begins at once. Plan the blast radius of a config change with this in mind. See [Staged rollout](#staged-rollout) below if a simultaneous fleet-wide roll is not what you want.
+:::
+
+## What a roll looks like per shard
+
+Within each cluster, the operator upgrades strictly one shard at a time, replacing before it retires:
+
+1. A new node running the up-to-date image joins the shard as a replica.
+2. Once the shard has more replicas than its target, an outdated replica is retired.
+3. If the primary itself is outdated, the operator issues exactly one failover onto an up-to-date replica: a clean handoff that waits for replication sync before promoting.
+4. Another up-to-date replica joins, putting the shard over its replica target again with the demoted former primary as the excess.
+5. The demoted, now-outdated former primary is retired as the excess replica.
+
+A node is only ever retired while the shard is above its replica target, so the shard never dips below its configured replica count at any point in the sequence.
+
+The cluster reports `Active` throughout: there is no `Updating` state you will observe. The full change-impact table, including which other spec changes trigger this same rolling-replacement mechanism, lives in [Reconciliation](../concepts/reconciliation.md); this page covers the image-upgrade case specifically.
+
+## Client impact
+
+Each shard experiences exactly one failover during its roll: the same event a primary-pod failure would cause, not a series of them. Writes to that shard fail for the duration of the failover; other shards are unaffected. A cluster-aware client handles the failover through its normal topology refresh, the same mechanism it uses for any primary change. See [Connecting to your cluster](../team-guide/connecting.md) for client requirements and retry guidance.
+
+## Staged rollout
+
+Because repointing a shared config rolls every referencing cluster at once, the recommended way to control an upgrade's pace is to stage it through configs rather than through the operator:
+
+1. Duplicate the config under a new name (for example, `standard` becomes `standard-v2`) pointing at the new image, leaving the original `standard` untouched.
+2. Migrate clusters gradually by editing each `ValkeyCluster.spec.configRef` from `standard` to `standard-v2`, one team, one cluster, or one batch at a time, on whatever schedule you choose.
+3. Once every cluster has moved, retire the old config, or repoint `standard` at the new image and drop `standard-v2` for the next round.
+
+This gives you a canary and a rollback point that repointing `imageRef` in place cannot. At any moment, some clusters are on the old image and some are on the new one, under your control, rather than the entire fleet moving together.
+
+## Monitoring a roll
+
+Watch the same signals as any rolling replacement:
+
+- `kubectl get valkeynodes -n <namespace>`: new nodes appear with `Joining` lifecycle, then flip to `Active`; outdated nodes disappear as they are retired.
+- `kubectl get valkeycluster -n <namespace> -w`: the cluster's node list and printer columns update as the roll proceeds; state stays `Active`.
+- Pod image column: confirm pods are coming up on the new image.
+
+See [Cluster status](../reference/cluster-status.md) for status field semantics and [Labels and annotations](../reference/labels-annotations.md) for the labels you can use to build a dashboard across the fleet. [Monitoring](monitoring.md) covers fleet-wide observability in depth.
+
+## Downgrading
+
+Downgrading uses the identical mechanism in reverse: register a `ValkeyImage` for the older version and repoint the config at it. The same per-shard procedure, concurrency behavior, and staged-rollout option all apply.
+
+:::warning
+Downgrade paths are not routinely exercised in practice: most fleets move forward only. Treat a downgrade as you would any under-tested operation: stage it (see above) rather than repointing a widely-shared config directly, and verify the target version behaves as expected on a non-critical cluster first. The engine version floor is firm regardless of direction: never downgrade below Valkey 9, since resharding depends on slot-migration commands introduced in that version, and older engines do not support them.
+:::

--- a/docs/self-hosted/valkey-operator/reference/api/index.md
+++ b/docs/self-hosted/valkey-operator/reference/api/index.md
@@ -1,0 +1,31 @@
+---
+title: API reference overview
+description: The five custom resources served by the Momento Valkey Operator, with conventions for reading the per-resource reference pages.
+sidebar_position: 1
+---
+
+# API reference overview
+
+This section documents every custom resource served by the Momento Valkey Operator: each field, its type, defaults, and the validation the API server enforces. It describes the API shipped with operator release v0.6.0.
+
+All five resources belong to API group and version `valkey.gomomento.com/v1alpha1`. None define short names, so use the full resource name with `kubectl` (for example, `kubectl get valkeyclusters`).
+
+## The five resources
+
+| Kind | Scope | Who touches it | Purpose |
+|---|---|---|---|
+| [`ValkeyImage`](valkeyimage.md) | Cluster | Platform team | Allowlist entry for a permitted Valkey container image. |
+| [`ValkeyConfig`](valkeyconfig.md) | Cluster | Platform team | A menu item defining how Valkey nodes are configured (image, resources, settings, platform ACLs), with inheritance via `baseRef`. |
+| [`ValkeyRole`](valkeyrole.md) | Cluster | Platform team | Reusable set of Valkey ACL command and category permissions, referenced from ACL bindings. |
+| [`ValkeyCluster`](valkeycluster.md) | Namespaced | Product team | The provisioning interface: picks a config from the menu and declares topology, placement, TLS, and per-cluster ACLs. |
+| [`ValkeyNode`](valkeynode.md) | Namespaced | Operator only (read-only for users) | Operator-internal representation of a single Valkey cluster member. |
+
+For an explanation of why the API is split this way and how the cluster-scoped menu resources implement governance, see [Resource model](../../concepts/resource-model.md).
+
+## Conventions on these pages
+
+- **Required**: `Yes` means the API server rejects a manifest that omits the field. `No` means the field is optional.
+- **Default**: the value applied when the field is omitted, where the schema defines one. `—` means no default: an omitted optional field is absent.
+- **Validation**: constraints the API server enforces at admission: enum values (shown with their exact serialized casing), numeric ranges, length limits, and admission rules (Kubernetes validation expressions) described in plain language. A manifest that violates any of them is rejected on create or update.
+- **Nested types**: object-valued fields are documented in their own sub-sections, with an "Appears in" line listing every field that uses them.
+- Field names are the exact serialized names you write in YAML. Casing matters: for example `configRef`, not `configref`.

--- a/docs/self-hosted/valkey-operator/reference/api/valkeycluster.md
+++ b/docs/self-hosted/valkey-operator/reference/api/valkeycluster.md
@@ -1,0 +1,176 @@
+---
+title: ValkeyCluster
+description: Reference for the ValkeyCluster custom resource, the product team's interface for provisioning a Valkey cluster.
+sidebar_position: 5
+---
+
+# ValkeyCluster
+
+`ValkeyCluster` is the product team's interface for provisioning a Valkey cluster with the Momento Valkey Operator. It selects a [`ValkeyConfig`](valkeyconfig.md) from the platform team's menu and declares topology, placement, TLS, ACL bindings, and pod annotations. For the provisioning workflow, see [Provisioning](../../team-guide/provisioning.md).
+
+## Resource metadata
+
+| | |
+|---|---|
+| API group/version | `valkey.gomomento.com/v1alpha1` |
+| Kind | `ValkeyCluster` |
+| Plural | `valkeyclusters` |
+| Scope | Namespaced |
+
+## Spec
+
+An admission rule on the spec as a whole enforces TLS immutability on updates: the `tls` field must be present on both the old and new spec, or absent from both. In practice, you cannot enable TLS on a cluster created without it, and you cannot disable TLS on a cluster created with it. Only the `secretRef` inside `tls` may change, for certificate rotation. See [TLS](../../security/tls.md).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `configRef` | string | Yes | — | none | Name of a `ValkeyConfig` on the platform menu. The named config (and the `ValkeyImage` it resolves to) must exist for the cluster to progress. |
+| `shards` | integer | Yes | — | Minimum 1. | Number of shards (hash-slot ranges). Changing this triggers slot rebalancing: see [Scaling](../../team-guide/scaling.md). |
+| `replicasPerShard` | integer | Yes | — | Minimum 0. | Number of replicas per shard, **not counting the primary**. `replicasPerShard: 1` yields two nodes per shard. |
+| `acl` | array of [`AclBinding`](#aclbinding) | No | — | Max 64 entries. Admission rule: no two entries may share a `username` ("duplicate username in ACL bindings"). | Per-cluster ACL user bindings. Additive to the config-level bindings, but cannot reuse a username defined at the config level. See [ACLs](../../security/acls.md). |
+| `placement` | object ([`Placement`](#placement)) | No | — | none | Zone and node-pool placement constraints for the cluster's pods. |
+| `tls` | object ([`Tls`](#tls)) | No | — | Presence is immutable (admission rule above). | TLS configuration. When set, the cluster runs TLS-only: the plaintext port is disabled (`port 0`) and TLS is served on 6379. |
+| `podAnnotations` | map of string to string | No | — | Admission rule: no key may start with `valkey.gomomento.com/` (that prefix is reserved by the operator). | Annotations applied verbatim to every managed pod. See [podAnnotations behavior](#podannotations-behavior). |
+
+### podAnnotations behavior
+
+Use `podAnnotations` for tooling that reads pod annotations, such as service-mesh sidecar injection or your own scrape configuration on customer-deployed components. The operator applies the map verbatim to every pod it manages.
+
+Changes propagate as follows:
+
+- **Adding a key or changing a value** is patched onto running pods in place. No pods are replaced.
+- **Removing a key** does not remove the annotation from running pods. The removal takes effect on each pod as it is next replaced for other reasons.
+
+:::note
+`kubectl explain valkeycluster.spec.podAnnotations` currently shows outdated description text claiming that existing pods keep their original annotations. The behavior above (in-place patching of additions and edits) is correct.
+:::
+
+### Tls
+
+Appears in: [`spec.tls`](#spec).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `secretRef` | string | Yes | — | none | Name of a [`kubernetes.io/tls` Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) in the same namespace as the cluster. Mutable: point it at a new Secret (or update the Secret in place) to rotate certificates. |
+
+The referenced Secret must contain `tls.crt`, `tls.key`, and `ca.crt`, and the certificate's SANs must include both `{cluster}.{namespace}.svc.cluster.local` and `*.{cluster}.{namespace}.svc.cluster.local`. A Secret that fails validation puts the cluster into the `Invalid` state with detail in `status.message`. Requirements, rotation, and a cert-manager walkthrough: [TLS](../../security/tls.md).
+
+### Placement
+
+Appears in: [`spec.placement`](#spec).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `zones` | array of string | No | — | none | Availability zones requiring per-shard coverage. When set, a hard [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) restricts pods to these zones, and a per-shard [topology spread constraint](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) distributes each shard's nodes across them. Full spread requires each shard to have at least as many nodes as there are zones. |
+| `zoneSpread` | string (enum) | No | Operator-wide default (`bestEffort` as shipped) | One of `bestEffort`, `required`. | Enforcement mode for the per-shard zone spread constraint. `bestEffort` schedules pods even when spreading is not possible; `required` leaves pods Pending until a valid zone placement exists. When unset, the cluster inherits the operator's configured default: see [Operator configuration](../operator-configuration.md). |
+| `nodeSelector` | map of string to string | No | — | none | Node labels passed through verbatim to each pod's [`nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector). Use to pin the cluster to a node pool. Composes with `zones`: Kubernetes requires a pod to satisfy both. |
+
+Changing `zones` or `nodeSelector` on a running cluster triggers a rolling replacement onto the new placement; changing `zoneSpread` affects only pods created afterward. See [Zone-aware placement](../../operations/zone-aware-placement.md).
+
+### AclBinding
+
+Appears in: [`spec.acl`](#spec) on this resource, and in `spec.acl` on [`ValkeyConfig`](valkeyconfig.md#aclbinding).
+
+A user-to-permissions binding for Valkey ACLs.
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `username` | string | Yes | — | Max length 128. Admission rules: must be non-empty and contain only letters, digits, hyphens, and underscores (`^[a-zA-Z0-9_-]+$`); must not start with `_momento_`, which is reserved for the operator's system users. | The Valkey username the binding creates. |
+| `passwordHashes` | array of string | Yes | — | 1–8 entries. Admission rule: each entry must be exactly 64 lowercase hexadecimal characters (a SHA-256 digest). | SHA-256 hashes of the user's passwords. Do not include Valkey's `#` prefix: the operator adds it. Multiple hashes enable rotation: add the new hash, update clients, then remove the old hash. |
+| `permissions` | array of [`Permission`](#permission) | Yes | — | 1–16 entries. Admission rule: at least one entry is required. | The first entry becomes the user's root permissions; each additional entry becomes an ACL selector scoped to its own key and channel patterns. |
+
+### Permission
+
+Appears in: [`AclBinding.permissions`](#aclbinding).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `roleRef` | string | Yes | — | Max length 253. | Name of a [`ValkeyRole`](valkeyrole.md) supplying command and category permissions. |
+| `keys` | array of [`KeyPattern`](#keypattern) | Yes | — | Max 16 entries. | Key access patterns. Required: no default-open behavior exists. |
+| `channels` | array of string | No | — | Max 16 entries, each max length 128. Admission rule: patterns must not contain control characters, spaces, or quotes. | Pub/Sub channel patterns. Do not include the `&` prefix: the operator adds it. Omit for no channel access. |
+
+### KeyPattern
+
+Appears in: [`Permission.keys`](#permission).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `pattern` | string | Yes | — | Max length 256. Admission rule: must not contain control characters, spaces, or quotes. | Key glob pattern, for example `myapp:*`. Do not include the `~` prefix: the operator adds the prefix that matches the access mode. |
+| `access` | string (enum) | No | `readwrite` | One of `read`, `write`, `readwrite`. | Access mode for keys matching the pattern: `read` grants read-only access, `write` grants write-only access, `readwrite` grants both. |
+
+## Status
+
+`ValkeyCluster` has a status subresource. For state semantics and transitions in depth, see [Cluster status](../cluster-status.md).
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | string (enum) | High-level lifecycle state. One of `Creating` (default), `Active`, `Updating`, `Invalid`: see below. |
+| `targetSpec` | object (same shape as [`spec`](#spec)) | Snapshot of the spec the operator is working toward, taken when a transition starts and cleared when the cluster reaches `Active`. Bootstrap drives its **topology** (`shards`, `replicasPerShard`) from this snapshot rather than the live spec, so topology edits made during a transition are deferred until it completes; other fields are read live but only shape nodes not yet created. See [Cluster status](../cluster-status.md#targetspec-snapshot-semantics). |
+| `nodes` | array of string | Schema-reserved; not populated in the current release. Use `kubectl get valkeynodes` to list members. See [Cluster status](../cluster-status.md). |
+| `message` | string | Human-readable detail for the current state, populated when `state` is `Invalid`. |
+
+States:
+
+| Value | Meaning |
+|---|---|
+| `Creating` | The operator is bootstrapping the Valkey cluster toward `targetSpec`. |
+| `Active` | The cluster matches its spec and is serving. |
+| `Updating` | Reserved. This value is defined in the schema but is not currently reported; running clusters show `Active` while changes roll out. |
+| `Invalid` | The spec references something invalid (for example, a TLS Secret that fails validation). `message` carries the detail. Reconciliation resumes automatically once the problem is corrected. |
+
+The status does not include a Kubernetes `conditions` array; `state` and `message` carry the health signal.
+
+## Printer columns
+
+`kubectl get valkeyclusters` shows:
+
+| Column | Source |
+|---|---|
+| `Config` | `.spec.configRef` |
+| `Shards` | `.spec.shards` |
+| `Replicas` | `.spec.replicasPerShard` |
+| `State` | `.status.state` |
+
+## References and referenced by
+
+- References a [`ValkeyConfig`](valkeyconfig.md) via `spec.configRef`, [`ValkeyRole`](valkeyrole.md) resources via `spec.acl[].permissions[].roleRef`, and a TLS Secret via `spec.tls.secretRef`.
+- The operator creates one [`ValkeyNode`](valkeynode.md) per cluster member, owned by the `ValkeyCluster` and linked back through `ValkeyNode.spec.clusterName`. See [Architecture](../../concepts/architecture.md) for the full ownership chain.
+
+## Example
+
+A three-shard TLS-enabled cluster with one replica per shard, a cluster-level ACL user, and zone-aware placement:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  acl:
+    - username: team-batch
+      passwordHashes:
+        - <sha256-hex-of-password>
+      permissions:
+        - roleRef: app-readwrite
+          keys:
+            - pattern: "batch:*"
+              access: readwrite
+        - roleRef: app-readwrite
+          keys:
+            - pattern: "metrics:*"
+              access: read
+  placement:
+    zones:
+      - us-east-1a
+      - us-east-1b
+    zoneSpread: required
+  tls:
+    secretRef: my-cluster-tls
+  podAnnotations:
+    example.com/inject-sidecar: "false"
+```
+
+The first `permissions` entry gives `team-batch` root permissions on `batch:*`; the second becomes a selector granting read-only access to `metrics:*`.

--- a/docs/self-hosted/valkey-operator/reference/api/valkeyconfig.md
+++ b/docs/self-hosted/valkey-operator/reference/api/valkeyconfig.md
@@ -1,0 +1,145 @@
+---
+title: ValkeyConfig
+description: Reference for the ValkeyConfig custom resource, the cluster-scoped configuration menu item with baseRef inheritance.
+sidebar_position: 3
+---
+
+# ValkeyConfig
+
+`ValkeyConfig` tells the Momento Valkey Operator how the nodes of a Valkey cluster are configured: which image they run, their resources, Valkey settings, and platform-level ACL bindings. Platform teams curate a menu of these cluster-scoped resources; product teams select one by name in `ValkeyCluster.spec.configRef`. See [Curating images and configs](../../platform-guide/curating-images-and-configs.md) for authoring guidance.
+
+## Resource metadata
+
+| | |
+|---|---|
+| API group/version | `valkey.gomomento.com/v1alpha1` |
+| Kind | `ValkeyConfig` |
+| Plural | `valkeyconfigs` |
+| Scope | Cluster |
+
+## Spec
+
+All spec fields are optional, but a usable config must provide `imageRef` either directly or through its `baseRef` chain.
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `imageRef` | string | No | — | none | Name of a [`ValkeyImage`](valkeyimage.md). If omitted, the base config referenced by `baseRef` (or a config further up the chain) must provide it. |
+| `baseRef` | string | No | — | none | Name of another `ValkeyConfig` to inherit from. Fields set on this config override the base. See [Inheritance](#inheritance). |
+| `resources` | object ([`ValkeyResources`](#valkeyresources)) | No | — | none | Resource requirements for each Valkey pod. |
+| `valkey` | map of string to string | No | — | none | Valkey configuration key-value pairs, written into each node's configuration. Some cluster-critical settings are always injected by the operator and override values set here: see [Forced settings](../forced-settings.md). |
+| `acl` | array of [`AclBinding`](#aclbinding) | No | — | Max 64 entries. Admission rule: no two entries may share a `username` ("duplicate username in ACL bindings"). | Platform-level ACL user bindings, applied to every cluster that uses this config. Cluster-level bindings are additive but cannot reuse usernames defined here. See [ACLs](../../security/acls.md). |
+
+### Inheritance
+
+`baseRef` builds configs by derivation: for example, a `large` config that inherits everything from `standard` and overrides only memory. Resolution follows these rules:
+
+- The operator follows the `baseRef` chain from the selected config toward its root. The chain may be at most 10 configs deep; a longer chain (including any cycle) fails resolution, and clusters using the config do not progress.
+- The child overrides the parent. `imageRef`, `resources.cpu`, and `resources.memory` are whole-field overrides: a value set on a derived config wins.
+- The `valkey` map merges per key: keys set on the derived config win, and parent keys the child does not set survive.
+- `acl` does **not** merge. The first config in the chain that sets `acl` supplies the complete binding list; setting `acl` on a derived config replaces the parent's bindings entirely. Omitting it inherits the parent's bindings.
+- `imageRef` must be set somewhere in the chain, and the named `ValkeyImage` must exist.
+
+Configs resolve at reconcile time, not at admission. Editing any config or image in a chain re-resolves every cluster that references it, which might trigger rolling replacements. See [Reconciliation](../../concepts/reconciliation.md) for which changes roll pods.
+
+### ValkeyResources
+
+Appears in: [`spec.resources`](#spec).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `cpu` | string | No | — | none | CPU request and limit for each Valkey pod, as a Kubernetes [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/), for example `"2"`. |
+| `memory` | string | No | — | none | Memory request and limit for each Valkey pod, for example `"4Gi"`. |
+
+Each value is applied as both the request and the limit of the Valkey container. Leave headroom between `memory` and the `maxmemory` Valkey setting. See [Sizing](../../operations/sizing.md).
+
+### AclBinding
+
+Appears in: [`spec.acl`](#spec) on this resource, and in `spec.acl` on [`ValkeyCluster`](valkeycluster.md#aclbinding).
+
+A user-to-permissions binding for Valkey ACLs.
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `username` | string | Yes | — | Max length 128. Admission rules: must be non-empty and contain only letters, digits, hyphens, and underscores (`^[a-zA-Z0-9_-]+$`); must not start with `_momento_`, which is reserved for the operator's system users. | The Valkey username the binding creates. |
+| `passwordHashes` | array of string | Yes | — | 1–8 entries. Admission rule: each entry must be exactly 64 lowercase hexadecimal characters (a SHA-256 digest). | SHA-256 hashes of the user's passwords. Do not include Valkey's `#` prefix: the operator adds it. Multiple hashes enable rotation: add the new hash, update clients, then remove the old hash. |
+| `permissions` | array of [`Permission`](#permission) | Yes | — | 1–16 entries. Admission rule: at least one entry is required. | The first entry becomes the user's root permissions; each additional entry becomes an ACL selector scoped to its own key and channel patterns. |
+
+### Permission
+
+Appears in: [`AclBinding.permissions`](#aclbinding).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `roleRef` | string | Yes | — | Max length 253. | Name of a [`ValkeyRole`](valkeyrole.md) supplying command and category permissions. |
+| `keys` | array of [`KeyPattern`](#keypattern) | Yes | — | Max 16 entries. | Key access patterns. Required: no default-open behavior exists. |
+| `channels` | array of string | No | — | Max 16 entries, each max length 128. Admission rule: patterns must not contain control characters, spaces, or quotes. | Pub/Sub channel patterns. Do not include the `&` prefix: the operator adds it. Omit for no channel access. |
+
+### KeyPattern
+
+Appears in: [`Permission.keys`](#permission).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `pattern` | string | Yes | — | Max length 256. Admission rule: must not contain control characters, spaces, or quotes. | Key glob pattern, for example `myapp:*`. Do not include the `~` prefix: the operator adds the prefix that matches the access mode. |
+| `access` | string (enum) | No | `readwrite` | One of `read`, `write`, `readwrite`. | Access mode for keys matching the pattern: `read` grants read-only access, `write` grants write-only access, `readwrite` grants both. |
+
+## Status
+
+`ValkeyConfig` has a status subresource, but it defines no fields today.
+
+## Printer columns
+
+`kubectl get valkeyconfigs` shows:
+
+| Column | Source |
+|---|---|
+| `ImageRef` | `.spec.imageRef` |
+| `BaseRef` | `.spec.baseRef` |
+
+## References and referenced by
+
+- References a [`ValkeyImage`](valkeyimage.md) via `spec.imageRef` and another `ValkeyConfig` via `spec.baseRef`.
+- References [`ValkeyRole`](valkeyrole.md) resources via `spec.acl[].permissions[].roleRef`.
+- Referenced by [`ValkeyCluster`](valkeycluster.md) via `spec.configRef`.
+
+## Example
+
+A base config and a derived variant:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: "2Gi"
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: "allkeys-lru"
+  acl:
+    - username: app-user
+      passwordHashes:
+        - <sha256-hex-of-password>
+      permissions:
+        - roleRef: app-readwrite
+          keys:
+            - pattern: "myapp:*"
+              access: readwrite
+---
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: large
+spec:
+  baseRef: standard
+  resources:
+    cpu: "4"
+    memory: "16Gi"
+  valkey:
+    maxmemory: "12gb"
+```
+
+`large` inherits `imageRef`, `maxmemory-policy`, and the `acl` bindings from `standard`, and overrides the resources and `maxmemory`. A variant that set only `resources.memory` would keep the base's `cpu`. Each resource field is overridden independently.

--- a/docs/self-hosted/valkey-operator/reference/api/valkeyimage.md
+++ b/docs/self-hosted/valkey-operator/reference/api/valkeyimage.md
@@ -1,0 +1,66 @@
+---
+title: ValkeyImage
+description: Reference for the ValkeyImage custom resource, the cluster-scoped allowlist of permitted Valkey container images.
+sidebar_position: 2
+---
+
+# ValkeyImage
+
+`ValkeyImage` registers a Valkey container image the Momento Valkey Operator is allowed to run. It is the allowlist: if no `ValkeyImage` exists for an image, no `ValkeyCluster` can use it. Platform teams manage these resources; see [Curating images and configs](../../platform-guide/curating-images-and-configs.md) for the workflow.
+
+## Resource metadata
+
+| | |
+|---|---|
+| API group/version | `valkey.gomomento.com/v1alpha1` |
+| Kind | `ValkeyImage` |
+| Plural | `valkeyimages` |
+| Scope | Cluster |
+
+## Spec
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `repository` | string | Yes | — | none | Container image repository, for example `valkey/valkey`. |
+| `tag` | string | Yes | — | none | Container image tag, for example `9.0.0`. |
+| `version` | string | Yes | — | none | The Valkey version the image provides, for example `9.0.0`. |
+
+The operator resolves a cluster's image at reconcile time by following `ValkeyCluster.spec.configRef` to a `ValkeyConfig`, then the config's `imageRef` to a `ValkeyImage`. If the referenced `ValkeyImage` does not exist, resolution fails and the cluster does not progress. This is where the allowlist is enforced.
+
+:::note
+Shard scaling uses server-side slot migration commands that require Valkey 9 or later. Unless a cluster will never be resharded, register Valkey 9+ images. See [Compatibility](../../support/compatibility.md).
+:::
+
+## Status
+
+`ValkeyImage` has a status subresource, but it defines no fields today.
+
+## Printer columns
+
+`kubectl get valkeyimages` shows:
+
+| Column | Source |
+|---|---|
+| `Repository` | `.spec.repository` |
+| `Tag` | `.spec.tag` |
+| `Version` | `.spec.version` |
+
+## References and referenced by
+
+- Referenced by [`ValkeyConfig`](valkeyconfig.md) via `spec.imageRef`. A config may also inherit its image from a base config's `imageRef`.
+- References no other resources.
+
+## Example
+
+A `ValkeyImage` for the `valkey-9-0` image:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0
+spec:
+  repository: valkey/valkey
+  tag: "9.0.0"
+  version: "9.0.0"
+```

--- a/docs/self-hosted/valkey-operator/reference/api/valkeynode.md
+++ b/docs/self-hosted/valkey-operator/reference/api/valkeynode.md
@@ -1,0 +1,103 @@
+---
+title: ValkeyNode
+description: Reference for the ValkeyNode custom resource, the operator-internal representation of a single Valkey cluster member.
+sidebar_position: 6
+---
+
+# ValkeyNode
+
+`ValkeyNode` represents a single member (one pod) of a Valkey cluster managed by the Momento Valkey Operator. The operator creates, mutates, and deletes these resources itself; they are documented here because you will see them with `kubectl` and they are useful for observing cluster transitions.
+
+:::info
+`ValkeyNode` is operator-internal and read-only for users. Do not create, edit, or delete `ValkeyNode` resources. To change a node's configuration, change the owning [`ValkeyCluster`](valkeycluster.md) or its [`ValkeyConfig`](valkeyconfig.md): the operator replaces nodes to converge on the change.
+:::
+
+## Resource metadata
+
+| | |
+|---|---|
+| API group/version | `valkey.gomomento.com/v1alpha1` |
+| Kind | `ValkeyNode` |
+| Plural | `valkeynodes` |
+| Scope | Namespaced |
+
+Each `ValkeyNode` is owned by a `ValkeyCluster` and is deleted with it. The node's name (`{cluster}` plus a random suffix) is also the name of the pod and configuration ConfigMap the operator creates for it.
+
+## Spec
+
+The spec is immutable by design: the operator never updates a node's configuration in place. When a node becomes outdated (a new image, changed resources or Valkey settings, or changed placement), the operator creates a replacement `ValkeyNode` and retires the old one. The single exception is `lifecycle`, the one mutable field, which the operator moves through the join/leave process.
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `clusterName` | string | Yes | — | none | Name of the owning [`ValkeyCluster`](valkeycluster.md). |
+| `image` | string | Yes | — | none | Container image as `repository:tag`, already resolved from the config's `ValkeyImage`, not a reference. |
+| `cpu` | string | No | — | none | CPU request and limit, copied from the resolved config. |
+| `memory` | string | No | — | none | Memory request and limit, copied from the resolved config. |
+| `valkeySettings` | map of string to string | No | `{}` | none | Valkey configuration key-value pairs with the operator's [forced settings](../forced-settings.md) baked in. |
+| `shardIndex` | integer | Yes | — | Minimum 0. | Operator-assigned scheduling index, propagated as a pod label so topology spread constraints keep each shard's nodes on separate hosts and across zones. Not the Valkey shard ID. |
+| `tlsSecret` | string | No | — | none | Name of the TLS Secret mounted at `/etc/valkey/tls/`. Set when the owning cluster has TLS enabled. |
+| `placement` | object (same shape as [`ValkeyCluster` `Placement`](valkeycluster.md#placement)) | No | — | none | Placement constraints copied from the owning cluster when the node is created. A later change to the cluster's `zones` or `nodeSelector` makes existing nodes outdated, driving a rolling replacement onto the new placement. |
+| `lifecycle` | string (enum) | No | `Active` | One of `Active`, `Joining`, `Leaving`. | The one mutable field: where this node is in the cluster join/leave process. `Joining`: being added to the Valkey cluster; `Active`: a full member; `Leaving`: being drained and retired. |
+
+Watching lifecycles is a practical way to observe a bootstrap or rolling replacement:
+
+```bash
+kubectl get valkeynodes -n my-app -w
+```
+
+```text
+NAME               CLUSTER      IMAGE                LIFECYCLE
+my-cluster-3f9a1   my-cluster   valkey/valkey:9.0.0   Active
+my-cluster-8c04d   my-cluster   valkey/valkey:9.0.0   Joining
+my-cluster-b52e7   my-cluster   valkey/valkey:9.0.0   Leaving
+```
+
+## Status
+
+`ValkeyNode` has no status subresource. It is the only one of the five resources without one. Observe node health through the pod of the same name and the owning cluster's status.
+
+## Printer columns
+
+`kubectl get valkeynodes` shows:
+
+| Column | Source |
+|---|---|
+| `Cluster` | `.spec.clusterName` |
+| `Image` | `.spec.image` |
+| `Lifecycle` | `.spec.lifecycle` |
+
+## References and referenced by
+
+- References its owning [`ValkeyCluster`](valkeycluster.md) via `spec.clusterName` (and an owner reference), and a TLS Secret via `spec.tlsSecret` when TLS is enabled.
+- Owns the pod and the node ConfigMap that carry its name.
+- Referenced by no user-facing resource.
+
+## Example
+
+A `ValkeyNode` as created by the operator for the TLS-enabled cluster `my-cluster` (shown for reading, not for applying):
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyNode
+metadata:
+  name: my-cluster-3f9a1
+  namespace: my-app
+  # ownerReferences to the ValkeyCluster omitted
+spec:
+  clusterName: my-cluster
+  image: valkey/valkey:9.0.0
+  cpu: "1"
+  memory: "2Gi"
+  shardIndex: 0
+  tlsSecret: my-cluster-tls
+  placement:
+    zones:
+      - us-east-1a
+      - us-east-1b
+    zoneSpread: required
+  valkeySettings:
+    cluster-enabled: "yes"
+    maxmemory: "1500mb"
+    # ... remaining settings from the resolved config plus forced settings
+  lifecycle: Active
+```

--- a/docs/self-hosted/valkey-operator/reference/api/valkeyrole.md
+++ b/docs/self-hosted/valkey-operator/reference/api/valkeyrole.md
@@ -1,0 +1,80 @@
+---
+title: ValkeyRole
+description: Reference for the ValkeyRole custom resource, a reusable set of Valkey ACL command and category permissions.
+sidebar_position: 4
+---
+
+# ValkeyRole
+
+`ValkeyRole` defines a reusable set of command and category permissions for the Valkey ACLs the Momento Valkey Operator manages. Roles contain only command-level rules; key patterns, channel patterns, and passwords are supplied where a role is bound: in the `acl` field of a [`ValkeyConfig`](valkeyconfig.md) or [`ValkeyCluster`](valkeycluster.md). Platform teams manage roles; see [ACLs](../../security/acls.md) for how roles, bindings, and users fit together.
+
+## Resource metadata
+
+| | |
+|---|---|
+| API group/version | `valkey.gomomento.com/v1alpha1` |
+| Kind | `ValkeyRole` |
+| Plural | `valkeyroles` |
+| Scope | Cluster |
+
+## Spec
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `categories` | array of [`CategoryRule`](#categoryrule) | No | — | Max 64 entries. | Rules for Valkey command categories such as `all`, `read`, `admin`. Do not include the `@` prefix: the operator adds it. |
+| `commands` | array of [`CommandRule`](#commandrule) | No | — | Max 256 entries. | Rules for individual Valkey commands. |
+
+### CategoryRule
+
+Appears in: [`spec.categories`](#spec).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `name` | string | Yes | — | Max length 64. Admission rule: must start with a letter and contain only letters, digits, hyphens, and underscores (`^[a-zA-Z][a-zA-Z0-9_-]*$`). | Category name without the `@` prefix, for example `all`, `read`, `admin`. |
+| `access` | string (enum) | Yes | — | One of `allow`, `deny`. | Whether to allow or deny commands in this category. |
+
+### CommandRule
+
+Appears in: [`spec.commands`](#spec).
+
+| Field | Type | Required | Default | Validation | Description |
+|---|---|---|---|---|---|
+| `name` | string | Yes | — | Max length 64. Admission rule: must start with a letter and match `^[a-zA-Z][a-zA-Z0-9_-]*$`. | Command name, for example `get`, `cluster`, `debug`. |
+| `subcommand` | string | No | — | Max length 64. Admission rule: when present, must start with a letter and match `^[a-zA-Z][a-zA-Z0-9_-]*$`. | Optional subcommand: for example `info` to target `cluster\|info`. |
+| `access` | string (enum) | Yes | — | One of `allow`, `deny`. | Whether to allow or deny this command. |
+
+## Status
+
+`ValkeyRole` has a status subresource, but it defines no fields today.
+
+## Printer columns
+
+`kubectl get valkeyroles` shows only the standard `Age` column (from `.metadata.creationTimestamp`).
+
+## References and referenced by
+
+- References no other resources.
+- Referenced by ACL bindings on [`ValkeyConfig`](valkeyconfig.md) and [`ValkeyCluster`](valkeycluster.md) via `spec.acl[].permissions[].roleRef`.
+
+## Example
+
+A role granting read and write data access, permitting `cluster|info`, and explicitly denying `flushall`:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyRole
+metadata:
+  name: app-readwrite
+spec:
+  categories:
+    - name: read
+      access: allow
+    - name: write
+      access: allow
+  commands:
+    - name: cluster
+      subcommand: info
+      access: allow
+    - name: flushall
+      access: deny
+```

--- a/docs/self-hosted/valkey-operator/reference/cluster-status.md
+++ b/docs/self-hosted/valkey-operator/reference/cluster-status.md
@@ -1,0 +1,128 @@
+---
+title: Cluster status
+description: ValkeyCluster state semantics, transitions, the targetSpec snapshot, status fields, and how to read kubectl output.
+sidebar_position: 2
+---
+
+# Cluster status
+
+This page defines the `ValkeyCluster` status schema for the Momento Valkey Operator: what each state means, when transitions happen, and how to interpret `kubectl get` and `kubectl describe` output. It is reference material for anyone watching a cluster; for symptom-driven remediation, see [Troubleshooting](../operations/troubleshooting.md).
+
+## Status fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `state` | enum | Overall cluster state: `Creating`, `Active`, `Updating`, or `Invalid`. Defaults to `Creating`. |
+| `targetSpec` | object (optional) | Snapshot of the spec the operator is currently working toward. Set when the cluster enters `Creating`; cleared when it reaches `Active`. |
+| `nodes` | array of string | Schema-reserved for the names of the cluster's pods, but **not populated in the current release**: no code path writes it. List the cluster's members with `kubectl get valkeynodes` instead. |
+| `message` | string (optional) | Human-readable detail for the current state. Populated when the state is `Invalid`; cleared on recovery. |
+
+The status subresource has no `conditions` array; the single `state` value plus `message` is the complete signal.
+
+## States
+
+Values serialize exactly as shown (PascalCase).
+
+| State | Meaning |
+|---|---|
+| `Creating` | The operator is bootstrapping the Valkey cluster: creating nodes, forming the cluster topology, assigning slots, and attaching replicas. A brand-new resource whose status has not been written yet is treated as `Creating`. |
+| `Active` | The Valkey cluster is formed and serving. All ongoing management (scaling, rolling replacements, failover recovery) happens while the cluster reports `Active`. |
+| `Updating` | Reserved. This value exists in the schema but is not reported by the current release; rolling replacements run entirely under `Active`. Treat it as equivalent to `Active` if you ever observe it. |
+| `Invalid` | The spec references something the operator cannot accept. In the current release the only trigger is TLS Secret validation failure. `message` carries the exact reason. |
+
+### Creating → Active
+
+Bootstrap completes (and the state flips to `Active`) when every node reports a healthy cluster view, all 16384 hash slots are assigned, the shard count meets the target, and every slot-holding primary has at least `replicasPerShard` replicas. At that moment the operator also clears `targetSpec`.
+
+### Any state → Invalid
+
+When `spec.tls` is set, the operator validates the referenced TLS Secret on every reconcile, in any state. If validation fails (the Secret is missing, lacks one of `tls.crt`, `tls.key`, or `ca.crt`, the certificate is not valid PEM/X.509, or its SANs do not include both `{cluster}.{namespace}.svc.cluster.local` and the matching wildcard), the operator sets `state: Invalid` and writes the reason to `message`. While `Invalid`, the operator takes no topology actions; it keeps maintaining the cluster's Service, auth Secret, and ACL ConfigMap, and re-checks the Secret periodically.
+
+:::note
+An **expired** certificate does not make the cluster `Invalid`. Expiry is logged as a warning only: the cluster stays `Active` while client connections fail. See [TLS](../security/tls.md).
+:::
+
+### Invalid → Creating → Active (auto-recovery)
+
+Recovery is automatic. Once validation passes again (for example, you fixed the Secret in place), the operator resets the state to `Creating` and clears `message`. A cluster that was previously formed passes through bootstrap as a no-op and returns to `Active` within a few reconcile ticks. No manual intervention on the `ValkeyCluster` resource is needed.
+
+## targetSpec snapshot semantics
+
+When a cluster enters `Creating`, the operator snapshots the spec into `status.targetSpec` and drives the bootstrap **topology** (the shard count and replicas per shard) from that snapshot, not from the live spec. Edits to `shards` or `replicasPerShard` made during the transition are deferred: they take effect only after the cluster reaches `Active`, at which point the snapshot is cleared and the live spec is reconciled normally. This prevents mid-formation topology changes from producing an inconsistent cluster.
+
+Other spec fields are not part of the snapshot. References (`configRef`, and `imageRef` behind it) resolve fresh on every reconcile, and `placement`, `tls.secretRef`, and `acl` are read live, but each node's own spec is fixed at the moment that node is created, so a live edit shapes only nodes the bootstrap has not created yet. It does not repair a node already stuck under the old values, and it can leave a mid-bootstrap cluster with nodes built from two different configurations.
+
+The practical consequence: **a spec mistake made at creation time generally cannot be corrected by editing the spec while the cluster is still `Creating`.** External fixes work (creating a missing `ValkeyConfig` or `ValkeyImage` unblocks bootstrap without a spec edit), but a wrong topology value, or an unsatisfiable `placement` already stamped onto stuck nodes, requires deleting and recreating the resource. See the [wedged bootstrap entry in Troubleshooting](../operations/troubleshooting.md).
+
+## Printer columns
+
+`kubectl get valkeyclusters` shows these columns:
+
+| Column | Source | Meaning |
+|---|---|---|
+| `CONFIG` | `.spec.configRef` | The `ValkeyConfig` menu item the cluster uses. |
+| `SHARDS` | `.spec.shards` | Desired number of shards (the spec value, not the currently formed count). |
+| `REPLICAS` | `.spec.replicasPerShard` | Desired replicas per shard, not counting the primary. |
+| `STATE` | `.status.state` | Current cluster state, as defined above. |
+
+## Worked examples
+
+A healthy three-shard cluster with one replica per shard:
+
+```bash
+kubectl get valkeyclusters -n my-app
+```
+
+```text
+NAME         CONFIG     SHARDS   REPLICAS   STATE
+my-cluster   standard   3        1          Active
+```
+
+`kubectl describe` shows the full spec and status, including the `targetSpec` snapshot during bootstrap:
+
+```bash
+kubectl describe valkeycluster my-cluster -n my-app
+```
+
+```text
+Name:         my-cluster
+Namespace:    my-app
+API Version:  valkey.gomomento.com/v1alpha1
+Kind:         ValkeyCluster
+Spec:
+  Config Ref:          standard
+  Replicas Per Shard:  1
+  Shards:              3
+Status:
+  State:  Active
+Events:   <none>
+```
+
+`status` carries no node list in the current release (the `nodes` field is schema-reserved; see the table above). List the cluster's members and their pod names with `kubectl get valkeynodes -n my-app`; pod names carry a random suffix rather than ordinal numbers (`-0`, `-1`) because the operator manages pods directly instead of using a StatefulSet; see [Pod management](../concepts/pod-management.md).
+
+A cluster in `Invalid` after a TLS Secret validation failure (the message text is exact; [Troubleshooting](../operations/troubleshooting.md#cluster-shows-invalid) lists every variant):
+
+```bash
+kubectl get valkeycluster my-cluster -n my-app -o yaml
+```
+
+```yaml
+status:
+  state: Invalid
+  message: TLS Secret "my-cluster-tls" missing required key "ca.crt"
+```
+
+For a node-level view during bootstrap, scaling, or replacements, list the operator-internal `ValkeyNode` resources; the `LIFECYCLE` column shows `Joining`, `Active`, or `Leaving` per node:
+
+```bash
+kubectl get valkeynodes -n my-app
+```
+
+```text
+NAME               CLUSTER      IMAGE                 LIFECYCLE
+my-cluster-1a4f2   my-cluster   valkey/valkey:9.0.0   Active
+my-cluster-7c03d   my-cluster   valkey/valkey:9.0.0   Active
+my-cluster-f31b9   my-cluster   valkey/valkey:9.0.0   Joining
+```
+
+`ValkeyNode` is read-only for users; see the [ValkeyNode API reference](api/valkeynode.md).

--- a/docs/self-hosted/valkey-operator/reference/examples.md
+++ b/docs/self-hosted/valkey-operator/reference/examples.md
@@ -1,0 +1,210 @@
+---
+title: Example manifests
+description: Complete, runnable manifests for the common shapes of menu resources and clusters, collected from across these docs in one place.
+sidebar_position: 6
+---
+
+# Example manifests
+
+Complete manifests for the shapes you'll create most often, collected in one place so you can start from a working example instead of assembling fields from reference tables. Each sample states its prerequisites; all of them use the same names as the rest of these docs (namespace `my-app`, cluster `my-cluster`, configs `standard` and `large`, image `valkey-9-0`).
+
+:::note
+These samples are starting points for demonstration and experimentation, not production configurations. Before production, work through the [security hardening checklist](../security/index.md#hardening-checklist) and [Sizing](../operations/sizing.md), and adjust names, sizes, zones, and credentials to your environment.
+:::
+
+## Platform menu
+
+These are cluster-scoped and platform-team-owned; see [Curating images and configs](../platform-guide/curating-images-and-configs.md) for the design guidance behind them.
+
+### Image allowlist entry
+
+No prerequisites. Registers one runnable image; without a `ValkeyImage`, no config can reference the image and no cluster can run it.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyImage
+metadata:
+  name: valkey-9-0
+spec:
+  repository: valkey/valkey
+  tag: "9.0.0"
+  version: "9.0.0"
+```
+
+### Base config
+
+Requires the `valkey-9-0` image above. A complete menu item: image, resources, and engine settings. Always set `resources` in curated configs; a config without them produces BestEffort pods, first evicted under node pressure.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: standard
+spec:
+  imageRef: valkey-9-0
+  resources:
+    cpu: "1"
+    memory: "2Gi"
+  valkey:
+    maxmemory: "1500mb"
+    maxmemory-policy: "allkeys-lru"
+```
+
+### Size variant via baseRef
+
+Requires the `standard` config above. Overrides sizing and inherits everything else, including the image and the per-key `valkey` map merge (`maxmemory-policy` survives from the base).
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyConfig
+metadata:
+  name: large
+spec:
+  baseRef: standard
+  resources:
+    cpu: "4"
+    memory: "16Gi"
+  valkey:
+    maxmemory: "12gb"
+```
+
+### Reusable ACL role
+
+No prerequisites. A named permission set that bindings on configs and clusters reference; see [ACLs](../security/acls.md).
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyRole
+metadata:
+  name: read-write
+spec:
+  categories:
+    - name: read
+      access: allow
+    - name: write
+      access: allow
+```
+
+## Clusters
+
+These are namespaced and product-team-owned; see [Provisioning a cluster](../team-guide/provisioning.md) for the walkthrough.
+
+### Minimal cluster
+
+Requires a published config (`standard` above) and the `my-app` namespace. Three shards, one replica each: six nodes.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+```
+
+### Zone-aware cluster
+
+Requires nodes labeled with the listed zones and, for the `nodeSelector`, a `node-pool: valkey` node label. Pins pods to three zones, enforces per-shard zone spread, and restricts scheduling to a dedicated pool; see [Zone-aware placement](../operations/zone-aware-placement.md) for what each field does and what happens when placement is unsatisfiable.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  placement:
+    zones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    zoneSpread: required
+    nodeSelector:
+      node-pool: valkey
+```
+
+### TLS-only cluster
+
+Requires a `kubernetes.io/tls` Secret named `my-cluster-tls` in `my-app` with `tls.crt`, `tls.key`, and `ca.crt`, with the SANs [TLS](../security/tls.md) specifies. TLS is immutable after creation: decide here, not later.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  tls:
+    secretRef: my-cluster-tls
+```
+
+With cert-manager, this Certificate produces a compliant Secret (it assumes an existing Issuer named `valkey-ca-issuer`; see the [cert-manager walkthrough](../security/tls.md#provisioning-certificates-with-cert-manager) for the Issuer and the reasoning):
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-cluster-tls
+  namespace: my-app
+spec:
+  secretName: my-cluster-tls
+  duration: 2160h      # 90d
+  renewBefore: 360h    # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - my-cluster.my-app.svc.cluster.local
+    - "*.my-cluster.my-app.svc.cluster.local"
+  issuerRef:
+    name: valkey-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+```
+
+### Cluster with an ACL user
+
+Requires the `read-write` role above. Binds one application user scoped to its own key prefix. The moment this binding exists, the permissive `default` user is disabled; every client needs credentials from then on. Generate the hash with `echo -n '<password>' | sha256sum`.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  acl:
+    - username: app-user
+      passwordHashes:
+        - <sha256-hex-of-password>
+      permissions:
+        - roleRef: read-write
+          keys:
+            - pattern: "myapp:*"
+              access: readwrite
+```
+
+## Where the other manifests live
+
+Some worked manifests stay on their task pages, where the surrounding procedure matters as much as the YAML:
+
+- [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md) — the complete tenant-onboarding bundle: namespace, Role, RoleBinding, ClusterRole, and ClusterRoleBinding.
+- [Networking and ports](../security/networking.md#networkpolicies) — a worked NetworkPolicy for namespaces that host clusters.
+- [Benchmarking](../operations/benchmarking.md) — in-cluster benchmark Job manifests, including TLS and ACL variants.
+- [Installation](../getting-started/installation.md) — the release artifacts (`crds.json`, `operator.yaml`) that install the operator itself.

--- a/docs/self-hosted/valkey-operator/reference/forced-settings.md
+++ b/docs/self-hosted/valkey-operator/reference/forced-settings.md
@@ -1,0 +1,63 @@
+---
+title: Forced Valkey settings
+description: The Valkey configuration directives the operator always injects, the additional TLS-mode settings, and how they interact with user-supplied settings.
+sidebar_position: 3
+---
+
+# Forced Valkey settings
+
+The Momento Valkey Operator injects a fixed set of Valkey configuration directives into every node it creates, regardless of what the `valkey` map in the resolved `ValkeyConfig` specifies. This page lists every injected setting and its value, so platform teams know exactly which parts of the node configuration are operator-owned.
+
+Forced settings are applied last during configuration resolution, so a user-supplied value for any of these keys never takes effect. They are baked into each node's rendered configuration file at node creation time; because node specs are immutable, a change to any effective Valkey setting rolls the cluster onto replacement nodes; see the [change-impact table](../concepts/reconciliation.md).
+
+## Base settings (always injected)
+
+| Setting | Value | Why it is forced |
+|---|---|---|
+| `cluster-enabled` | `yes` | The operator manages Valkey exclusively in cluster mode; every managed node must participate in the cluster protocol. |
+| `cluster-node-timeout` | `5000` | Fixes the failure-detection window at 5 seconds. The operator's failover handling is built around this value; a user-tuned timeout would change failover behavior underneath it. |
+| `cluster-config-file` | `/var/lib/valkey/nodes.conf` | Pins the cluster state file to the node's data volume, where the operator expects it. |
+| `dir` | `/var/lib/valkey` | Fixes the working directory to the node's data volume. |
+| `port` | `6379` | The client port must match the per-cluster Service, the liveness probe, and the operator's own connections. (Superseded in TLS mode; see below.) |
+| `bind` | `0.0.0.0` | Nodes must accept connections on their pod IP so clients, cluster peers, and the operator can reach them. |
+| `protected-mode` | `no` | Protected mode rejects non-loopback connections, which would break all pod-network access. ACLs provide access control instead. |
+| `aclfile` | `/etc/valkey/acl/users.acl` | Points Valkey at the ACL file the operator renders and mounts from the cluster's ACL ConfigMap. |
+| `primaryuser` | `_momento_repl` | Replicas authenticate to their primary as the operator-managed replication user. See [ACLs](../security/acls.md) for the system users. |
+
+## Dynamically managed: primaryauth
+
+In addition to the fixed table above, the operator injects `primaryauth <replication-password>` into every node's configuration file when it renders the node's ConfigMap. The value is the replication password generated in the cluster's `{cluster}-operator-auth` Secret, and it appears in **plaintext** in each node's `{node}-config` ConfigMap. Read access to ConfigMaps in a cluster's namespace is therefore credential-equivalent; see [RBAC](../security/rbac.md).
+
+## TLS-mode settings
+
+When `spec.tls` is set on a `ValkeyCluster`, the operator additionally injects the following into every node. These are applied after the base settings, so `port 0` overrides the forced `port 6379`: the plaintext port is closed and the cluster is TLS-only.
+
+| Setting | Value | Why it is set |
+|---|---|---|
+| `port` | `0` | Closes the plaintext client port entirely; a TLS cluster accepts no unencrypted connections. |
+| `tls-port` | `6379` | Serves TLS on the standard port, so Service definitions and client configuration keep the same port number. |
+| `tls-cluster` | `yes` | Encrypts the cluster bus (node-to-node gossip and topology traffic). |
+| `tls-replication` | `yes` | Encrypts replication traffic between primaries and replicas. |
+| `tls-cert-file` | `/etc/valkey/tls/tls.crt` | Certificate from the mounted TLS Secret. |
+| `tls-key-file` | `/etc/valkey/tls/tls.key` | Private key from the mounted TLS Secret. |
+| `tls-ca-cert-file` | `/etc/valkey/tls/ca.crt` | CA bundle from the mounted TLS Secret; used to verify peers and replication connections. |
+| `tls-auth-clients` | `no` | Clients are not required to present certificates (no mutual TLS); clients authenticate with ACL credentials. |
+| `cluster-announce-hostname` | `{pod}.{cluster}.{namespace}.svc.cluster.local` | Each node announces its per-pod DNS name, which the required wildcard SAN covers, so hostname verification succeeds. |
+| `cluster-preferred-endpoint-type` | `hostname` | Cluster-aware clients receive hostnames rather than pod IPs in redirects, keeping TLS verification intact. |
+
+See [TLS](../security/tls.md) for the Secret shape and SAN requirements these settings depend on.
+
+## Everything else passes through
+
+:::info
+The operator does **not** validate or reject any other Valkey setting. Two consequences:
+
+- If you specify a value for one of the forced settings above, it is **silently overridden**: there is no error, no event, and no status message. The forced value wins.
+- Any other key in the `valkey` map (including unknown, mistyped, or dangerous directives such as `requirepass` or raw `user` lines) passes through to the node's configuration file **unchecked**. A bad directive can prevent nodes from starting or silently undermine the cluster's authentication and ACL model.
+
+Platform teams should treat the `valkey` map in curated `ValkeyConfig` resources as production configuration and review it accordingly.
+:::
+
+## Enforcement is at render time, not runtime
+
+Forced settings are injected when a node's configuration file is rendered, and that file is read once, at process start. The operator does not monitor or re-assert settings on running nodes: a client with ACL access to `CONFIG SET` can change any setting on a live node, forced or not, and the change stands until that pod is replaced. The one exception is the TLS certificate paths, which the TLS controller re-issues periodically as part of certificate reload. See [Changing configuration](../team-guide/changing-configuration.md#manual-changes-on-live-nodes) for the full manual-drift policy, and [ACLs](../security/acls.md) for restricting which users can run `CONFIG SET` at all.

--- a/docs/self-hosted/valkey-operator/reference/index.md
+++ b/docs/self-hosted/valkey-operator/reference/index.md
@@ -1,0 +1,29 @@
+---
+title: Reference
+description: "Lookup material for the Momento Valkey Operator: API schemas, status semantics, forced settings, labels, naming, and operator configuration."
+sidebar_position: 1
+---
+
+# Reference
+
+This section is lookup material for the Momento Valkey Operator: exact field schemas, enum values, injected settings, label keys, naming patterns, and configuration knobs. Come here when you know what you are looking for; for task-oriented walkthroughs, see the [platform team](../platform-guide/index.md) and [product team](../team-guide/index.md) guides.
+
+All content in this section is verified against the generated `crds.json` for release v0.6.0.
+
+## Pages
+
+- **[API reference](api/index.md)** — one page per custom resource (`ValkeyImage`, `ValkeyConfig`, `ValkeyRole`, `ValkeyCluster`, `ValkeyNode`): field tables, validation rules, status schemas, printer columns, and worked examples.
+- **[Cluster status](cluster-status.md)** — what each `ValkeyCluster` state means, how transitions happen, the `targetSpec` snapshot, and how to read `kubectl get` and `kubectl describe` output.
+- **[Forced Valkey settings](forced-settings.md)** — the Valkey configuration directives the operator always injects into every node, the additional settings applied in TLS mode, and what happens to user-supplied settings.
+- **[Labels, annotations, and naming](labels-annotations.md)** — the label taxonomy on operator-created resources, resource naming patterns, the reserved annotation prefix, and what is safe to build NetworkPolicies and monitoring selectors on.
+- **[Operator configuration](operator-configuration.md)** — the `valkey-operator-config` ConfigMap, its environment variable mapping, and how to apply changes.
+- **[Example manifests](examples.md)** — complete, runnable manifests for the common menu and cluster shapes, collected from across these docs.
+
+## Conventions
+
+- **API group and version.** Every custom resource uses `apiVersion: valkey.gomomento.com/v1alpha1`.
+- **Field names** appear exactly as serialized in YAML (camelCase, for example `configRef`, `replicasPerShard`).
+- **Enum values** are listed with their exact serialized casing. State and lifecycle values are PascalCase (`Creating`, `Active`); option values such as zone spread are camelCase (`bestEffort`, `required`).
+- **Required** in a field table means the API server rejects a manifest that omits the field. **Validation** covers both schema constraints (types, ranges, item limits) and CEL admission rules; CEL rules are enforced at admission time, before the operator ever sees the object.
+- **Examples** use the documentation-wide sample names: namespace `my-app`, cluster `my-cluster`, configs `standard` and `large`, image `valkey-9-0`.
+- **Release pinning.** Version-specific artifacts reference release v0.6.0.

--- a/docs/self-hosted/valkey-operator/reference/labels-annotations.md
+++ b/docs/self-hosted/valkey-operator/reference/labels-annotations.md
@@ -1,0 +1,81 @@
+---
+title: Labels, annotations, and naming
+description: The label taxonomy on operator-created resources, resource naming patterns, the reserved annotation prefix, and what selectors are safe to build on.
+sidebar_position: 4
+---
+
+# Labels, annotations, and naming
+
+This page catalogs the labels, annotations, names, and other identifying metadata the Momento Valkey Operator puts on the resources it creates. Use it to build NetworkPolicies, monitoring selectors, and dashboards on stable keys rather than observed behavior.
+
+## Pod labels
+
+Every Valkey pod carries these labels:
+
+| Label | Value | Stability |
+|---|---|---|
+| `app.kubernetes.io/name` | `valkey` | Stable. Identifies all Valkey pods managed by the operator, across all clusters. |
+| `app.kubernetes.io/instance` | `{cluster}` (the `ValkeyCluster` name) | Stable. Identifies the pods of one Valkey cluster. This is the selector the operator itself uses, and the selector on the cluster's Service. |
+| `valkey.gomomento.com/shard-index` | `{n}` (operator-assigned integer) | Stable per node. A scheduling index used for topology spread; it is **not** the Valkey shard ID. |
+
+## ValkeyNode labels
+
+`valkey.gomomento.com/join-type` (`replica`, `primary`, or `shard`) appears on **`ValkeyNode` resources, not on Pods**: a `kubectl get pods` selector on it matches nothing. It records how a node joined the cluster (replacement replica, dead-primary replacement, or scale-out shard). Only the `shard` value is cleared when the join completes; `replica` and `primary` values persist on the `ValkeyNode` after the node is active, so treat the label as "how this node joined", not "whether it is still joining". Use `kubectl get valkeynodes -l valkey.gomomento.com/join-type=<value>` to query it.
+
+### What to build on
+
+- **NetworkPolicies and monitoring selectors**: use `app.kubernetes.io/name=valkey` to match all Valkey pods, and `app.kubernetes.io/instance={cluster}` to match one cluster's pods. Both are guaranteed on every Valkey pod.
+- **Per-shard dashboards**: `valkey.gomomento.com/shard-index` groups a shard's primary and replicas for topology-spread purposes and is safe for grouping in dashboards, with the caveat that it is a scheduling index, not the runtime Valkey shard ID.
+- **`valkey.gomomento.com/join-type`**: do not build policy on it; it lives on `ValkeyNode` resources, not Pods, and is not consistently removed after a join completes.
+
+Example NetworkPolicy selector for one cluster:
+
+```yaml
+podSelector:
+  matchLabels:
+    app.kubernetes.io/name: valkey
+    app.kubernetes.io/instance: my-cluster
+```
+
+:::note
+The label guarantees above are documented for pods. Identify the other per-cluster resources (Service, Secret, ConfigMaps) by their naming patterns below rather than by labels.
+:::
+
+## Resource naming patterns
+
+For a `ValkeyCluster` named `my-cluster`, the operator creates:
+
+| Resource | Name pattern | Example |
+|---|---|---|
+| Headless Service | `{cluster}` | `my-cluster` |
+| Operator auth Secret | `{cluster}-operator-auth` | `my-cluster-operator-auth` |
+| ACL ConfigMap | `{cluster}-acl` | `my-cluster-acl` |
+| `ValkeyNode` / Pod | `{cluster}-{random-suffix}` (5-character hex) | `my-cluster-1a4f2` |
+| Per-node ConfigMap | `{node}-config` | `my-cluster-1a4f2-config` |
+
+A `ValkeyNode`, its Pod, and the prefix of its ConfigMap share the same name. Pod names are random-suffixed rather than ordinal because the operator manages pods directly instead of through a StatefulSet; see [Pod management](../concepts/pod-management.md).
+
+All of these resources are owner-referenced to the `ValkeyCluster` (directly or via their `ValkeyNode`), so deleting the cluster cascade-deletes everything.
+
+:::warning
+Never delete the `{cluster}-operator-auth` Secret. It holds the operator and replication credentials for the cluster and has no rotation mechanism; see [ACLs](../security/acls.md).
+:::
+
+## Reserved annotation prefix
+
+The prefix `valkey.gomomento.com/` on annotations is reserved for the operator. The `ValkeyCluster` CRD rejects any `spec.podAnnotations` key under this prefix at admission time with the message that the prefix is reserved. All other `podAnnotations` keys pass through verbatim to every managed pod.
+
+## Finalizers
+
+The operator's finalizers also live under the reserved prefix:
+
+| Finalizer | On |
+|---|---|
+| `valkey.gomomento.com/cleanup` | `ValkeyCluster` |
+| `valkey.gomomento.com/node-cleanup` | `ValkeyNode` |
+
+If a resource is stuck in `Terminating`, these finalizers are usually waiting on an operator that is down or was uninstalled first; see [Troubleshooting](../operations/troubleshooting.md) before considering manual removal.
+
+## Built-in arm64 toleration
+
+Every Valkey pod carries a toleration for `kubernetes.io/arch=arm64:NoSchedule`. This lets Valkey pods schedule onto tainted arm64 node pools without any per-cluster configuration; it is a no-op on Kubernetes clusters without such taints. It cannot be removed per cluster. See [Compatibility](../support/compatibility.md) for supported architectures.

--- a/docs/self-hosted/valkey-operator/reference/operator-configuration.md
+++ b/docs/self-hosted/valkey-operator/reference/operator-configuration.md
@@ -1,0 +1,64 @@
+---
+title: Operator configuration
+description: The valkey-operator-config ConfigMap, its environment variable mapping, the read-at-startup model, and how to apply changes.
+sidebar_position: 5
+---
+
+# Operator configuration
+
+This page documents the process-level configuration of the Momento Valkey Operator: the `valkey-operator-config` ConfigMap, how its keys reach the operator, and how to change them. It is for platform teams who own the operator installation.
+
+The operator installation (`operator.yaml`) creates the ConfigMap `valkey-operator-config` in the `valkey-operator` namespace. The ConfigMap is optional: if it is absent, the operator runs with compiled-in defaults.
+
+## Configuration keys
+
+| Key | Values | Default | Effect |
+|---|---|---|---|
+| `defaultZoneSpread` | `bestEffort` \| `required` | `bestEffort` | The operator-wide default for zone spreading of Valkey pods, used by every `ValkeyCluster` that does not set `placement.zoneSpread` itself. `bestEffort` schedules pods even when zone spread cannot be satisfied; `required` leaves pods Pending until a valid zone placement exists. See [Zone-aware placement](../operations/zone-aware-placement.md). |
+
+A per-cluster `placement.zoneSpread` always overrides this default. The value spellings are identical in the ConfigMap and in the `ValkeyCluster` field: exactly `bestEffort` or `required`.
+
+## Environment variable mapping
+
+The operator reads its settings from environment variables; the Deployment wires each ConfigMap key to its variable:
+
+| ConfigMap key | Environment variable |
+|---|---|
+| `defaultZoneSpread` | `DEFAULT_ZONE_SPREAD` |
+
+The Deployment marks the reference optional, which is why a missing ConfigMap or key falls back to the compiled default rather than blocking startup.
+
+The Deployment also sets `RUST_LOG=info`, which controls the operator's JSON log verbosity. It is plain environment configuration, not a ConfigMap key. See [Monitoring](../platform-guide/monitoring.md).
+
+## Changes require an operator restart
+
+The operator reads configuration once at startup and holds it for the life of the process: there is deliberately no live reload. Changing the ConfigMap alone has no effect on a running operator. To apply a change, patch the ConfigMap and restart the operator Deployment:
+
+```bash
+kubectl patch configmap valkey-operator-config -n valkey-operator \
+  --type merge -p '{"data":{"defaultZoneSpread":"required"}}'
+
+kubectl rollout restart deployment/valkey-operator -n valkey-operator
+kubectl rollout status deployment/valkey-operator -n valkey-operator
+```
+
+Running Valkey clusters keep serving traffic during the restart; reconciliation pauses briefly and resumes when the new operator pod is up.
+
+:::note
+A changed `defaultZoneSpread` affects only pods created after the restart. Existing pods keep the spread behavior they were scheduled with; the operator does not roll clusters for a zone-spread change. See [Zone-aware placement](../operations/zone-aware-placement.md).
+:::
+
+## Invalid values fail startup
+
+If `DEFAULT_ZONE_SPREAD` is set to anything other than `bestEffort` or `required`, the operator logs the error and exits at startup, and the Deployment goes into a crash loop. This is deliberate fail-fast behavior: a misconfigured operator does not start, rather than running silently with a wrong or guessed default.
+
+If you encounter this after a configuration change, fix the ConfigMap value and restart again:
+
+```bash
+kubectl logs deployment/valkey-operator -n valkey-operator
+kubectl patch configmap valkey-operator-config -n valkey-operator \
+  --type merge -p '{"data":{"defaultZoneSpread":"bestEffort"}}'
+kubectl rollout restart deployment/valkey-operator -n valkey-operator
+```
+
+Existing Valkey clusters continue serving while the operator is down; no reconciliation (scaling, replacement, failover recovery) happens until it is healthy again. See [Failure modes](../operations/failure-modes.md).

--- a/docs/self-hosted/valkey-operator/roadmap.md
+++ b/docs/self-hosted/valkey-operator/roadmap.md
@@ -1,0 +1,31 @@
+---
+title: Roadmap
+description: Direction for the Momento Valkey Operator, explicitly non-contractual; everything else in these docs describes shipped behavior.
+sidebar_position: 11
+---
+
+# Roadmap
+
+:::note
+This page describes direction for the Momento Valkey Operator, not committed features or dates. Everything else in these docs describes behavior the operator ships today.
+:::
+
+## Central governance service
+
+Today, the image allowlist and configuration menu live entirely as `ValkeyImage` and `ValkeyConfig` custom resources that the platform team manages by hand in each Kubernetes cluster. The direction under consideration is a Momento-managed control plane the operator would query at runtime for allowlisted images and configuration constraints, alongside fleet-wide observability that aggregates cluster state across every Kubernetes cluster running the operator, not just the one it's deployed in. For a platform team running the operator across many Kubernetes clusters, this would mean defining policy once centrally instead of keeping cluster-scoped custom resources in sync across every cluster by hand.
+
+## Metrics export from the operator
+
+The operator emits structured logs and `ValkeyCluster` status today; no metrics endpoint exists (see [Monitoring](platform-guide/monitoring.md)). Direction under consideration includes native metrics export from the operator itself, covering reconciliation activity and cluster health, without requiring a platform team to stand up their own exporter. This would give platform teams a standard scrape target for operator-level observability instead of relying solely on logs and periodic status polling.
+
+## Namespace-level policy constraints
+
+Today, governance stops at the menu: a product team can pick any published config and provision any number of clusters from it, with no finer-grained limits. Under consideration are per-namespace or per-team constraints layered on top of the existing menu: restricting a team to a subset of configs, or capping shard count or cluster count per namespace. This would let a platform team express quota-style policy without resorting to external admission tooling.
+
+## Backup and restore
+
+The operator provisions no persistent storage today, and there is no backup or restore facility (see [Data durability](concepts/data-durability.md)). Backup and restore support, aimed at cache warm-up scenarios rather than durable primary storage, is under investigation. This would give platform teams a way to pre-populate a newly created or recovered cluster instead of relying entirely on client-side re-hydration after a data-loss event.
+
+## Broader engine-version support for slot migration
+
+Shard scaling relies on server-side slot-migration commands available starting in Valkey 9; today that is the operator's version floor for resharding (see [Compatibility](support/compatibility.md)). Broader engine-version support for slot migration, covering older Valkey releases through a different migration mechanism, is a direction under consideration. This would let platform teams run the operator's scaling features against a wider range of already-deployed Valkey versions instead of first upgrading the engine.

--- a/docs/self-hosted/valkey-operator/security/acls.md
+++ b/docs/self-hosted/valkey-operator/security/acls.md
@@ -1,0 +1,132 @@
+---
+title: ACLs
+description: The structured ACL model, where bindings live, password rules and rotation, key access patterns, default-user semantics, and the reserved system users.
+sidebar_position: 3
+---
+
+# ACLs
+
+This page covers Valkey access control on clusters managed by the Momento Valkey Operator: the structured permission model, where user bindings are declared, password and rotation rules, and the default-user behavior every reviewer should understand before relying on it. It is written for platform teams authoring roles and product teams binding users.
+
+## The structured model
+
+No raw ACL strings exist anywhere in the API. Two pieces compose into the rendered Valkey ACL:
+
+- **`ValkeyRole`**: a named, reusable set of command permissions; allow/deny rules on command categories (`@read`, `@write`, `@admin`, and so on) and on individual commands or subcommands. A role carries no key patterns, channel patterns, or passwords; those are supplied where the role is bound.
+- **`AclBinding`**: attaches a username and password hashes to one or more roles, each scoped to specific key patterns (and optionally channel patterns). Bindings live in the `acl` field of a `ValkeyConfig` or a `ValkeyCluster`.
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyRole
+metadata:
+  name: read-write
+spec:
+  categories:
+    - name: read
+      access: allow
+    - name: write
+      access: allow
+```
+
+```yaml
+# on a ValkeyCluster, spec.acl:
+acl:
+  - username: app-user
+    passwordHashes:
+      - <sha256-hex-of-password>
+    permissions:
+      - roleRef: read-write
+        keys:
+          - pattern: "myapp:*"
+            access: readwrite
+```
+
+## Where bindings live
+
+Bindings can be declared at two levels:
+
+| Level | Field | Scope |
+|---|---|---|
+| Platform | `ValkeyConfig.spec.acl` | Applies to every `ValkeyCluster` that references this config via `configRef`. |
+| Team | `ValkeyCluster.spec.acl` | Applies to this cluster only. |
+
+Cluster-level bindings are **additive** to config-level bindings: a product team can bind additional users without touching the platform config. They cannot, however, redefine a username the config already binds: a cluster-level binding whose `username` collides with a config-level binding is an error, and the cluster's reconciliation fails until the collision is removed.
+
+Config-level ACLs use **replace, not merge**, through the config inheritance chain. When a `ValkeyConfig` sets `baseRef` to inherit from another config, the first config in the chain that sets its own `acl` field wins in full: its bindings are not merged with the base's, they replace them. A config that omits `acl` entirely inherits its base's bindings unchanged.
+
+## Users and passwords
+
+Username rules, enforced at admission:
+
+- Usernames must match `[a-zA-Z0-9_-]+` (non-empty, no other characters).
+- The `_momento_` prefix is reserved for the operator's own system users (below) and rejected on any user-defined binding.
+
+Password rules:
+
+- `passwordHashes` takes SHA-256 hashes, lowercase hex, exactly 64 characters each, never a plaintext password. Do not include the `#` prefix Valkey's ACL syntax uses; the operator adds it when rendering.
+- A binding can hold up to eight hashes, which exist specifically to support rotation without downtime.
+
+:::info
+No field anywhere in the API accepts a plaintext password. If you need a hash, compute it yourself (`sha256sum`, a language standard library, and so on) before writing the manifest.
+:::
+
+### Password rotation procedure
+
+1. Add the new hash to `passwordHashes` alongside the existing one (a binding can hold up to eight).
+2. Update your application's credentials to the new password once the binding has propagated (see [Propagation](#propagation) below).
+3. Remove the old hash from `passwordHashes`.
+
+Both hashes authenticate simultaneously while both are present, which is what makes the rollover non-disruptive.
+
+## Key access patterns
+
+Each entry in a permission's `keys` list carries a glob pattern and an access mode. The operator adds the Valkey ACL prefix for you. Do not include it in the pattern:
+
+| `access` | Valkey ACL prefix | Meaning |
+|---|---|---|
+| `read` | `%R~` | Read-only access to matching keys. |
+| `write` | `%W~` | Write-only access to matching keys. |
+| `readwrite` | `~` | Full read/write access to matching keys. Default if `access` is omitted. |
+
+`keys` is required on every permission entry: there is no default-open pattern. Channel patterns (for Pub/Sub) are optional and, when present, get the `&` prefix the same way.
+
+## Permission semantics
+
+A binding's `permissions` list can hold multiple entries, each referencing a `roleRef`:
+
+- The **first** entry becomes the binding's root/base ACL permissions.
+- Every **additional** entry becomes a parenthesized ACL selector, scoped to its own key and channel patterns: a way to grant a user broader command access on one key pattern and narrower access on another, all under one username.
+
+## Default user
+
+:::info
+Whether the Valkey `default` user is open depends entirely on whether any ACL binding exists anywhere for the cluster, on the config or the cluster:
+
+- **Zero bindings anywhere**: the `default` user is fully permissive (no password, all keys, all channels, all commands). This is the state of a freshly provisioned quickstart cluster: it is open to any client that can reach it on the network, with authentication providing no protection.
+- **Any binding exists, anywhere, and none of them is named `default`**: the `default` user is disabled outright. Adding your **first** ACL user (even one scoped to a single application's keys) cuts off every unauthenticated client, including any tooling that was relying on the open default.
+
+No intermediate, partially-restricted state exists for the default user. If you want the default user to remain usable alongside explicit bindings, bind it explicitly with its own restricted permissions.
+:::
+
+## System users
+
+The operator provisions two reserved Valkey users on every cluster, appended after all user-defined bindings so they cannot be overridden:
+
+| User | Commands | Purpose |
+|---|---|---|
+| `_momento_operator` | `+cluster +acl\|load +ping +info +config\|set` | The operator's own connection: topology commands, ACL reload, health checks, and TLS certificate reload. |
+| `_momento_repl` | `+psync +replconf +ping +cluster\|syncslots` | Replication authentication between each primary and its replicas. |
+
+Neither user can read or write application keys: their command sets are scoped to exactly what each function needs. Their password hashes are derived from the two passwords generated once into the `{cluster}-operator-auth` Secret at cluster creation.
+
+:::warning
+No rotation mechanism exists for the system users' passwords. Never delete the `{cluster}-operator-auth` Secret while the cluster exists: the operator and replication authenticate with the credentials in it, and it is not safely regenerable on a running cluster. See the [secret-material inventory](index.md#secret-material-inventory) for the full picture, including where the replication password also appears in plaintext.
+:::
+
+## Propagation
+
+ACL changes reach nodes in two stages: kubelet propagates the updated ACL ConfigMap into each pod's mounted volume (typically up to about a minute), and a separate controller, ticking every 30 seconds, issues `ACL LOAD` on every running node once it sees the new file. `ACL LOAD` is atomic per node: if any rule in the file is invalid, that node keeps its previously loaded ACLs rather than applying a partial or broken set. A node that is temporarily unreachable does not block the rollout to the rest; it catches up on a later tick once it recovers.
+
+## Invalid roleRef
+
+Every `permissions[].roleRef` must name a `ValkeyRole` that exists. If it does not, the entire cluster's reconciliation fails: the operator cannot render the ACL ConfigMap without resolving every referenced role, so no other changes (scaling, upgrades, and so on) proceed either until the missing role is created or the reference is fixed. See [Troubleshooting](../operations/troubleshooting.md) for how this surfaces and how to recover.

--- a/docs/self-hosted/valkey-operator/security/index.md
+++ b/docs/self-hosted/valkey-operator/security/index.md
@@ -1,0 +1,69 @@
+---
+title: Security model
+description: Trust boundaries, secret material, and pod security posture of the Momento Valkey Operator, with a hardening checklist.
+sidebar_position: 1
+---
+
+# Security model
+
+This page describes the security model of the Momento Valkey Operator: what the operator can touch, what secret material it creates and where that material lands, and the pod security posture it ships with. It is written for platform teams and security reviewers evaluating the operator for production use. The four companion pages cover practice: [TLS](tls.md), [ACLs](acls.md), [RBAC](rbac.md), and [Networking and ports](networking.md).
+
+## Trust boundaries
+
+The operator runs as a single Deployment (one replica) in the `valkey-operator` namespace under its own ServiceAccount. That ServiceAccount is bound to a ClusterRole granting:
+
+| Scope | Resources | Verbs |
+|---|---|---|
+| `valkey.gomomento.com` API group | all resources and their `status` subresources | all |
+| Core API group, **cluster-wide** | `pods`, `services`, `configmaps`, `secrets` | all |
+
+The core grants are cluster-wide because the operator creates and owns pods, a headless Service, ConfigMaps, and Secrets for every Valkey cluster in any namespace. The consequence a reviewer should draw: **a compromise of the operator's ServiceAccount is a cluster-wide compromise of pods, services, ConfigMaps, and Secrets**, not only of Valkey-related resources, because Kubernetes RBAC cannot scope core-resource verbs to operator-owned objects. Restrict access to the `valkey-operator` namespace (and to the operator's ServiceAccount token) accordingly. The full rule listing and tenant-facing grants are in [RBAC](rbac.md).
+
+Product teams, by contrast, need only namespaced write access to `valkeyclusters` (plus read access to `valkeynodes` and the cluster-scoped menu resources). They never need direct access to pods, Services, ConfigMaps, or Secrets; granting it undermines the model, as the secret-material inventory below explains.
+
+### Per-cluster system users
+
+For every Valkey cluster the operator provisions two reserved Valkey users, always appended last in the rendered ACL file so user-defined bindings cannot override them:
+
+| User | Commands granted | Purpose |
+|---|---|---|
+| `_momento_operator` | `+cluster +acl\|load +ping +info +config\|set` | The operator's own connection for topology management, ACL loading, health checks, and TLS certificate reload |
+| `_momento_repl` | `+psync +replconf +ping +cluster\|syncslots` | Replication authentication between primaries and replicas |
+
+Both command sets are tightly scoped to what each function requires; neither user can read or write keys. The `_momento_` username prefix is reserved and rejected at admission for user-defined bindings. See [ACLs](acls.md) for details.
+
+## Secret-material inventory
+
+Three pieces of secret material exist per Valkey cluster. Know where each one lives before you design namespace RBAC.
+
+| # | Material | Location | Contents | Lifecycle and exposure |
+|---|---|---|---|---|
+| 1 | Operator auth Secret | Secret `{cluster}-operator-auth` in the cluster's namespace | Two generated passwords (`operator-password`, `repl-password`), each 128 hex characters | Generated once at cluster creation and reused as-is thereafter. **No rotation mechanism exists.** Never delete this Secret while the cluster exists: the operator and replication authenticate with it, and it is not safely regenerable on a running cluster. It is owner-referenced to the `ValkeyCluster` and deleted with it. |
+| 2 | TLS Secret | Customer-provided `kubernetes.io/tls` Secret named by `spec.tls.secretRef` | `tls.crt`, `tls.key`, `ca.crt` | You create and rotate it; the operator reads it, validates it every reconcile, and mounts it into every pod. See [TLS](tls.md). |
+| 3 | Replication credential in ConfigMaps | Every node's `{node}-config` ConfigMap | The `repl-password` value rendered in **plaintext** as `primaryauth` in `valkey.conf` | Present for the life of each node. This is a deliberate consequence of how Valkey consumes `primaryauth`; there is no hashed alternative. |
+
+:::info
+Because of item 3, **read access to ConfigMaps in a cluster's namespace is credential-equivalent to holding the cluster's replication password**. Treat `get`/`list` on ConfigMaps in namespaces that host Valkey clusters with the same care as Secret read access when you design RBAC. The [RBAC](rbac.md) page repeats this disclosure with the grant tables.
+:::
+
+For completeness: the `{cluster}-acl` ConfigMap contains the rendered ACL file. It holds SHA-256 password hashes only, never plaintext user passwords, but hashes of low-entropy passwords are still offline-crackable, so it is not public material either.
+
+## Pod security posture
+
+The operator sets **no `securityContext`** on Valkey pods or on its own Deployment, and there is no field to add one in `ValkeyCluster` or `ValkeyConfig`. The operator's own image is distroless with no `USER` directive and runs as root. For Valkey pods the image is whatever you register in a `ValkeyImage`, so its user posture is yours to control. However, the operator starts `valkey-server` directly, bypassing the image's entrypoint script and any privilege drop it would normally perform. Without an explicit `runAsNonRoot` declaration, the pods fail `restricted` admission regardless of the image's actual user.
+
+As shipped, the operator and the clusters it manages are **incompatible with the `restricted` Pod Security Standard**: namespaces enforcing `restricted` reject the pods (no `runAsNonRoot`, no seccomp profile, default capabilities). Plan for namespaces at `privileged` or `baseline` enforcement. See [Prerequisites](../getting-started/prerequisites.md) for the admission behavior you observe.
+
+## Default-user semantics
+
+With zero ACL bindings anywhere, the `default` user is fully permissive: a quickstart cluster is **open to any client that can reach it on the network**. The moment any binding exists, the `default` user is disabled unless explicitly bound, cutting off all unauthenticated clients. No intermediate state exists; the full semantics and rendered rules are in [ACLs](acls.md).
+
+## Hardening checklist
+
+Work through these before a production rollout:
+
+1. **Enable TLS at creation**: TLS cannot be added to an existing cluster. Client traffic, replication, and the cluster bus are all encrypted, and the plaintext port is closed. [TLS](tls.md).
+2. **Define ACL users and roles**: remove the permissive default user by binding at least one user, and scope key patterns per application. [ACLs](acls.md).
+3. **Scope Kubernetes RBAC**: grant product teams only the namespaced cluster grants; treat ConfigMap and Secret read access in Valkey namespaces as credential access; restrict the operator namespace. [RBAC](rbac.md).
+4. **Apply NetworkPolicies**: the operator creates none; network segmentation is your responsibility. [Networking and ports](networking.md) states the full connection matrix and gives a worked policy; [Labels and annotations](../reference/labels-annotations.md) states the guaranteed label set.
+5. **Monitor certificate expiry**: the operator does not block or alert on an expiring certificate; an expired certificate leaves the cluster `Active` while clients fail to connect. [TLS](tls.md) and [Monitoring](../platform-guide/monitoring.md).

--- a/docs/self-hosted/valkey-operator/security/networking.md
+++ b/docs/self-hosted/valkey-operator/security/networking.md
@@ -1,0 +1,98 @@
+---
+title: Networking and ports
+description: Every network connection the operator and its Valkey clusters make, the ports and TLS posture of each, and how to write NetworkPolicies around them.
+sidebar_position: 5
+---
+
+# Networking and ports
+
+This page is the operator's network contract: every connection that exists at runtime, who initiates it, on which port, and with what encryption and authentication. It is written for platform and security engineers designing NetworkPolicies or reviewing the deployment's network exposure. For the application developer's view of connecting, see [Connecting to your cluster](../team-guide/connecting.md).
+
+## The connection matrix
+
+| # | Connection | Port | TLS | Authentication |
+|---|---|---|---|---|
+| 1 | Application clients → Valkey pods | TCP 6379 | If the cluster has `spec.tls` | ACL user credentials; see [ACLs](acls.md) |
+| 2 | Valkey pod ↔ Valkey pod (cluster bus) | TCP 16379 | Forced on for TLS clusters (`tls-cluster yes`) | Cluster bus protocol |
+| 3 | Valkey pod → its primary (replication) | TCP 6379 | Forced on for TLS clusters (`tls-replication yes`) | The `_momento_repl` system user |
+| 4 | Operator → Valkey pods | TCP 6379 | If the cluster has `spec.tls` | The `_momento_operator` system user |
+| 5 | Operator → Kubernetes API server | Cluster-specific | Yes | The operator's ServiceAccount |
+| 6 | Operator and Valkey pods → cluster DNS | UDP/TCP 53 | — | — |
+| 7 | kubelet → Valkey pods (TLS clusters only) | TCP 6379 | TCP probe, no handshake | None; see the probe note below |
+
+Details behind each row:
+
+- **Client port 6379 in both modes.** A plaintext cluster listens on `port 6379`. A TLS cluster closes the plaintext listener (`port 0`) and serves TLS on the same number (`tls-port 6379`). There is never a mode with both, and the port number your clients use does not change when TLS is enabled.
+- **Cluster bus 16379.** Node-to-node gossip and failure detection use the cluster bus; the operator declares 16379 (Valkey's convention of client port plus 10000) as the named `valkey-bus` port on every pod and on the Service. Application clients never use it.
+- **The operator connects to pods directly**, never through the Service: by pod IP on plaintext clusters, and by per-pod DNS name on TLS clusters so the certificate hostname verifies. It authenticates as `_momento_operator` and presents no client certificate; the cluster runs `tls-auth-clients no`, so the server never requires client certificates (no mutual TLS is enforced). The [security model](index.md#per-cluster-system-users) lists both system users' exact grants.
+- **Probes.** Plaintext clusters use an exec liveness probe (`valkey-cli PING` inside the container), which generates no network traffic. TLS clusters use a TCP socket probe on 6379, so the kubelet on each Kubernetes node opens connections to local Valkey pods.
+
+## What listens where
+
+Valkey pods expose exactly two ports, 6379 (`valkey`) and 16379 (`valkey-bus`). The rendered configuration forces `bind 0.0.0.0` and `protected-mode no`: the listener accepts connections from any source address, and access control is entirely ACLs plus, on TLS clusters, encryption. Network segmentation around the pods is your responsibility; the operator ships no NetworkPolicies.
+
+The operator pod listens on **nothing**. It runs no metrics, health, or webhook endpoint and binds no port, so a NetworkPolicy can deny all ingress to the operator namespace without breaking anything. The operator needs only egress: to the Kubernetes API server, to Valkey pods on 6379 in every namespace that hosts clusters, and to cluster DNS. This also means there is no admission webhook in the network path: custom resource validation is CEL, evaluated inside the API server.
+
+Each cluster's Service is headless (`clusterIP: None`) with ports 6379 and 16379. It exists for DNS, not for traffic: it load-balances nothing, and every connection a client makes lands on a pod IP directly. Filtering "traffic to the Service" therefore filters nothing; write policies against the pod labels below.
+
+## Topology announcements and the cluster boundary
+
+A cluster-aware client learns the cluster's topology from the nodes themselves, and what nodes announce determines who can reach them:
+
+- **Plaintext clusters** announce pod IPs. `MOVED` redirects and topology queries return pod IPs on port 6379.
+- **TLS clusters** announce per-pod DNS names of the form `{pod}.{cluster}.{namespace}.svc.cluster.local`, so redirects stay verifiable against the certificate's wildcard SAN.
+
+Both are reachable and resolvable only inside the Kubernetes cluster's network. No mechanism exists to announce an externally reachable address: no LoadBalancer or NodePort integration, and no announce-address remapping. **Applications running inside the same Kubernetes cluster are the designed path.** A client outside the Kubernetes cluster cannot follow redirects to pod IPs or resolve cluster-internal DNS, so out-of-cluster access is not supported as shipped; it would require network infrastructure (flat pod routing plus DNS forwarding, or a proxy layer) that the operator neither provides nor manages.
+
+## NetworkPolicies
+
+Valkey pods carry a stable label set you can select on; [Labels and annotations](../reference/labels-annotations.md) states the guarantees. The examples below use the release-artifact install, where the operator runs in the `valkey-operator` namespace with pod label `app: valkey-operator`.
+
+In each namespace that hosts Valkey clusters, admit clients, the operator, and intra-cluster traffic:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valkey-ingress
+  namespace: my-app
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: valkey
+  policyTypes: ["Ingress"]
+  ingress:
+    # Application clients, port 6379 only. Adjust the selector to your workloads.
+    - from:
+        - podSelector:
+            matchLabels:
+              valkey-client: "true"
+      ports:
+        - port: 6379
+    # The operator.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: valkey-operator
+          podSelector:
+            matchLabels:
+              app: valkey-operator
+      ports:
+        - port: 6379
+    # Valkey node to node: replication (6379) and cluster bus (16379).
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: valkey
+      ports:
+        - port: 6379
+        - port: 16379
+```
+
+If you also apply default-deny egress policies, allow the Valkey pods to reach each other on 6379 and 16379, and allow them DNS egress: nodes in a TLS cluster dial each other by the announced DNS names. The operator's namespace needs egress to the API server, to cluster DNS, and to port 6379 in every namespace that hosts clusters (select those namespaces however your platform labels them).
+
+:::warning
+On TLS clusters the liveness probe is a TCP connection from the kubelet, which originates outside any pod. Most CNIs exempt kubelet probe traffic from NetworkPolicy enforcement, but this is CNI-specific behavior. If a default-deny ingress policy catches probe traffic in your CNI, the kubelet kills the pods as unhealthy; verify probes still pass after applying the policy.
+:::
+
+There is one cross-namespace flow to preserve above all: **operator → Valkey pods on 6379**. If a policy blocks it, running clusters keep serving traffic, but every operator function stops converging: bootstraps stall, failed primaries are not replaced, and ACL and TLS changes stop propagating. The failure shows up in operator logs as connection errors, not in cluster status; see [Troubleshooting](../operations/troubleshooting.md).

--- a/docs/self-hosted/valkey-operator/security/rbac.md
+++ b/docs/self-hosted/valkey-operator/security/rbac.md
@@ -1,0 +1,63 @@
+---
+title: RBAC
+description: The operator's ClusterRole grants, what tenants receive, how to restrict further, and the secret-access implications a security review needs.
+sidebar_position: 4
+---
+
+# RBAC
+
+This page is reference material on Kubernetes RBAC as it applies to the Momento Valkey Operator: exactly what the operator's own ClusterRole grants, what a tenant (product team) receives, how to restrict access further, and what that access implies for secret exposure. It is written for security reviewers and platform teams who need the precise grant surface, not just the summary in [Security model](index.md).
+
+## What the operator's ClusterRole grants
+
+The operator runs under a single ServiceAccount bound to one ClusterRole via a ClusterRoleBinding, cluster-wide:
+
+| API group | Resources | Verbs |
+|---|---|---|
+| `valkey.gomomento.com` | all resources (`valkeyimages`, `valkeyconfigs`, `valkeyroles`, `valkeyclusters`, `valkeynodes`) | all |
+| `valkey.gomomento.com` | all `*/status` subresources | all |
+| `` (core) | `pods` | all |
+| `` (core) | `services` | all |
+| `` (core) | `configmaps` | all |
+| `` (core) | `secrets` | all |
+
+These grants are not namespace-scoped. No per-namespace or per-cluster restriction exists anywhere in the shipped RBAC objects.
+
+**Why it is this broad**: the operator is a single Deployment that reconciles every `ValkeyCluster` in every namespace. For each one it creates and owns a headless Service, an auth Secret, ACL and per-node ConfigMaps, and bare Pods. Kubernetes RBAC has no mechanism to scope a `ClusterRole` bound via `ClusterRoleBinding` to only the resources a controller happens to own: granting "manage Services, ConfigMaps, Secrets, and Pods for any Valkey cluster, in any namespace" is expressed as "manage Services, ConfigMaps, Secrets, and Pods, full stop."
+
+**What a reviewer should conclude**: a compromise of the operator's ServiceAccount (its token, or the Deployment's ability to run arbitrary code) is a cluster-wide compromise of every Pod, Service, ConfigMap, and Secret in the Kubernetes cluster, not only Valkey-related ones. Treat the `valkey-operator` namespace, the operator's ServiceAccount token, and who can exec into or read logs from the operator Pod as high-value targets, and scope access to them accordingly (separate approval path, restricted `exec`/`get secrets` RBAC on the `valkey-operator` namespace, audit logging on the ServiceAccount's token use).
+
+## What tenants get
+
+A product team onboarded to use the operator receives two separate grants, deliberately split by scope:
+
+| Grant | Binding type | Resources | Verbs | Scope |
+|---|---|---|---|---|
+| Cluster management | `RoleBinding`, in the team's namespace | `valkeyclusters` | get, list, watch, create, update, patch, delete | Namespaced: the team's own namespace only |
+| Node visibility | Same `RoleBinding` | `valkeynodes` | get, list, watch | Namespaced: read-only |
+| Menu visibility | `ClusterRoleBinding` | `valkeyimages`, `valkeyconfigs`, `valkeyroles` | get, list, watch | Cluster-wide, read-only |
+
+The cluster-management grant is a `RoleBinding` (not a `ClusterRoleBinding`) specifically so the team's write access to `valkeyclusters` cannot reach any namespace but its own. The menu grant must be a `ClusterRoleBinding` because `ValkeyImage`, `ValkeyConfig`, and `ValkeyRole` are cluster-scoped resources (a namespaced `RoleBinding` cannot grant access to them at all), but the verbs are read-only, so a team can see the platform's menu without being able to change it.
+
+Product teams receive **no** direct grant on `pods`, `services`, `configmaps`, or `secrets`. Only the operator's own ServiceAccount has that. This is deliberate: see [secret-access implications](#secret-access-implications) below for why.
+
+## Restricting further
+
+The grants above are a starting point, not a ceiling:
+
+- **Narrow the menu grant's audience.** The menu `ClusterRoleBinding` is inherently cluster-wide because the resources it covers are cluster-scoped, but you control who it is bound to. Bind it only to the identity groups that need to discover available images and configs, rather than to all authenticated users.
+- **Keep cluster and node access namespaced.** The `RoleBinding` pattern above already prevents a team from seeing or touching `valkeyclusters`/`valkeynodes` outside its own namespace. Do not substitute a `ClusterRoleBinding` for convenience: that reintroduces cross-namespace visibility the namespaced pattern is designed to avoid.
+- **Do not extend tenant RBAC to core resources.** A team that can `get`/`list` `configmaps` or `secrets` in its own namespace gains implicit access to cluster credentials. See below. If a team needs to inspect a running cluster, prefer read-only visibility through the `ValkeyCluster`/`ValkeyNode` status fields (see [Cluster status](../reference/cluster-status.md)) over granting core-resource access.
+
+See [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md) for the complete manifests used to onboard a team with this pattern.
+
+## Secret-access implications
+
+The operator's core-resource grants mean it routinely reads and writes secret material on tenants' behalf:
+
+- It **reads** the customer-provided TLS Secret referenced by `spec.tls.secretRef` on every reconcile, to validate it and mount it into pods.
+- It **creates** the `{cluster}-operator-auth` Secret containing the generated operator and replication passwords, and reads it continuously to authenticate its own connections and render ACL password hashes.
+
+:::info
+The replication password is also rendered in **plaintext** as `primaryauth` in every node's `{node}-config` ConfigMap: this is how Valkey itself consumes replication credentials; there is no hashed alternative. As a direct consequence, **`get`/`list` access to ConfigMaps in a namespace that hosts Valkey clusters is credential-equivalent to Secret access** in that namespace. When you scope RBAC (for tenants, for CI systems, for any principal), treat ConfigMap read access in Valkey namespaces with the same care you would give Secret read access. This is the same disclosure made in [Security model](index.md#secret-material-inventory) and in [ACLs](acls.md#system-users); it belongs wherever RBAC decisions get made.
+:::

--- a/docs/self-hosted/valkey-operator/security/tls.md
+++ b/docs/self-hosted/valkey-operator/security/tls.md
@@ -1,0 +1,196 @@
+---
+title: TLS
+description: Enable TLS at cluster creation, the required Secret shape, certificate rotation, expiry monitoring, and a cert-manager walkthrough.
+sidebar_position: 2
+---
+
+# TLS
+
+This page covers enabling and operating TLS on a Valkey cluster managed by the Momento Valkey Operator: the Secret shape the operator expects, what TLS-only mode enforces, how validation and rotation work, and how to provision the certificate with cert-manager. It is written for platform and product-team engineers configuring a cluster for encrypted traffic.
+
+## Enable TLS at cluster creation
+
+Set `spec.tls.secretRef` on the `ValkeyCluster` to the name of a `kubernetes.io/tls` Secret in the same namespace:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+  tls:
+    secretRef: my-cluster-tls
+```
+
+:::warning
+Whether `spec.tls` is set is immutable after creation. You cannot add TLS to a cluster created without it, and you cannot remove TLS from a cluster created with it: the CRD rejects the change at admission. Decide at creation time; if you need to change your mind, create a new cluster. Only `tls.secretRef` itself can change afterward, which is how certificate rotation works (below).
+:::
+
+## Secret shape
+
+The Secret referenced by `spec.tls.secretRef` must be type `kubernetes.io/tls` and contain:
+
+| Key | Contents |
+|---|---|
+| `tls.crt` | The leaf certificate, valid PEM and a valid X.509 certificate. |
+| `tls.key` | The private key matching `tls.crt`. |
+| `ca.crt` | The CA bundle used to verify peer certificates on replication and the cluster bus. |
+
+The certificate's SANs must include exactly:
+
+- `{cluster}.{namespace}.svc.cluster.local`, for example `my-cluster.my-app.svc.cluster.local`
+- `*.{cluster}.{namespace}.svc.cluster.local`: the wildcard, covering the per-pod DNS names each node announces in TLS mode
+
+## What TLS-only mode enforces
+
+When `spec.tls` is set, every node runs TLS-only: the plaintext port is closed (`port 0`), and client traffic, replication, and the cluster bus are all encrypted. Clients are not required to present certificates: there is no mutual TLS on the client connection, only ACL-based authentication. The full list of settings the operator forces in TLS mode, and why, is in [Forced Valkey settings](../reference/forced-settings.md).
+
+## Validation on every reconcile
+
+The operator validates the referenced Secret on every reconcile, in any cluster state, not only at creation. It checks that the Secret exists and has data, that all three keys are present, that `tls.crt` parses as PEM/X.509, and that its SANs cover both required names. Any failure sets the cluster to `Invalid` with the exact reason in `status.message`; the operator takes no topology actions while `Invalid` but keeps re-checking the Secret. Once validation passes again, the cluster recovers to `Active` automatically: no action on the `ValkeyCluster` resource itself is needed. See [Cluster status](../reference/cluster-status.md) for the full state model.
+
+## Rotating the leaf certificate
+
+Update the Secret's data in place. Do not change `tls.secretRef` unless you are also renaming the Secret. Rotation then reaches every node in two stages: kubelet propagates the updated Secret content into each pod's mounted volume (typically up to about a minute), and the TLS reload controller, which ticks every 30 seconds, issues a configuration reload once it sees the new files on disk. No pod restart is needed: nodes reload their certificate in place, and established connections are not expected to be affected since the reload changes only which certificate is presented to new connections.
+
+## Rotating the CA
+
+Rotating the CA needs an overlap step, because the operator (and each node, when verifying peers) trusts only what is currently in `ca.crt`:
+
+1. Update `ca.crt` in the Secret to contain **both** the old and the new CA certificates, bundled together, alongside the new leaf in `tls.crt`/`tls.key` signed by the new CA.
+2. Wait for the two-stage propagation above to reach every node.
+3. Once every node is confirmed on the new leaf, update `ca.crt` again to contain only the new CA, removing the old one.
+
+Skipping the bundle step and rotating straight to a new CA breaks verification for any node that has not yet picked up the new certificate, because it no longer trusts what its peers are presenting.
+
+## Certificate expiry
+
+:::warning
+Certificate expiry is a warn-only condition. An expired certificate does **not** move the cluster to `Invalid`: the cluster stays `Active` and continues to be managed normally, while client connections that depend on the expired certificate fail. The operator does not alert on approaching or past expiry.
+:::
+
+You are responsible for monitoring certificate expiry and rotating before it happens. If you provision the Secret with cert-manager, its renewal cycle covers this automatically. See the walkthrough below. Otherwise, wire certificate expiry into your own alerting; see [Monitoring](../platform-guide/monitoring.md).
+
+## Provisioning certificates with cert-manager
+
+The operator consumes a `kubernetes.io/tls` Secret in the shape above but does not create or renew it. cert-manager is the recommended way to produce and rotate that Secret: it issues the certificate, writes it into a Secret in the right shape, and renews it before expiry, and the operator reloads each renewal across the cluster with no restart. This requires cert-manager installed in the Kubernetes cluster.
+
+**1. Bootstrap a private CA.** If you already run a cert-manager `Issuer`/`ClusterIssuer` backed by your own CA or an external PKI, use it and skip to step 2. Otherwise, create a one-time self-signed `Issuer` that signs a long-lived CA certificate, then a `CA` issuer that signs cluster leaf certificates from it:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-bootstrap
+  namespace: my-app
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: valkey-ca
+  namespace: my-app
+spec:
+  isCA: true
+  commonName: my-app-valkey-ca
+  secretName: valkey-ca-keypair
+  duration: 87600h    # 10y; keep the CA long-lived
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: valkey-ca-issuer
+  namespace: my-app
+spec:
+  ca:
+    secretName: valkey-ca-keypair
+```
+
+:::note
+Use a private-CA issuer (`CA`, `SelfSigned`, or an internal PKI) rather than a public ACME issuer. The certificate's SANs are internal `*.svc.cluster.local` names, which a public ACME issuer cannot validate or issue for: there is no HTTP or DNS challenge it can complete inside the cluster. A private-CA issuer also populates `ca.crt` in the resulting Secret, which the operator needs to verify peer certificates on replication and the cluster bus; ACME issuers do not produce one.
+:::
+
+**2. Issue the cluster's leaf certificate.** Its `secretName` must match `spec.tls.secretRef` on the `ValkeyCluster`. Two fields are commonly misconfigured:
+
+- `dnsNames` must list both required SANs exactly.
+- `usages` should include both `server auth` and `client auth`. Each node serves TLS to clients and also opens TLS connections to its peers for replication and the cluster bus, so it is a TLS client as well as a server. This requirement follows from the operator's forced `tls-cluster` and `tls-replication` settings, which put every node in a client role toward its peers, not from anything the operator validates directly. The operator's own check is limited to Secret keys, PEM validity, and SANs (see [Validation on every reconcile](#validation-on-every-reconcile) above).
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-cluster-tls
+  namespace: my-app
+spec:
+  secretName: my-cluster-tls
+  duration: 2160h      # 90d
+  renewBefore: 360h    # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - my-cluster.my-app.svc.cluster.local
+    - "*.my-cluster.my-app.svc.cluster.local"
+  issuerRef:
+    name: valkey-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+```
+
+`rotationPolicy: Always` makes cert-manager issue a fresh key on every renewal rather than reusing the existing one: a stricter rotation posture appropriate for infrastructure credentials.
+
+**3. Point the cluster at the Secret:**
+
+```yaml
+spec:
+  tls:
+    secretRef: my-cluster-tls
+```
+
+Renewal from here is automatic: cert-manager renews the leaf before expiry (per `renewBefore`) and rewrites the same Secret in place, and the operator reloads the new certificate on every node through the two-stage propagation described above, with no restart. Leaf renewal keeps the same CA, so no extra coordination is needed for routine renewals. Keep the CA itself long-lived so it does not need to rotate underneath a running cluster. To rotate the CA itself, follow the bundle procedure above.
+
+## Verifying TLS end to end
+
+Once the cluster is `Active`, prove the TLS setup works before pointing applications at it. From a pod inside the Kubernetes cluster, with the CA certificate available as `ca.crt`:
+
+```bash
+valkey-cli -h my-cluster.my-app.svc.cluster.local --tls --cacert ca.crt -p 6379 PING
+```
+
+Success prints:
+
+```text
+PONG
+```
+
+(If any ACL binding exists, add `--user` and `--pass`; an auth error at this point is an ACL problem, not a TLS problem.) Then confirm both failure directions behave, so you know encryption is actually enforced and verification is actually on:
+
+1. **A plaintext connection must be rejected.** Run the same command without `--tls`. It must fail to get a `PONG`; the plaintext listener is closed (`port 0`), so anything other than an error means you are not talking to the cluster you think.
+2. **Verification must be against the right CA.** Run the `--tls` command without `--cacert` (or against a different CA bundle). It must fail the handshake with a certificate verification error. If it succeeds, your client is not verifying the server certificate, and you lose the protection hostname verification provides during redirects.
+
+Finally, check the certificate the nodes are actually serving, which matters after a rotation:
+
+```bash
+openssl s_client -connect my-cluster.my-app.svc.cluster.local:6379 \
+  -servername my-cluster.my-app.svc.cluster.local -CAfile ca.crt </dev/null 2>/dev/null \
+  | openssl x509 -noout -enddate -subject
+```
+
+The `notAfter` date tells you whether the rotation you just performed is what clients now receive. Wire this check into your expiry monitoring; recall that an expired certificate leaves the cluster `Active` while clients fail (see [Certificate expiry](#certificate-expiry)).

--- a/docs/self-hosted/valkey-operator/support/compatibility.md
+++ b/docs/self-hosted/valkey-operator/support/compatibility.md
@@ -1,0 +1,36 @@
+---
+title: Compatibility
+description: The canonical version floors, supported architectures, and release artifact locations for the Momento Valkey Operator.
+sidebar_position: 2
+---
+
+# Compatibility
+
+This page is the canonical source for version and platform support for the Momento Valkey Operator. Other pages that mention version requirements ([Prerequisites](../getting-started/prerequisites.md) among them) summarize and link back here.
+
+## Version floors
+
+| Requirement | Minimum | Why |
+|---|---|---|
+| Operator | v0.6.0 | The version these docs describe. |
+| Kubernetes | 1.27+ | Per-shard placement relies on `matchLabelKeys` in topology spread constraints, a scheduling feature enabled by default starting in Kubernetes 1.27. On an older Kubernetes cluster, per-shard spread silently does not work as documented. |
+| Valkey (in any `ValkeyImage` you register) | 9+ | Shard scaling moves hash slots with the server-side slot-migration commands introduced in Valkey 9. This is also the practical floor for any image you allowlist: an older Valkey version can bootstrap a cluster, but resharding will fail against it. |
+| Architecture | amd64 or arm64 | Both the operator image and the images you register can run on either architecture. |
+
+:::note
+Every Valkey pod the operator creates carries a built-in toleration for `kubernetes.io/arch=arm64:NoSchedule`, regardless of which architecture you actually run. If your platform taints arm64 node pools to keep workloads off them unless explicitly opted in, account for this. See [Labels, annotations, and naming](../reference/labels-annotations.md).
+:::
+
+## Release artifacts
+
+| Artifact | Where |
+|---|---|
+| `crds.json` | Attached to each release on the [GitHub releases page](https://github.com/momentohq/valkey-operator/releases) |
+| `operator.yaml` | Attached to each release on the same page |
+| Operator container image | Docker Hub, `gomomento/valkey-operator`, tagged by release version (multi-arch: amd64 and arm64) |
+
+See [Installation](../getting-started/installation.md) for how these artifacts fit together.
+
+## Tested vs. supported
+
+These version floors derive from specific mechanisms (the Kubernetes scheduling feature per-shard placement depends on, and the Valkey server commands shard scaling depends on), not from a certification matrix run against named Kubernetes distributions. The operator does not check or enforce these floors at runtime: it targets any Kubernetes cluster meeting the floor above, on any CNCF-conformant distribution, and any Valkey image meeting the Valkey version floor. [What we test](what-we-test.md) states exactly which behaviors the test suites verify, and on what kind of cluster. If you hit behavior that looks version-related, check both floors before filing a report. See [Getting support](getting-support.md).

--- a/docs/self-hosted/valkey-operator/support/faq.md
+++ b/docs/self-hosted/valkey-operator/support/faq.md
@@ -1,0 +1,71 @@
+---
+title: Frequently asked questions
+description: Short answers to the questions evaluators and new users ask most, each linking to the page that covers the topic in full.
+sidebar_position: 3
+---
+
+# Frequently asked questions
+
+Short answers to the questions platform engineers ask when evaluating the Momento Valkey Operator, each with a pointer to the page that treats the topic fully. If you're starting from zero, the [overview](../index.md) and [glossary](../getting-started/glossary.md) are better entry points.
+
+## Running an in-memory store on Kubernetes
+
+### Is it safe to run an in-memory datastore on Kubernetes?
+
+Yes, with the right expectations: durability comes from replication, failover, and zone placement, not from disks. Pods use ephemeral storage, so any single pod's data survives only as long as a replica holds a copy. [Data durability](../concepts/data-durability.md) states the exact loss semantics per failure event; size your `replicasPerShard` and placement accordingly.
+
+### What exactly is lost when a pod dies?
+
+It depends on the pod's role. A lost replica costs nothing; a lost primary with a surviving replica costs at most the writes in replication lag at the moment of failure; a lost primary with no replica costs that shard's entire dataset, and the operator recreates the shard empty. [Data durability](../concepts/data-durability.md) has the full table, and [Failure modes](../operations/failure-modes.md) covers what the operator does in each case.
+
+### Why is there no backup or persistence option?
+
+The operator runs Valkey as an in-memory tier by design: nothing is written to persistent volumes, so there is nothing to snapshot. If your workload cannot tolerate the loss semantics above, it needs a durable system of record behind the cache. For where the product is headed, see the [roadmap](../roadmap.md).
+
+## The operator
+
+### What happens if the operator itself goes down?
+
+Your Valkey clusters keep serving traffic: the operator is not on the data path, and Valkey's own failover still protects shards that hold quorum. What stops is convergence, so scaling, upgrades, node replacement, and ACL and TLS propagation wait until the operator returns. [Failure modes](../operations/failure-modes.md) covers this row in detail, and [Monitoring](../platform-guide/monitoring.md) covers how to alert on it.
+
+### Why does the operator manage bare pods instead of StatefulSets?
+
+Cluster-topology-aware operations (replace-before-retire, exactly one failover per shard, topology-ordered replacement) need decisions that generic pod controllers can't express. The visible consequences (random pod name suffixes, `restartPolicy: Never`, no PodDisruptionBudgets) each have a documented stand-in. [Pod management](../concepts/pod-management.md) makes the full argument.
+
+### Why are images, configs, and roles cluster-scoped resources?
+
+Cluster scoping is the governance mechanism: the platform team holds write access to the menu, product teams get read-only visibility plus write access to `ValkeyCluster` in their own namespaces, and plain Kubernetes RBAC enforces the whole model with no admission webhooks or policy engine. [Resource model](../concepts/resource-model.md) explains the design; [Multi-tenancy and RBAC](../platform-guide/multi-tenancy-and-rbac.md) has the onboarding manifests.
+
+### Does the operator call home or depend on any external service?
+
+No. Every connection the operator makes stays inside the Kubernetes cluster: the API server, the Valkey pods it manages, and cluster DNS. It exposes no endpoints of its own. [Networking and ports](../security/networking.md) is the complete connection matrix.
+
+### Can I run more than one cluster in a namespace?
+
+Yes. `ValkeyCluster` is namespaced and nothing limits the count per namespace; each cluster gets its own Service, Secret, ConfigMaps, and nodes. See [Provisioning a cluster](../team-guide/provisioning.md).
+
+## Day-2 operations
+
+### Why can't I add TLS to an existing cluster?
+
+The TLS choice is immutable after creation, enforced by schema validation: converting a running cluster between plaintext and TLS-only would require a coordinated restart of every node across a mode boundary the operator does not manage. Decide at provisioning time; [TLS](../security/tls.md) and [Provisioning](../team-guide/provisioning.md#create-time-decisions) both flag this.
+
+### Why is Valkey 9 the version floor?
+
+Shard rebalancing uses Valkey 9's atomic slot-migration commands, so scaling shards on an older image fails. The operator does not enforce the floor at admission; an older image bootstraps and then breaks at the first reshard. [Compatibility](compatibility.md) owns the version floors and their reasons.
+
+### What actually happens during an engine upgrade?
+
+Repointing a config at a new image rolls every referencing cluster, one shard at a time per cluster: a new-image replica joins, the primary fails over to it, and the old node retires. Expect one client-visible failover per shard. [Managing Valkey upgrades](../platform-guide/valkey-upgrades.md) covers pacing, blast radius, and the staged-rollout pattern.
+
+### What if someone changes settings directly with CONFIG SET?
+
+The operator neither detects nor reverts runtime config changes: a manual `CONFIG SET` lasts until the pod is next replaced, then silently disappears. The exception is ACLs, which the operator reconverges continuously, wiping manual ACL edits on its next pass. [Changing configuration](../team-guide/changing-configuration.md#manual-changes-on-live-nodes) states the full drift policy.
+
+### How do I pause the operator during an incident?
+
+There is no per-cluster pause. The only way to stop reconciliation is scaling the operator Deployment to zero, which halts convergence for the whole fleet while clusters keep serving. [Failure modes](../operations/failure-modes.md#halting-reconciliation-deliberately) covers when that fleet-wide trade-off is worth it.
+
+### Why doesn't a dead pod restart?
+
+Valkey pods run with `restartPolicy: Never`: a restarted container would rejoin with empty memory anyway, so the operator instead handles failover and replaces the pod as a new cluster member. [Pod management](../concepts/pod-management.md) explains the reasoning, and [Failure modes](../operations/failure-modes.md) shows the replacement flow per scenario.

--- a/docs/self-hosted/valkey-operator/support/getting-support.md
+++ b/docs/self-hosted/valkey-operator/support/getting-support.md
@@ -1,0 +1,27 @@
+---
+title: Getting support
+description: How to engage Momento support for the Valkey Operator, what to include in a report, and where release notes live.
+sidebar_position: 5
+---
+
+# Getting support
+
+This page covers how to get help with the Momento Valkey Operator, what to include when you do, and where to find release notes.
+
+## How to engage support
+
+Engage support for the Momento Valkey Operator through your Momento account team. For urgent production incidents, use the same channel and state the urgency explicitly: severity handling is part of your support arrangement with Momento, not something inferred from a report.
+
+## What to attach
+
+Before reaching out, gather diagnostics for the affected cluster: the `ValkeyCluster` resource and its status, the state of its `ValkeyNode` resources, operator logs covering the relevant time window, and any recent Kubernetes events for the cluster's pods. [Troubleshooting](../operations/troubleshooting.md) documents the exact commands to collect this diagnostic set: run through it first, both because it might resolve the issue directly and because its output is what a report should include.
+
+Always include:
+
+- The operator release version.
+- The Kubernetes version and distribution.
+- The affected cluster's spec (shards, replicas, placement, TLS/ACL configuration): the `ValkeyCluster` manifest itself is the easiest way to convey this.
+
+## Release notes and artifacts
+
+Release notes, and the `crds.json` and `operator.yaml` artifacts for every release, are published on the [GitHub releases page](https://github.com/momentohq/valkey-operator/releases). See [Compatibility](compatibility.md) for the full artifact and image list.

--- a/docs/self-hosted/valkey-operator/support/index.md
+++ b/docs/self-hosted/valkey-operator/support/index.md
@@ -1,0 +1,14 @@
+---
+title: Support
+description: Version and platform compatibility for the Momento Valkey Operator, and how to get help.
+sidebar_position: 1
+---
+
+# Support
+
+This section covers what the Momento Valkey Operator supports and how to get help when something goes wrong.
+
+- **[Compatibility](compatibility.md)** — the canonical version floors for the operator, Kubernetes, and Valkey; supported architectures; and where release artifacts and images are published.
+- **[Frequently asked questions](faq.md)** — short answers to common evaluator questions, each linking to the page that covers the topic in full.
+- **[What we test](what-we-test.md)** — the behaviors the automated suites verify on real clusters and in simulation, and the explicit limits of that coverage.
+- **[Getting support](getting-support.md)** — how to engage Momento support, what to include in a report, and where release notes live.

--- a/docs/self-hosted/valkey-operator/support/what-we-test.md
+++ b/docs/self-hosted/valkey-operator/support/what-we-test.md
@@ -1,0 +1,78 @@
+---
+title: What we test
+description: The behaviors the operator's test suites verify, on real clusters and in simulation, and the things the suites deliberately do not cover.
+sidebar_position: 4
+---
+
+# What we test
+
+This page states which operator behaviors are verified by automated tests, and which are not. It exists so you can calibrate the claims in these docs: [Compatibility](compatibility.md) distinguishes supported from tested, and this page is the "tested" side of that line, including its limits.
+
+## How the operator is tested
+
+Two test tiers back the behaviors below:
+
+- **Simulation tests** run the operator's real reconciliation code against a simulated Kubernetes API and a simulated Valkey cluster. They verify convergence: that repeated reconciliation drives the cluster from a starting state to the declared goal state. Convergence bounds are reconcile counts, not wall-clock time, so no timing promise follows from them.
+- **Integration tests** run against a real Kubernetes cluster with real Valkey pods, and assert outcomes through the Kubernetes API and `valkey-cli` against the running nodes.
+
+Where a behavior below is marked **real-cluster**, it is verified end to end on the integration tier; the rest is simulation-verified. Behaviors covered by both tiers are the ones these docs state with the most confidence.
+
+## Verified behaviors
+
+Nearly every scenario below asserts the same safety invariant at convergence: all 16384 hash slots assigned. Whatever the disturbance, the suite verifies the operator drives the cluster back to full slot coverage.
+
+### Bootstrap
+
+- Clusters across a matrix of one to four shards and zero to two replicas per shard reach `Active` with full slot coverage, the exact expected node count, and every node a full member. **Real-cluster** for representative shapes, including healthy replication on every primary.
+- Spec edits made while a cluster is still `Creating` are deferred, not lost: bootstrap completes with its snapshotted spec, then the edit is applied. See [Reconciliation](../concepts/reconciliation.md).
+
+### Scaling
+
+- Scaling out converges to an evenly balanced slot distribution across the new shard count, not merely "the new shard got some slots". **Real-cluster** for several shapes.
+- Scaling in converges to the target shard count with all 16384 slots still covered and evenly rebalanced, and every surplus node fully removed. **Real-cluster**, including scaling down to a single shard. (The sequential-drain mechanism itself is a design claim; see the ordering gap below.)
+- Replica counts scale up and down to the exact target on every shard, including from and to zero replicas. **Real-cluster.**
+
+### Rolling upgrades
+
+- Changing a cluster's image rolls every node to the new image with no net change in node count and no reshuffling of which nodes belong to which shard. **Real-cluster** for a patch-level Valkey upgrade.
+
+### Failure recovery
+
+- All four failure quadrants recover on **real clusters**: primary loss with and without a surviving replica, each with and without cluster quorum. Where Valkey's own failover can act, the operator waits for it; where it cannot (no quorum, or no replica), the operator forces promotion or replaces the node. Each quadrant is exercised two ways, by deleting the pod and by killing the Valkey process in place. See [Failure modes](../operations/failure-modes.md) for what each quadrant means for your data.
+- Faults injected mid-scale-out, mid-scale-in, and mid-upgrade do not wedge the operator: the in-flight change still converges.
+
+### Placement
+
+- `nodeSelector` passes through to pods verbatim; `zoneSpread: required` emits the documented pair of topology spread constraints, and Kubernetes accepts them. **Real-cluster.**
+- Unsatisfiable placement fails safe: the pod sits `Pending` rather than the operator forcing or abandoning anything. **Real-cluster.**
+- Changing `zones` or `nodeSelector` replaces every pod (verified by node identity, not just state); changing `zoneSpread` replaces none. See [Zone-aware placement](../operations/zone-aware-placement.md).
+
+### TLS
+
+- A TLS-only cluster bootstraps and serves; a plaintext connection to it is rejected. **Real-cluster.**
+- A missing TLS Secret puts the cluster in `Invalid`, and the cluster recovers to `Active` on its own once a valid Secret exists, without recreating the resource. **Real-cluster.**
+- Full CA-plus-leaf rotation using the documented CA-bundle procedure completes with zero pod restarts and the cluster reachable over TLS at every asserted checkpoint (continuous request success is not measured; see the availability gap below). **Real-cluster.** See [TLS](../security/tls.md).
+
+### ACLs
+
+- The rendered ACL semantics documented in [ACLs](../security/acls.md) are asserted directly: a permissive default user with zero bindings, default user disabled the moment bindings exist, and the two system users always present.
+- ACL changes reach every node individually (ACLs are per-node state, and the suite deliberately checks each node) and bound credentials actually authenticate. **Real-cluster.** A dead node not blocking the rollout for the rest, with the laggard catching up after recovery, is simulation-verified.
+
+### Pod annotations
+
+- `podAnnotations` edits apply to existing pods in place, and reconciliation is additive: annotations set by other controllers survive. **Real-cluster** for creation-time passthrough.
+
+## What the suites do not cover
+
+Read these as the boundary of test-backed confidence. Where these docs make claims in these areas, the claims come from design and code inspection, not from tests, and the relevant pages say so.
+
+- **Data survival.** No test writes keys and verifies they survive resharding, failover, or upgrade; assertions are about topology and slot coverage. The suites also confirm the expected loss case: a primary lost with no replica comes back as an empty replacement. [Data durability](../concepts/data-durability.md) owns the loss semantics.
+- **Client-observed availability.** "Zero pod restarts" and "converges to healthy" are asserted; continuous request success and failover duration are never measured. No wall-clock behavior is test-backed.
+- **In-flight ordering.** End states are asserted; interim invariants (one shard disrupted at a time, replacement joins before retirement) are design claims, not test assertions.
+- **Partition and crash scenarios.** Network partitions, simultaneous multi-node failures, and operator restarts mid-workflow are not simulated; nodes in tests are only ever alive or dead.
+- **Real multi-zone distribution.** Zone spread is verified as emitted constraints accepted by Kubernetes, not as observed pod distribution across a real multi-zone cluster.
+- **Scale.** Verified shapes are small (up to four shards, up to two replicas per shard). Larger topologies and many-cluster fleets are outside the suite.
+- **Negative security cases.** No test verifies that a bound ACL user is denied outside its grants, or exercises malformed or wrong-SAN certificates beyond the missing-Secret case.
+- **Version skew.** Image swaps in tests are patch-level; downgrades and rollback mid-upgrade are untested, as [Managing Valkey upgrades](../platform-guide/valkey-upgrades.md) discloses.
+
+If a behavior you depend on falls in this list, treat it as a question for [your support channel](getting-support.md) rather than an implied guarantee.

--- a/docs/self-hosted/valkey-operator/team-guide/changing-configuration.md
+++ b/docs/self-hosted/valkey-operator/team-guide/changing-configuration.md
@@ -1,0 +1,59 @@
+---
+title: Changing configuration
+description: Switch a cluster's ValkeyConfig, edit pod annotations, and change placement, and which of those changes replace pods versus apply in place.
+sidebar_position: 5
+---
+
+# Changing configuration
+
+This guide covers the day-2 changes you make to a running `ValkeyCluster` beyond scaling, through the Momento Valkey Operator: switching configs, editing pod annotations, and changing placement. Each behaves differently: some roll every pod, some apply without disruption, and the [change-impact table in Reconciliation](../concepts/reconciliation.md#what-happens-when-you-change-the-spec) is the canonical reference for every field. This page covers only the fields you're most likely to touch.
+
+## Switching configs
+
+Point `spec.configRef` at a different `ValkeyConfig` from the menu, for example, to move to a larger resource profile:
+
+```bash
+kubectl -n my-app patch valkeycluster my-cluster --type merge -p '{"spec": {"configRef": "large"}}'
+```
+
+If the new config resolves to a different image, resource allocation, or Valkey setting than the current one, the operator carries out a rolling replacement. One shard at a time, it brings up a replacement node before retiring the old one, and performs exactly one failover per shard when the primary itself needs replacing. Existing shards keep serving throughout. See [Reconciliation](../concepts/reconciliation.md#how-a-rolling-replacement-proceeds) for the mechanics.
+
+## Editing pod annotations
+
+`spec.podAnnotations` is a map of annotations the operator applies to every pod in the cluster (useful for tooling that reads pod annotations, such as metrics scraping or sidecar injection):
+
+```bash
+kubectl -n my-app patch valkeycluster my-cluster --type merge -p '{
+  "spec": {"podAnnotations": {"example.com/scrape": "true"}}
+}'
+```
+
+Additions and changes are patched onto live pods in place: no rolling replacement, no restart. Removing a key from `spec.podAnnotations`, however, does not strip it from pods that are already running. The operator can't distinguish its own annotation from one added by another controller once it's on a live pod. A removal takes effect the next time that pod is replaced, for example, during a config change or upgrade.
+
+Keys under the `valkey.gomomento.com/` prefix are reserved for the operator's own use; the API rejects them at apply time.
+
+## Changing placement
+
+`spec.placement.zones` and `spec.placement.nodeSelector` are hard scheduling constraints, so changing either one triggers a rolling replacement. The operator can't move a running pod between zones or node pools, only replace it with one scheduled correctly. This follows the same one-shard-at-a-time, replace-before-retire procedure as a config change.
+
+`spec.placement.zoneSpread` is different. Changing it, in either direction, and regardless of whether the mode itself is a hard (`required`) or soft (`bestEffort`) scheduling constraint, does **not** replace any existing pods. The new mode only affects pods created afterward, during a later scale-up, config change, or replacement.
+
+:::note
+If the new placement is unsatisfiable (a `nodeSelector` no node matches, or a zone with no available capacity), the roll stalls safely. The replacement pod for the shard in progress sits `Pending`, and every other pod (including the one being replaced) keeps running and serving traffic. The rollout resumes on its own once a matching node becomes available, for example after your cluster autoscaler provisions one.
+:::
+
+For the full mechanics of zones, node selectors, and spread modes, see [Zone-aware placement](../operations/zone-aware-placement.md).
+
+## Manual changes on live nodes
+
+Declared configuration flows one way: from the resolved `ValkeyConfig` into a rendered config file that each node reads once, at process start. What happens if someone bypasses that and changes a live node directly depends on what they change:
+
+- **`CONFIG SET` is neither detected nor reverted.** The operator never reads a node's live configuration; it compares declared specs against each other, not against running processes. A manual `CONFIG SET` therefore takes effect immediately and silently survives until that pod is next replaced (by a config change, upgrade, or failure recovery), at which point the replacement starts from the rendered config and the manual change vanishes. Nothing records that the drift ever existed.
+- **`CONFIG REWRITE` cannot persist anything.** The config file is a read-only mount, so attempts to rewrite it fail; there is no path to make a runtime change permanent from inside the node.
+- **Manual ACL changes are actively reverted.** Unlike ordinary settings, ACLs are reconverged continuously: on its next pass the ACL controller reloads every node's ACLs from the declared state, wiping any manual `ACL SETUSER` or `ACL DELUSER`. Manage users only through the spec; see [ACLs](../security/acls.md).
+
+The practical rule: treat `CONFIG SET` on a managed node as a diagnostic tool with an unpredictable lifetime, never as a configuration mechanism. If a setting matters, put it in the `ValkeyConfig` (or ask your platform team to), where it survives replacements and applies to every node uniformly.
+
+## The full change-impact picture
+
+Config, placement, pod annotations, ACLs, and TLS rotation each have different impact: rolling replacement, in-place, or future-pods-only. Rather than duplicate that table here, see the canonical version in [Reconciliation](../concepts/reconciliation.md#what-happens-when-you-change-the-spec) before making a change you're unsure about.

--- a/docs/self-hosted/valkey-operator/team-guide/connecting.md
+++ b/docs/self-hosted/valkey-operator/team-guide/connecting.md
@@ -1,0 +1,80 @@
+---
+title: Connecting to your cluster
+description: Endpoints, cluster-aware client requirements, TLS, ACL authentication, and failover resilience for applications connecting to a ValkeyCluster.
+sidebar_position: 3
+---
+
+# Connecting to your cluster
+
+This guide covers how your applications connect to a Valkey cluster provisioned through the Momento Valkey Operator: the endpoint to use, why the client library matters, and how to connect over TLS. It also covers how to authenticate and how to handle the brief disruption a failover causes.
+
+## Endpoints
+
+Every `ValkeyCluster` gets one headless Service, named after the cluster, reachable at:
+
+```text
+{cluster}.{namespace}.svc.cluster.local:6379
+```
+
+For `my-cluster` in namespace `my-app`, that's `my-cluster.my-app.svc.cluster.local:6379`. The Service resolves to the IPs of every node's pod; it load-balances nothing on its own. Your client discovers the actual topology (which node owns which hash slots) from the cluster itself.
+
+Port `16379` (the cluster bus) is also exposed on the Service, but it's used for node-to-node gossip and replication, not by application clients. Point your application only at `6379`.
+
+These endpoints exist only inside the Kubernetes cluster's network: nodes announce pod IPs (or, under TLS, cluster-internal DNS names), so your application must run in the same Kubernetes cluster as the Valkey cluster it uses. [Networking and ports](../security/networking.md) states this boundary and the full connection matrix.
+
+## Use a cluster-aware client
+
+A Valkey cluster shards data by hash slot across primaries, and slot ownership changes as the operator rebalances, scales, or replaces nodes. A client that isn't cluster-aware sends commands to whichever node it first connected to. It fails (or silently gets wrong results) whenever that node doesn't own the requested key's slot. Your client **must** speak the cluster protocol: it needs to follow `MOVED` redirects and refresh its view of slot ownership as the topology changes.
+
+From `valkey-cli`, pass `-c` to enable cluster mode:
+
+```bash
+valkey-cli -c -h my-cluster.my-app.svc.cluster.local -p 6379 PING
+```
+
+For application clients, look for a "cluster mode" or "cluster client" option in your client library and enable it. Plain single-node clients do not work correctly against a Valkey cluster. With `valkey-glide` (Valkey's official client library), for example, the cluster client takes the Service DNS name as its seed address and discovers the topology from there:
+
+```typescript
+import { GlideClusterClient } from "@valkey/valkey-glide";
+
+const client = await GlideClusterClient.createClient({
+  addresses: [{ host: "my-cluster.my-app.svc.cluster.local", port: 6379 }],
+});
+await client.set("greeting", "hello");
+```
+
+The same shape applies in any language: give the cluster client the Service DNS name as a seed, and it discovers and tracks the shard topology itself. Beyond enabling cluster mode, most client libraries need no cluster-specific configuration to follow redirects. The guidance that matters is in [resilience during a failover](#resilience-during-a-failover) below.
+
+## TLS connections
+
+If your cluster was created with `spec.tls` set (see [Provisioning](provisioning.md#create-time-decisions)), all traffic on port 6379 is TLS: there is no plaintext fallback. Connect with the cluster's CA certificate:
+
+```bash
+valkey-cli -c -h my-cluster.my-app.svc.cluster.local --tls --cacert ca.crt -p 6379 PING
+```
+
+`ca.crt` comes from the same TLS Secret your platform team (or you) referenced in `spec.tls.secretRef`; get it from wherever that Secret's contents are distributed to your application, not from the cluster directly.
+
+Clients do **not** present a certificate of their own: the cluster does not use mutual TLS. Your application needs only the CA certificate to verify the server; it authenticates with ACL credentials (below), not a client cert.
+
+Hostname verification matters here because of how redirects work under TLS: each node announces its own per-pod DNS name (`{pod}.{cluster}.{namespace}.svc.cluster.local`) rather than a bare IP. The certificate's SAN is a wildcard covering that pattern. When your client follows a redirect to a different node, it validates the new node's certificate against that same wildcard, so redirects stay verifiable without per-node certificates. Configure your client library's TLS options to validate against the server hostname, not to skip hostname verification.
+
+## Authenticating with an ACL user
+
+If any ACL bindings exist on your cluster (see [ACLs](../security/acls.md)), authenticate as one of the bound users:
+
+```bash
+valkey-cli -c -h my-cluster.my-app.svc.cluster.local -p 6379 --user app-user --pass '<password>' PING
+```
+
+The username, password, and permissions come from a binding you (or your platform team) added under `spec.acl`. The password itself is never stored in the cluster spec, only a SHA-256 hash of it. Manage the plaintext credential the way you manage any application secret: your team owns issuing it to your clients and rotating it. See [ACLs](../security/acls.md) for the binding format and the rotation procedure.
+
+:::info
+The moment any ACL binding exists on your cluster (yours or your platform team's), the `default` user is disabled. If your application was relying on unauthenticated access, it stops working as soon as the first binding is added, and it needs bound credentials from then on.
+:::
+
+## Resilience during a failover
+
+When a primary fails, Valkey promotes a replica to take its place. While that failover is in progress, writes (and reads for keys in that shard) to the affected shard's slots briefly fail; other shards are unaffected. This is normal, expected behavior for any cluster-aware Valkey deployment, not specific to how this operator manages the cluster.
+
+Your client should treat these failures as transient: retry with backoff. Also, make sure the client refreshes its topology view (its map of slot ownership to nodes) after a connection error or a redirect, rather than caching it indefinitely. Most cluster-aware client libraries do this automatically once cluster mode is enabled. Confirm your library's retry and topology-refresh behavior rather than assuming defaults are enough for your workload's tolerance for transient errors.

--- a/docs/self-hosted/valkey-operator/team-guide/index.md
+++ b/docs/self-hosted/valkey-operator/team-guide/index.md
@@ -1,0 +1,32 @@
+---
+title: For product teams
+description: How product teams provision, connect to, scale, and reconfigure Valkey clusters through the ValkeyCluster resource.
+sidebar_position: 1
+---
+
+# For product teams
+
+This section is for developers on a product team who consume Valkey clusters from a platform their organization runs. You interact with exactly one resource, `ValkeyCluster`, in your own namespace. The Momento Valkey Operator does everything else: forming the cluster, keeping it healthy, and carrying out the changes you request.
+
+## What you own, what the platform handles
+
+Your platform team curates a menu of approved building blocks and installs and runs the operator. You pick from that menu and declare the Valkey cluster you want; the operator reconciles your `ValkeyCluster` into a running cluster.
+
+| Concern | Who owns it |
+|---|---|
+| `ValkeyCluster` resources in your namespace: creating, scaling, reconfiguring, deleting | You |
+| ACL users bound on your clusters, and your applications' connection and retry logic | You |
+| The config menu (`ValkeyConfig`), image allowlist (`ValkeyImage`), and reusable ACL roles (`ValkeyRole`) | Platform team |
+| Installing, upgrading, and configuring the operator | Platform team |
+| Cluster bootstrap, slot assignment, failover, rebalancing, rolling replacements | The operator |
+
+You can read the menu resources to see what is on offer (cluster-scoped, so visible from any namespace), but you cannot create or edit them. If you need a new image version, a different resource profile, or a new ACL role, ask your platform team.
+
+## Guides in this section
+
+- [Provisioning a cluster](provisioning.md) — discover the config menu, apply a `ValkeyCluster`, watch it move from `Creating` to `Active`, read its status with `kubectl get`/`describe`, understand what your RBAC grants allow, and delete a cluster cleanly. Covers the decisions you make once, at creation time: TLS in particular cannot be added later.
+- [Connecting to your cluster](connecting.md) — the DNS endpoint your clients use, why a cluster-aware client is required, how to connect over TLS, how to authenticate with an ACL user, and how to handle the brief write failures a failover causes.
+- [Scaling](scaling.md) — grow or shrink the cluster by editing `spec.shards` and `spec.replicasPerShard`, what to expect while the operator rebalances slots, and why an edit made during `Creating` won't fix a bad initial spec.
+- [Changing configuration](changing-configuration.md) — switch to a different `ValkeyConfig`, edit pod annotations, and change placement, and which of those changes replace pods, which apply in place, and which affect only future pods.
+
+For the exact meaning of every status field and state you might see in `kubectl` output, keep [Cluster status](../reference/cluster-status.md) at hand. If a cluster looks stuck, start with [Troubleshooting](../operations/troubleshooting.md).

--- a/docs/self-hosted/valkey-operator/team-guide/provisioning.md
+++ b/docs/self-hosted/valkey-operator/team-guide/provisioning.md
@@ -1,0 +1,148 @@
+---
+title: Provisioning a cluster
+description: Discover the config menu, apply a ValkeyCluster, watch it reach Active, and understand what your RBAC grants allow.
+sidebar_position: 2
+---
+
+# Provisioning a cluster
+
+This guide walks through provisioning a Valkey cluster with the Momento Valkey Operator as a product team: finding out what your platform team has made available, applying a `ValkeyCluster`, and watching it come up. It also covers the decisions you need to get right before you apply it, because a few of them can't be changed afterward.
+
+## Discover the menu
+
+Your platform team curates the building blocks you provision from: `ValkeyConfig` (resource and Valkey-setting profiles), `ValkeyImage` (allowed Valkey versions), and `ValkeyRole` (reusable ACL permission sets). All three are cluster-scoped, so they're visible from any namespace, and your access to them is read-only.
+
+List the configs on offer:
+
+```bash
+kubectl get valkeyconfigs
+```
+
+```text
+NAME       IMAGEREF     BASEREF
+standard   valkey-9-0
+large      valkey-9-0   standard
+```
+
+Inspect a config to see what it resolves to before you commit to it:
+
+```bash
+kubectl describe valkeyconfig standard
+```
+
+The value you put in `configRef` is the `metadata.name` of one of these: `standard` in the example above. If you need a profile that isn't on the menu, or a Valkey version that isn't allowlisted, ask your platform team. You cannot create `ValkeyConfig` or `ValkeyImage` resources yourself.
+
+## Apply a ValkeyCluster
+
+`ValkeyCluster` is namespaced; create it in the namespace where your application runs:
+
+```yaml
+apiVersion: valkey.gomomento.com/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+  namespace: my-app
+spec:
+  configRef: standard
+  shards: 3
+  replicasPerShard: 1
+```
+
+```bash
+kubectl apply -f my-cluster.yaml
+```
+
+`configRef` must name a `ValkeyConfig` your platform team has published. `shards` and `replicasPerShard` set the initial topology: you can change both later; see [Scaling](scaling.md).
+
+## States you'll observe
+
+Watch the cluster come up:
+
+```bash
+kubectl -n my-app get valkeycluster my-cluster -w
+```
+
+A new cluster starts in `Creating` while the operator forms the topology: creating nodes, assigning hash slots, attaching replicas. It moves to `Active` once the cluster is fully formed and serving. You might also see `Invalid` if a referenced TLS Secret fails validation; the operator recovers automatically once the Secret is fixed. For the full state definitions and transition rules, see [Cluster status](../reference/cluster-status.md).
+
+## Reading cluster status
+
+Check the cluster's status:
+
+```bash
+kubectl -n my-app get valkeycluster my-cluster
+```
+
+```text
+NAME         CONFIG     SHARDS   REPLICAS   STATE
+my-cluster   standard   3        1          Active
+```
+
+`kubectl describe` shows the full spec and status:
+
+```bash
+kubectl -n my-app describe valkeycluster my-cluster
+```
+
+```text
+Name:         my-cluster
+Namespace:    my-app
+API Version:  valkey.gomomento.com/v1alpha1
+Kind:         ValkeyCluster
+Spec:
+  Config Ref:          standard
+  Replicas Per Shard:  1
+  Shards:              3
+Status:
+  State:  Active
+```
+
+The status carries no pod list; to see the members backing the cluster, list the operator-internal `ValkeyNode` resources, which also show per-node lifecycle (`Joining`, `Active`, `Leaving`). Names carry a random suffix rather than an ordinal (`-0`, `-1`) because the operator manages pods directly:
+
+```bash
+kubectl -n my-app get valkeynodes
+```
+
+```text
+NAME               CLUSTER      IMAGE                LIFECYCLE
+my-cluster-1a2b3   my-cluster   valkey/valkey:9.0.0  Active
+my-cluster-4c5d6   my-cluster   valkey/valkey:9.0.0  Active
+my-cluster-7e8f9   my-cluster   valkey/valkey:9.0.0  Joining
+```
+
+`ValkeyNode` is read-only for product teams, useful for observing bootstrap and rollout progress, but not something you create or edit directly.
+
+## RBAC reality
+
+Your platform team grants you namespaced create/read/update/delete access to `valkeyclusters`, plus read access to `valkeynodes`, in your own namespace. Access to the menu resources (`valkeyimages`, `valkeyconfigs`, `valkeyroles`) is cluster-wide but read-only. In practice this means:
+
+- You can provision, scale, reconfigure, and delete any number of `ValkeyCluster` resources in your namespace.
+- You can inspect the menu to decide what to reference, but you cannot register a new image, publish a new config, or define a new role. Those go through your platform team.
+- You have no direct access to the Pods, Services, ConfigMaps, or Secrets the operator creates on your cluster's behalf. Day-to-day state is visible through `ValkeyCluster` status and the `ValkeyNode` resources, but some failures surface only in operator logs your platform team can read; see [Troubleshooting](../operations/troubleshooting.md).
+
+## Deletion
+
+Delete the cluster:
+
+```bash
+kubectl -n my-app delete valkeycluster my-cluster
+```
+
+Deleting a `ValkeyCluster` tears down everything it owns: every `ValkeyNode`, pod, per-node ConfigMap, the ACL ConfigMap, the auth Secret, and the headless Service. Nothing is left orphaned in your namespace. Deletion is finalizer-backed and scoped entirely to the cluster's namespace; it never touches another team's resources or the platform-level menu.
+
+:::warning
+Finalizer cleanup requires a running operator. If the operator is down when you delete a cluster, the resource sits in `Terminating` until the operator comes back. See the stuck-`Terminating` entry in [Troubleshooting](../operations/troubleshooting.md).
+:::
+
+## Create-time decisions
+
+A few fields are worth getting right before you apply the cluster, because they're expensive or impossible to change afterward.
+
+**TLS.** Set `spec.tls.secretRef` to encrypt client traffic, replication, and the cluster bus from the start.
+
+:::warning
+TLS presence is immutable. You cannot add TLS to a cluster that was created without it, or remove it from one that has it. Only the referenced Secret (for certificate rotation) can change. If you might need TLS, enable it at creation. See [TLS](../security/tls.md).
+:::
+
+**Placement.** `spec.placement` controls which availability zones and node pools your cluster's pods land on, and how strictly each shard is spread across zones. It can be changed later, but a change to `zones` or `nodeSelector` triggers a rolling replacement of every pod. That's worth setting deliberately up front for anything beyond a dev cluster. See [Zone-aware placement](../operations/zone-aware-placement.md).
+
+**ACLs.** `spec.acl` binds users to your cluster, additive to anything your platform team has bound at the config level. Until you bind at least one user, the cluster's `default` user is fully open to any client that can reach it on the network. That's worth deciding deliberately rather than by omission. See [ACLs](../security/acls.md).

--- a/docs/self-hosted/valkey-operator/team-guide/scaling.md
+++ b/docs/self-hosted/valkey-operator/team-guide/scaling.md
@@ -1,0 +1,50 @@
+---
+title: Scaling
+description: Grow or shrink a ValkeyCluster by editing spec.shards and spec.replicasPerShard, and what to expect while the operator rebalances.
+sidebar_position: 4
+---
+
+# Scaling
+
+This guide covers changing the size of a Valkey cluster you own: adding or removing shards, and adding or removing replicas. It also covers what to expect while the Momento Valkey Operator carries out the change.
+
+## Scaling shards
+
+Edit `spec.shards` to change the number of shards:
+
+```bash
+kubectl -n my-app patch valkeycluster my-cluster --type merge -p '{"spec": {"shards": 4}}'
+```
+
+Scaling out or in changes how the cluster's 16384 hash slots are distributed, not just how many nodes exist. The operator moves slots between shards with a single server-side command that starts an asynchronous slot migration. The migration proceeds one batch of slots per reconciliation tick, until every shard holds an even share.
+
+- **Scaling out** adds new, empty shards and migrates slots from existing shards onto them until the distribution is even again.
+- **Scaling in** fully drains the smallest shard (migrating all of its slots to other shards) before removing it. Only the drained shard's primary and replicas are removed; nothing else in the cluster is touched.
+
+:::info
+Slot migration relies on a Valkey 9+ command. Clusters running an older Valkey image cannot reshard. See [Compatibility](../support/compatibility.md) for version requirements.
+:::
+
+## Scaling replicas
+
+Edit `spec.replicasPerShard` to change replica count uniformly across every shard:
+
+```bash
+kubectl -n my-app patch valkeycluster my-cluster --type merge -p '{"spec": {"replicasPerShard": 2}}'
+```
+
+The operator adds or removes replicas evenly, one node at a time, until every shard reaches the target count. This doesn't move any hash slots; only the number of copies of each shard's data changes.
+
+## What to expect
+
+Both kinds of scaling happen while the cluster reports `Active`: there's no separate "scaling" state to watch for beyond the shard and replica counts converging to your new values. How long a rebalance takes depends on how much data has to move, which scales with the size of your dataset. This guide won't give you a duration to expect because it depends entirely on your cluster's data volume and the pace of migration batches.
+
+Client impact during scaling is minimal for a properly configured cluster-aware client: as slots move, clients following `MOVED` redirects and refreshing topology (see [Connecting](connecting.md#use-a-cluster-aware-client)) adapt automatically. Scaling out adds capacity without disrupting existing shards' availability; scaling in only touches the shard being drained.
+
+## Edits while the cluster is still Creating
+
+If you change `spec.shards` or `spec.replicasPerShard` while the cluster is still in its initial `Creating` bootstrap, the edit is not lost, but it's also not picked up immediately. Bootstrap works from a snapshot of the spec it captured when it began (`status.targetSpec`), not the live spec. Your edit takes effect only after bootstrap completes and the cluster reaches `Active`. See [Cluster status](../reference/cluster-status.md) for the full snapshot semantics.
+
+One consequence worth knowing before you provision: **a spec mistake made at creation time generally cannot be fixed by editing the spec while the cluster is still `Creating`.** A wrong `shards` value waits out the whole bootstrap before your correction applies. Fields outside the topology (like `configRef` or `placement`) only shape nodes the bootstrap has not created yet; they do not repair nodes already built with the wrong values. If a cluster is stuck in `Creating` because of a spec-level problem, see the wedged-bootstrap entry in [Troubleshooting](../operations/troubleshooting.md). The fix is usually to delete and recreate the cluster with the corrected spec, not to patch it in place.
+
+Once a cluster is `Active`, this snapshot behavior doesn't apply. A scaling edit made while a previous scaling operation is still rebalancing is picked up as the new target on the next reconciliation pass. You don't need to wait for one scaling change to finish before requesting another.

--- a/docs/self-hosted/valkey-operator/why-this-operator.md
+++ b/docs/self-hosted/valkey-operator/why-this-operator.md
@@ -1,0 +1,41 @@
+---
+title: Why this operator
+description: The top factual benefits of the Momento Valkey Operator, grounded in shipped behavior.
+sidebar_position: 2
+---
+
+# Why this operator
+
+This page states the Momento Valkey Operator's top benefits factually, each grounded in behavior documented elsewhere in these docs. It does not compare against named products; where useful, it anchors a claim against typical expectations for operators of stateful systems on Kubernetes.
+
+## Governance is built into the resource model, not bolted on
+
+Many operators for stateful systems leave governance to whatever the platform team can construct externally: admission webhooks, a separate policy engine, or process discipline. This operator's governance is the resource model itself: an allowlist of permitted images, a curated menu of configuration profiles, and reusable ACL role definitions all live as cluster-scoped custom resources, readable by every namespace but writable only by the platform team. A product team's `ValkeyCluster` can only ever reference what the platform team has already published: there is no field where an unapproved image or setting could go. No admission webhook is required for this to hold. See [Resource model](concepts/resource-model.md).
+
+## Direct pod management for topology-aware operations
+
+Generic Kubernetes workload controllers reconcile a pod count against a template; they have no concept of shard membership, primary/replica role, or replication sync state. This operator manages pods directly so it can express operations that require that awareness: replacing a node only after its successor has joined and synced, and performing exactly one coordinated failover per shard during a rolling change, never more, never as a side effect of an unrelated pod restart. See [Pod management](concepts/pod-management.md).
+
+## Explicit, deliberate engine versioning
+
+Every image a cluster can run comes from the platform team's allowlist, and nothing in the operator initiates an engine upgrade on its own. A cluster moves to a different image only when what its config resolves to changes: the platform team repoints a `ValkeyConfig`'s `imageRef` or edits a registered `ValkeyImage`, or a product team switches its cluster to a different config from the approved menu. Every one of those is an explicit, auditable Kubernetes resource change made by a person; none happens automatically. See [Managing Valkey upgrades](platform-guide/valkey-upgrades.md).
+
+## No cap on clusters per namespace
+
+A namespace can hold any number of `ValkeyCluster` resources. Product teams are free to organize clusters (one per application, one per environment, or any other scheme) without the operator itself imposing a one-cluster-per-namespace ceiling, which is a real constraint some operators for stateful systems apply. See [Provisioning a cluster](team-guide/provisioning.md).
+
+## TLS-only mode and structured ACLs
+
+A Valkey cluster can run TLS-only, encrypting client traffic, replication, and the cluster bus, with the plaintext port closed entirely. Access control is expressed structurally (reusable permission roles, key-pattern scoping, and password-hash rotation) rather than as hand-assembled ACL strings a platform team has to get right by hand on every cluster. See [Security](security/index.md).
+
+## Zone-aware placement with hard per-shard guarantees
+
+With required zone spread, every shard's members are guaranteed to land across distinct availability zones (a hard constraint enforced by Kubernetes scheduling, not a best-effort preference), so a single zone failure cannot, by construction, take out both a shard's primary and all its replicas. See [Zone-aware placement](operations/zone-aware-placement.md).
+
+## Predictable, observable reconciliation
+
+Where many controllers reconcile by re-evaluating and applying a full desired state, this operator takes at most one corrective action per reconciliation pass, then requeues. A cluster's formation is snapshotted into `status.targetSpec`, and every node's join/leave progress is visible through its `ValkeyNode` resource, so a platform team can watch a change happen step by step rather than treating the operator as a black box. This bounds the blast radius of any single mistake or fault to one small step. See [Reconciliation](concepts/reconciliation.md).
+
+## An honest operations story
+
+Operators for stateful systems on Kubernetes often stay quiet about what happens to data when things go wrong, leaving teams to discover the answer during an incident. This operator's documentation states the storage model plainly: Valkey clusters are in-memory, and durability comes from replication, failover, and placement, not from disks. Exactly which failure events lose data, and which don't, is written down rather than implied. For a team evaluating a system that will hold production data, that itself is a benefit: what you read here is what you will observe in production, with no gap between the two. See [Data durability](concepts/data-durability.md).


### PR DESCRIPTION
Incorporate Momento Valkey Operator docs under self-hosted/valkey-operator (T-0052)

56 pages from the operator's generated doc set (S-016, tmp-generated-docs, operator v0.6.0), preserving IA structure. Format-adapted for Docusaurus: GitHub-alert admonitions -> ::: containers; backticks stripped from 21 headings (T-0055 rule). All 453 relative links + 66 anchors validated (0 broken, 0 cross-tree). readme/ build-notes and presentations/ deck not published.