### PR TITLE
Momento Cache pricing: switch to capacity-only model (T-0056)

### DIFF
--- a/docs/product/cache/pricing.md
+++ b/docs/product/cache/pricing.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Pricing
 title: Momento Cache pricing
-description: How Momento Cache pricing works across client traffic, capacity, and cloud data transfer.
+description: How Momento Cache pricing works — a single, capacity-based charge for your cluster.
 ---
 
 <!-- Projects: cache2/pricing/pricing -->
@@ -9,58 +9,38 @@ description: How Momento Cache pricing works across client traffic, capacity, an
 # Pricing
 
 :::note
-The pricing model is set, but the figures shown are provisional and may change.
+Pricing is provisional and may change before general availability.
 :::
 
-Momento Cache usage is based on client traffic and storage capacity. In addition,
-AWS data-transfer costs are passed through.
+Momento Cache uses simple, capacity-based pricing: you pay for the size of your cluster and
+nothing else. There are no separate charges for connections, request traffic, or data
+transfer — including cross-AZ traffic, which is included in the capacity price.
 
-## Client Traffic
+## Capacity
 
-Client traffic is measured as total data transfer into and out of the service, as well
-as total connection time (RESP and HTTP).
+You pay for cluster capacity, measured either as the amount of storage available to Valkey or
+as the underlying instance, depending on how you [size your Capacity
+Pool](/product/cache/concepts/provisioning-and-sizing).
 
-| Dimension                | Price | Unit                      |
-| ------------------------ | ----- | ------------------------- |
-| Data transfer (in + out) | $0.01 | per GB                    |
-| Connections              | $0.25 | per 1M connection-minutes |
+| Dimension               | Price                     | Unit                |
+| ----------------------- | ------------------------- | ------------------- |
+| Cluster size (storage)  | $30.00                    | per GB-month        |
+| Cluster size (instance) | 2.8 × instance list price | per instance-month  |
 
-## Capacity (Cluster)
+Capacity scales with the shape of your [Capacity
+Pool](/product/cache/concepts/capacity-pool) — instance type, shard count, and replica count.
 
-A [Capacity Pool](/product/cache/concepts/capacity-pool) using Cluster capacity mode, also known as
-"explicit" provisioning, tracks the number of instances running in your cluster. Instance
-type, shard count, and replica count determine how many total instance-hours the Capacity
-Pool uses.
+## Examples
 
-| Dimension | Price                     | Unit              |
-| --------- | ------------------------- | ----------------- |
-| Instance  | 1.5 × instance list price | per instance-hour |
-
-## Capacity (Flex)
-
-A [Capacity Pool](/product/cache/concepts/capacity-pool) using Flex capacity mode, also known as
-"managed" provisioning, tracks the amount of physical storage allocated to your cluster.
-Storage size and replica count determine how many total GB-hours the Capacity Pool uses.
-
-| Dimension             | Price  | Unit        |
-| --------------------- | ------ | ----------- |
-| Storage (standard)    | $0.014 | per GB-hour |
-| Storage (performance) | $0.021 | per GB-hour |
-
-## Cloud Data Transfer
-
-The service passes through these underlying costs at the cloud provider's list price:
-
-| Dimension                | Price      | Unit   |
-| ------------------------ | ---------- | ------ |
-| Data transfer (cross-AZ) | list price | per GB |
-| Data transfer (egress)   | list price | per GB |
+- Momento Cache runs a minimum of **3 shards**. The smallest cluster is 3 shards of 4 GB each
+  (12 GB total) with no replicas, at **$360 / month**.
+- Adding one replica per shard in a second Availability Zone for high availability doubles the
+  capacity, at **$720 / month**.
 
 ## How this maps to your usage
 
-- **Instance-hours** and **GB-hours** follow your pool's shape. A larger instance type,
-  more shards, or more replicas increase instance-hours. You control this when you
+- **Storage** and **instance** capacity follow your pool's shape. A larger instance type,
+  more shards, or more replicas increase the capacity you pay for. You control this when you
   [size the pool](/product/cache/concepts/provisioning-and-sizing).
-- **Connection-minutes** accrue while clients are connected through the gateway.
-- **Data transfer** accrues on request and response traffic; cross-AZ and egress follow AWS
-  list price.
+- High availability adds replicas in additional Availability Zones, which increases capacity
+  and therefore cost.


### PR DESCRIPTION
Replace the multi-dimensional pricing page (data transfer + connections + per-hour instance/GB-hour, Cluster/Flex split) with the confirmed capacity-only model: cluster size at $30/GB-month or instance list price x2.8/instance-month, no separate connection or request-traffic charges. Includes worked minimums ($360/mo smallest cluster, $720/mo with HA).

Projected from kb/products/cache2/pricing/pricing.md (owner-confirmed 2026-08-10, S-040).