### PR TITLE
Momento Cache: add Manage Databases + Security pages (T-0009)

### DIFF
--- a/docs/product/cache/manage/databases.md
+++ b/docs/product/cache/manage/databases.md
@@ -1,0 +1,60 @@
+---
+sidebar_label: Manage Databases
+title: Manage Databases
+description: Create, list, and delete Databases on a Capacity Pool from the console or the control-plane API.
+---
+
+<!-- Projects: cache2/concepts/database, cache2/interfaces/control-plane-api -->
+
+# Manage Databases
+
+A [Database](/product/cache/concepts/database) is a logical container pinned to exactly one
+[Capacity Pool](/product/cache/concepts/capacity-pool). Multiple Databases can share the capacity of
+one Pool. This page covers creating, listing, and deleting Databases. Each activity can be performed
+in the console or via the [control-plane API](/product/cache/api-reference/database).
+
+A Database is a metadata object: creating one allocates a slot on its Pool, and deleting one reclaims
+that slot. A Database has no mutable fields, so there is no update operation. To change the capacity a
+Database runs on, scale its [Pool](/product/cache/manage/pools) instead.
+
+## Create a Database
+
+Create a Database on an existing Pool. The Pool must already exist; the Database is pinned to it for
+its lifetime and cannot move to another Pool.
+
+1. Choose the target Capacity Pool and a Database name that is unique within your account.
+2. Create the Database (console, or `POST /database/{name}` with `{ "pool_name": "<pool>" }`).
+3. Connect a client to the Database through the pool's gateway endpoint. See
+   [Connect a client](/product/cache/connect/clients).
+
+The Database name is how clients select it at connection time: the name is the `AUTH` username, and one
+connection serves exactly one Database. See [Security](/product/cache/security) for the connection
+credential model.
+
+## List and inspect Databases
+
+List every Database in your account across all Pools (console, or `GET /database`). Each entry reports
+the Database name and the name of the Pool it is pinned to. Describe a single Database (`GET
+/database/{name}`) to read the same details for one container.
+
+## Delete a Database
+
+Delete removes the Database and frees its slot on the Pool. Deletion is synchronous in the control
+plane; the underlying resources are reclaimed afterward.
+
+1. Confirm no client depends on the Database.
+2. Delete the Database (console, or `DELETE /database/{name}`).
+
+:::note
+
+A Pool cannot be deleted while any Database is still pinned to it. Delete every Database on a Pool
+before you [delete the Pool](/product/cache/manage/pools).
+
+:::
+
+## Isolation between Databases
+
+Isolation is guaranteed at the Pool boundary, not between Databases that share a Pool. Databases on the
+same Pool draw from the same capacity and are subject to noisy-neighbor effects from one another. When a
+workload needs a hard performance boundary, give it its own Pool. See
+[Isolation](/product/cache/concepts/isolation) for the full model.

--- a/docs/product/cache/security.md
+++ b/docs/product/cache/security.md
@@ -1,0 +1,71 @@
+---
+sidebar_label: Security
+title: Security
+description: Transport security and credential management for Momento Cache — TLS connections, API keys, and connection credentials.
+---
+
+<!-- Projects: cache2/concepts/shared-gateway, cross-product/authentication, cross-product/roles-and-permissions -->
+
+# Security
+
+Momento Cache has two credentialed surfaces: the **control plane**, where you manage Capacity Pools and
+Databases, and the **data plane**, where clients connect to a Database and run commands. Both are reached
+over TLS and both authenticate with Momento credentials. This page covers transport security and how to
+manage the credentials that reach each surface.
+
+Authentication and authorization are a cross-product concern. This page covers what applies to Momento
+Cache; the full credential and permission model lives under
+[Platform · Authentication](/platform/authentication).
+
+## Transport security
+
+All client traffic reaches a Database through the [shared gateway](/product/cache/concepts/connectivity-and-gateway),
+which terminates TLS at the edge:
+
+- Clients connect on port `6379` with TLS enabled. The port is configurable, but TLS is always in force.
+- TLS is terminated at the gateway. The gateway does not require client certificates, so there is no
+  mutual-TLS setup: a client presents its credential with the Valkey `AUTH` command over the encrypted
+  connection.
+- Configure the client for **standalone** mode, not cluster mode. The gateway presents the backing
+  cluster as a single node.
+
+Control-plane API calls are likewise made over HTTPS to the region endpoint. See
+[Connect a client](/product/cache/connect/clients) for per-client connection examples.
+
+## Credentials
+
+Two kinds of credential reach the two surfaces:
+
+- **Control-plane requests** send a Momento API Key in the `Authorization` header. Generate a key in the
+  [Momento console](https://console.gomomento.com/key). The key authenticates every Capacity Pool and
+  Database management call.
+- **Data-plane connections** authenticate with `AUTH <username> <password>`, where the **username is the
+  Database name** and the **password is a Momento API token**. The username fixes the Database for the
+  connection; there is no `SELECT` to switch Databases on an open connection.
+
+Both surfaces accept the same family of Momento credentials, described next.
+
+## Managing credentials
+
+Momento supports two credential types, which differ in lifetime and in how you manage them:
+
+- **API keys** are long-lived credentials. Modern Global API Keys are issued centrally, are valid in every
+  region, and are individually trackable and revocable. Each key is bound to a role that determines what it
+  can do.
+- **Disposable tokens** are short-lived credentials that carry their permissions inline and must expire.
+  Use them to hand a narrowly-scoped, self-expiring credential to a client rather than distributing a
+  long-lived key.
+
+You can list your outstanding API keys, inspect an individual key, and revoke a key. Revoking a key stops
+it from authenticating. Key management is a control-plane operation; see
+[Platform · Authentication](/platform/authentication/api-keys) for the full key lifecycle, and
+[roles and permissions](/platform/authentication/roles-and-permissions) for how a credential's role
+determines its access.
+
+### Recommended practices
+
+- Give each application its own credential so you can revoke one without disrupting the others.
+- Prefer short-lived disposable tokens for clients you cannot fully trust, and reserve long-lived API keys
+  for backend services and automation.
+- Store credentials in a secret manager rather than in source control or images, and rotate them on a
+  regular schedule by issuing a replacement and revoking the old credential.

--- a/sidebars.site.json
+++ b/sidebars.site.json
@@ -28,7 +28,9 @@
             ]
           },
           "product/cache/manage/pools",
+          "product/cache/manage/databases",
           "product/cache/connect/clients",
+          "product/cache/security",
           {
             "type": "category",
             "label": "API reference",


### PR DESCRIPTION
- manage/databases.md: create/list/delete Databases how-to (projects cache2/concepts/database, cache2/interfaces/control-plane-api)
- security.md: TLS transport + credential management (projects cache2/concepts/shared-gateway, cross-product/authentication, cross-product/roles-and-permissions); FGAC deferred to a post-launch task
- siteSidebar: add both pages under Cloud > Momento Cache